### PR TITLE
Uriel endpoint for viewing bundle problem items

### DIFF
--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/client/problem/ClientProblemService.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/client/problem/ClientProblemService.java
@@ -15,8 +15,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import judgels.sandalphon.api.problem.ProblemInfo;
-import judgels.sandalphon.api.problem.ProblemSubmissionConfig;
-import judgels.sandalphon.api.problem.ProblemWorksheet;
+import judgels.sandalphon.api.problem.bundle.BundleProblemWorksheet;
+import judgels.sandalphon.api.problem.programming.ProblemSubmissionConfig;
+import judgels.sandalphon.api.problem.programming.ProgrammingProblemWorksheet;
 import judgels.service.api.client.BasicAuthHeader;
 
 @Path("/api/v2/client/problems")
@@ -29,16 +30,24 @@ public interface ClientProblemService {
             @PathParam("problemJid") String problemJid);
 
     @GET
-    @Path("/{problemJid}/submission-config")
+    @Path("/{problemJid}/programming/submission-config")
     @Produces(APPLICATION_JSON)
     ProblemSubmissionConfig getProblemSubmissionConfig(
             @HeaderParam(AUTHORIZATION) BasicAuthHeader authHeader,
             @PathParam("problemJid") String problemJid);
 
     @GET
-    @Path("/{problemJid}/worksheet")
+    @Path("/{problemJid}/programming/worksheet")
     @Produces(APPLICATION_JSON)
-    ProblemWorksheet getProblemWorksheet(
+    ProgrammingProblemWorksheet getProgrammingProblemWorksheet(
+            @HeaderParam(AUTHORIZATION) BasicAuthHeader authHeader,
+            @PathParam("problemJid") String problemJid,
+            @QueryParam("language") Optional<String> language);
+
+    @GET
+    @Path("/{problemJid}/bundle/worksheet")
+    @Produces(APPLICATION_JSON)
+    BundleProblemWorksheet getBundleProblemWorksheet(
             @HeaderParam(AUTHORIZATION) BasicAuthHeader authHeader,
             @PathParam("problemJid") String problemJid,
             @QueryParam("language") Optional<String> language);

--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/ProblemInfo.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/ProblemInfo.java
@@ -8,6 +8,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableProblemInfo.class)
 public interface ProblemInfo {
     String getSlug();
+    ProblemType getType();
     String getDefaultLanguage();
     Map<String, String> getTitlesByLanguage();
 

--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/ProblemType.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/ProblemType.java
@@ -1,0 +1,6 @@
+package judgels.sandalphon.api.problem;
+
+public enum ProblemType {
+    PROGRAMMING,
+    BUNDLE
+}

--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/bundle/BundleProblemWorksheet.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/bundle/BundleProblemWorksheet.java
@@ -1,0 +1,15 @@
+package judgels.sandalphon.api.problem.bundle;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableBundleProblemWorksheet.class)
+public interface BundleProblemWorksheet {
+    Optional<String> getReasonNotAllowedToSubmit();
+    List<ProblemItem> getItems();
+
+    class Builder extends ImmutableBundleProblemWorksheet.Builder {}
+}

--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/bundle/ProblemItem.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/bundle/ProblemItem.java
@@ -1,0 +1,15 @@
+package judgels.sandalphon.api.problem.bundle;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableProblemItem.class)
+public interface ProblemItem {
+    String getJid();
+    ProblemItemType getType();
+    String getMeta();
+    String getConfig();
+
+    class Builder extends ImmutableProblemItem.Builder {}
+}

--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/bundle/ProblemItemType.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/bundle/ProblemItemType.java
@@ -1,0 +1,6 @@
+package judgels.sandalphon.api.problem.bundle;
+
+public enum ProblemItemType {
+    STATEMENT,
+    MULTIPLE_CHOICE
+}

--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/programming/ProblemLimits.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/programming/ProblemLimits.java
@@ -1,4 +1,4 @@
-package judgels.sandalphon.api.problem;
+package judgels.sandalphon.api.problem.programming;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;

--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/programming/ProblemStatement.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/programming/ProblemStatement.java
@@ -1,4 +1,4 @@
-package judgels.sandalphon.api.problem;
+package judgels.sandalphon.api.problem.programming;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;

--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/programming/ProblemSubmissionConfig.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/programming/ProblemSubmissionConfig.java
@@ -1,4 +1,4 @@
-package judgels.sandalphon.api.problem;
+package judgels.sandalphon.api.problem.programming;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Map;

--- a/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/programming/ProgrammingProblemWorksheet.java
+++ b/judgels-backends/sandalphon/sandalphon-api/src/main/java/judgels/sandalphon/api/problem/programming/ProgrammingProblemWorksheet.java
@@ -1,16 +1,16 @@
-package judgels.sandalphon.api.problem;
+package judgels.sandalphon.api.problem.programming;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonDeserialize(as = ImmutableProblemWorksheet.class)
-public interface ProblemWorksheet {
+@JsonDeserialize(as = ImmutableProgrammingProblemWorksheet.class)
+public interface ProgrammingProblemWorksheet {
     ProblemStatement getStatement();
     ProblemLimits getLimits();
     ProblemSubmissionConfig getSubmissionConfig();
     Optional<String> getReasonNotAllowedToSubmit();
 
-    class Builder extends ImmutableProblemWorksheet.Builder {}
+    class Builder extends ImmutableProgrammingProblemWorksheet.Builder {}
 }

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/SandalphonUtils.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/SandalphonUtils.java
@@ -11,7 +11,7 @@ import javax.ws.rs.ForbiddenException;
 import judgels.gabriel.api.LanguageRestriction;
 import judgels.gabriel.api.SubmissionSource;
 import judgels.sandalphon.api.problem.ProblemInfo;
-import judgels.sandalphon.api.problem.ProblemSubmissionConfig;
+import judgels.sandalphon.api.problem.programming.ProblemSubmissionConfig;
 
 public class SandalphonUtils {
     private SandalphonUtils() {}

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/AbstractSubmissionClient.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/AbstractSubmissionClient.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import judgels.gabriel.api.GradingRequest;
 import judgels.gabriel.api.SubmissionSource;
-import judgels.sandalphon.api.problem.ProblemSubmissionConfig;
+import judgels.sandalphon.api.problem.programming.ProblemSubmissionConfig;
 import judgels.sandalphon.api.submission.Submission;
 import judgels.sandalphon.api.submission.SubmissionData;
 import judgels.sandalphon.persistence.AbstractGradingModel;

--- a/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/ContestErrors.java
+++ b/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/ContestErrors.java
@@ -5,6 +5,7 @@ import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.logsafe.SafeArg;
 import java.util.Set;
 import java.util.stream.Collectors;
+import judgels.sandalphon.api.problem.ProblemType;
 
 public class ContestErrors {
     private ContestErrors() {}
@@ -15,6 +16,9 @@ public class ContestErrors {
     public static final ErrorType PROBLEM_SLUGS_NOT_ALLOWED =
             ErrorType.create(ErrorType.Code.PERMISSION_DENIED, "Uriel:ContestProblemSlugsNotAllowed");
 
+    public static final ErrorType WRONG_PROBLEM_TYPE =
+            ErrorType.create(ErrorType.Code.INVALID_ARGUMENT, "Uriel:WrongProblemType");
+
     public static ServiceException slugAlreadyExists(String slug) {
         return new ServiceException(SLUG_ALREADY_EXISTS, SafeArg.of("slug", slug));
     }
@@ -23,5 +27,9 @@ public class ContestErrors {
         return new ServiceException(
                 PROBLEM_SLUGS_NOT_ALLOWED,
                 SafeArg.of("slugs", slugs.stream().collect(Collectors.joining(", "))));
+    }
+
+    public static ServiceException wrongProblemType(ProblemType problemType) {
+        return new ServiceException(WRONG_PROBLEM_TYPE, SafeArg.of("problemType", problemType));
     }
 }

--- a/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/problem/ContestBundleProblemWorksheet.java
+++ b/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/problem/ContestBundleProblemWorksheet.java
@@ -2,17 +2,17 @@ package judgels.uriel.api.contest.problem;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Set;
-import judgels.sandalphon.api.problem.ProblemWorksheet;
+import judgels.sandalphon.api.problem.bundle.BundleProblemWorksheet;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonDeserialize(as = ImmutableContestProblemWorksheet.class)
-public interface ContestProblemWorksheet {
+@JsonDeserialize(as = ImmutableContestBundleProblemWorksheet.class)
+public interface ContestBundleProblemWorksheet {
     String getDefaultLanguage();
     Set<String> getLanguages();
     ContestProblem getProblem();
     long getTotalSubmissions();
-    ProblemWorksheet getWorksheet();
+    BundleProblemWorksheet getWorksheet();
 
-    class Builder extends ImmutableContestProblemWorksheet.Builder{}
+    class Builder extends ImmutableContestBundleProblemWorksheet.Builder{}
 }

--- a/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/problem/ContestProblemService.java
+++ b/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/problem/ContestProblemService.java
@@ -33,9 +33,18 @@ public interface ContestProblemService {
             @PathParam("contestJid") String contestJid);
 
     @GET
-    @Path("/{problemAlias}/worksheet")
+    @Path("/{problemAlias}/programming/worksheet")
     @Produces(APPLICATION_JSON)
-    ContestProblemWorksheet getProblemWorksheet(
+    ContestProgrammingProblemWorksheet getProgrammingProblemWorksheet(
+            @HeaderParam(AUTHORIZATION) Optional<AuthHeader> authHeader,
+            @PathParam("contestJid") String contestJid,
+            @PathParam("problemAlias") String problemAlias,
+            @QueryParam("language") Optional<String> language);
+
+    @GET
+    @Path("/{problemAlias}/bundle/worksheet")
+    @Produces(APPLICATION_JSON)
+    ContestBundleProblemWorksheet getBundleProblemWorksheet(
             @HeaderParam(AUTHORIZATION) Optional<AuthHeader> authHeader,
             @PathParam("contestJid") String contestJid,
             @PathParam("problemAlias") String problemAlias,

--- a/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/problem/ContestProgrammingProblemWorksheet.java
+++ b/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/problem/ContestProgrammingProblemWorksheet.java
@@ -1,0 +1,18 @@
+package judgels.uriel.api.contest.problem;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Set;
+import judgels.sandalphon.api.problem.programming.ProgrammingProblemWorksheet;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableContestProgrammingProblemWorksheet.class)
+public interface ContestProgrammingProblemWorksheet {
+    String getDefaultLanguage();
+    Set<String> getLanguages();
+    ContestProblem getProblem();
+    long getTotalSubmissions();
+    ProgrammingProblemWorksheet getWorksheet();
+
+    class Builder extends ImmutableContestProgrammingProblemWorksheet.Builder{}
+}

--- a/judgels-backends/uriel/uriel-app/src/integTest/java/judgels/uriel/api/mocks/MockSandalphon.java
+++ b/judgels-backends/uriel/uriel-app/src/integTest/java/judgels/uriel/api/mocks/MockSandalphon.java
@@ -37,6 +37,10 @@ public class MockSandalphon {
     public static final String PROBLEM_2_SLUG = "problemSlug2";
     private static final String[] PROBLEM_SLUGS = {PROBLEM_1_SLUG, PROBLEM_2_SLUG};
 
+    public static final String PROBLEM_1_TYPE = "PROGRAMMING";
+    public static final String PROBLEM_2_TYPE = "PROGRAMMING";
+    private static final String[] PROBLEM_TYPES = {PROBLEM_1_TYPE, PROBLEM_2_TYPE};
+
     public static final int SANDALPHON_PORT = 9002;
 
     private MockSandalphon() {}
@@ -46,7 +50,7 @@ public class MockSandalphon {
                 .port(SANDALPHON_PORT)
                 .extensions(new TranslateAllowedSlugToJidsTransformer()));
 
-        mockSandalphon.stubFor(get("/api/v2/client/problems/" + PROBLEM_1_JID + "/submission-config")
+        mockSandalphon.stubFor(get("/api/v2/client/problems/" + PROBLEM_1_JID + "/programming/submission-config")
                 .withHeader(HttpHeaders.AUTHORIZATION, containing("Basic"))
                 .willReturn(okForJson(ImmutableMap.of(
                         "sourceKeys", ImmutableMap.of("source", "Source"),
@@ -61,6 +65,7 @@ public class MockSandalphon {
                 .withHeader(HttpHeaders.AUTHORIZATION, containing("Basic"))
                 .willReturn(okForJson(ImmutableMap.of(
                         PROBLEM_1_JID, ImmutableMap.of(
+                                "type", PROBLEM_1_TYPE,
                                 "slug", PROBLEM_1_SLUG,
                                 "defaultLanguage", "en",
                                 "titlesByLanguage", ImmutableMap.of("en", "Problem 1"))))));

--- a/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/contest/problem/ContestProblemResource.java
+++ b/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/contest/problem/ContestProblemResource.java
@@ -20,6 +20,7 @@ import judgels.sandalphon.api.client.problem.ClientProblemService;
 import judgels.sandalphon.api.problem.ProblemInfo;
 import judgels.sandalphon.api.problem.ProblemType;
 import judgels.sandalphon.api.problem.bundle.BundleProblemWorksheet;
+import judgels.sandalphon.api.problem.bundle.ProblemItem;
 import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import judgels.sandalphon.api.problem.programming.ProblemSubmissionConfig;
 import judgels.sandalphon.api.problem.programming.ProgrammingProblemWorksheet;
@@ -241,6 +242,14 @@ public class ContestProblemResource implements ContestProblemService {
 
         BundleProblemWorksheet finalWorksheet = new BundleProblemWorksheet.Builder()
                 .from(worksheet)
+                .items(worksheet.getItems().stream()
+                    .map(item -> new ProblemItem.Builder()
+                        .from(item)
+                        .config(replaceRenderUrls(item.getConfig(), problemJid))
+                        .build()
+                    )
+                    .collect(Collectors.toList())
+                )
                 .reasonNotAllowedToSubmit(reasonNotAllowedToSubmit)
                 .build();
 

--- a/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/contest/submission/ContestSubmissionResource.java
+++ b/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/contest/submission/ContestSubmissionResource.java
@@ -36,7 +36,7 @@ import judgels.persistence.api.Page;
 import judgels.sandalphon.SandalphonUtils;
 import judgels.sandalphon.api.client.problem.ClientProblemService;
 import judgels.sandalphon.api.problem.ProblemInfo;
-import judgels.sandalphon.api.problem.ProblemSubmissionConfig;
+import judgels.sandalphon.api.problem.programming.ProblemSubmissionConfig;
 import judgels.sandalphon.api.submission.Submission;
 import judgels.sandalphon.api.submission.SubmissionData;
 import judgels.sandalphon.api.submission.SubmissionWithSource;

--- a/judgels-frontends/raphael/src/modules/api/uriel/contestProblem.ts
+++ b/judgels-frontends/raphael/src/modules/api/uriel/contestProblem.ts
@@ -64,6 +64,6 @@ export const contestProblemAPI = {
     language?: string
   ): Promise<ContestProblemWorksheet> => {
     const params = stringify({ language });
-    return get(`${baseURL(contestJid)}/${problemAlias}/worksheet?${params}`, token);
+    return get(`${baseURL(contestJid)}/${problemAlias}/programming/worksheet?${params}`, token);
   },
 };

--- a/judgels-legacy/sandalphon-blackbox-adapters/app/org/iatoki/judgels/sandalphon/problem/programming/grading/blackbox/AbstractBoxGradingEngineAdapter.java
+++ b/judgels-legacy/sandalphon-blackbox-adapters/app/org/iatoki/judgels/sandalphon/problem/programming/grading/blackbox/AbstractBoxGradingEngineAdapter.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import org.iatoki.judgels.gabriel.GradingConfig;
 import org.iatoki.judgels.gabriel.SubmissionSource;
 import org.iatoki.judgels.gabriel.blackbox.BlackBoxGradingConfig;

--- a/judgels-legacy/sandalphon-blackbox-adapters/app/org/iatoki/judgels/sandalphon/problem/programming/statement/blackbox/blackBoxViewStatementView.scala.html
+++ b/judgels-legacy/sandalphon-blackbox-adapters/app/org/iatoki/judgels/sandalphon/problem/programming/statement/blackbox/blackBoxViewStatementView.scala.html
@@ -1,4 +1,4 @@
-@import judgels.sandalphon.api.problem.ProblemStatement
+@import judgels.sandalphon.api.problem.programming.ProblemStatement
 @import play.i18n.Messages
 @import com.google.common.base.Joiner
 @import org.iatoki.judgels.gabriel.GradingLanguageRegistry

--- a/judgels-legacy/sandalphon-commons/app/org/iatoki/judgels/sandalphon/problem/bundle/statement/bundleStatementView.scala.html
+++ b/judgels-legacy/sandalphon-commons/app/org/iatoki/judgels/sandalphon/problem/bundle/statement/bundleStatementView.scala.html
@@ -1,4 +1,4 @@
-@import judgels.sandalphon.api.problem.ProblemStatement
+@import judgels.sandalphon.api.problem.programming.ProblemStatement
 @import play.i18n.Messages
 
 @(postSubmitUri: String, statement: ProblemStatement, itemsHtml: List[Html], reasonNotAllowedToSubmit: String)

--- a/judgels-legacy/sandalphon-commons/app/org/iatoki/judgels/sandalphon/problem/programming/grading/GradingEngineAdapter.java
+++ b/judgels-legacy/sandalphon-commons/app/org/iatoki/judgels/sandalphon/problem/programming/grading/GradingEngineAdapter.java
@@ -1,6 +1,6 @@
 package org.iatoki.judgels.sandalphon.problem.programming.grading;
 
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import org.iatoki.judgels.FileInfo;
 import org.iatoki.judgels.gabriel.GradingConfig;
 import org.iatoki.judgels.gabriel.SubmissionSource;

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/controllers/api/client/v1/ClientBundleProblemStatementAPIControllerV1.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/controllers/api/client/v1/ClientBundleProblemStatementAPIControllerV1.java
@@ -1,7 +1,7 @@
 package org.iatoki.judgels.sandalphon.controllers.api.client.v1;
 
 import com.google.common.collect.ImmutableList;
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import judgels.service.api.client.Client;
 import org.iatoki.judgels.play.IdentityUtils;
 import org.iatoki.judgels.play.api.JudgelsAPIForbiddenException;

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/controllers/api/client/v1/ClientProgrammingProblemStatementAPIControllerV1.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/controllers/api/client/v1/ClientProgrammingProblemStatementAPIControllerV1.java
@@ -3,7 +3,7 @@ package org.iatoki.judgels.sandalphon.controllers.api.client.v1;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import judgels.gabriel.api.LanguageRestriction;
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import judgels.service.api.client.Client;
 import org.iatoki.judgels.gabriel.GradingConfig;
 import org.iatoki.judgels.gabriel.GradingEngineRegistry;

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/controllers/api/client/v2/ClientProblemAPIControllerV2.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/controllers/api/client/v2/ClientProblemAPIControllerV2.java
@@ -2,11 +2,15 @@ package org.iatoki.judgels.sandalphon.controllers.api.client.v2;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import judgels.gabriel.api.LanguageRestriction;
+import judgels.sandalphon.api.problem.ProblemType;
 import judgels.sandalphon.api.problem.ProblemInfo;
-import judgels.sandalphon.api.problem.ProblemLimits;
-import judgels.sandalphon.api.problem.ProblemStatement;
-import judgels.sandalphon.api.problem.ProblemSubmissionConfig;
-import judgels.sandalphon.api.problem.ProblemWorksheet;
+import judgels.sandalphon.api.problem.programming.ProblemLimits;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemSubmissionConfig;
+import judgels.sandalphon.api.problem.programming.ProgrammingProblemWorksheet;
+import judgels.sandalphon.api.problem.bundle.BundleProblemWorksheet;
+import judgels.sandalphon.api.problem.bundle.ProblemItem;
+import judgels.sandalphon.api.problem.bundle.ProblemItemType;
 import judgels.service.client.ClientChecker;
 import org.iatoki.judgels.gabriel.GradingEngineRegistry;
 import org.iatoki.judgels.gabriel.blackbox.BlackBoxGradingConfig;
@@ -14,6 +18,8 @@ import org.iatoki.judgels.play.api.JudgelsAPIInternalServerErrorException;
 import org.iatoki.judgels.play.api.JudgelsAPINotFoundException;
 import org.iatoki.judgels.play.controllers.apis.AbstractJudgelsAPIController;
 import org.iatoki.judgels.sandalphon.StatementLanguageStatus;
+import org.iatoki.judgels.sandalphon.problem.bundle.item.BundleItem;
+import org.iatoki.judgels.sandalphon.problem.bundle.item.BundleItemService;
 import org.iatoki.judgels.sandalphon.problem.base.Problem;
 import org.iatoki.judgels.sandalphon.problem.base.ProblemService;
 import org.iatoki.judgels.sandalphon.problem.programming.ProgrammingProblemService;
@@ -25,9 +31,11 @@ import play.mvc.Result;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.List;
 
 @Singleton
 public final class ClientProblemAPIControllerV2 extends AbstractJudgelsAPIController {
@@ -35,13 +43,15 @@ public final class ClientProblemAPIControllerV2 extends AbstractJudgelsAPIContro
     private final UserService userService;
     private final ProblemService problemService;
     private final ProgrammingProblemService programmingProblemService;
+    private final BundleItemService bundleItemService;
 
     @Inject
-    public ClientProblemAPIControllerV2(ClientChecker clientChecker, UserService userService, ProblemService problemService, ProgrammingProblemService programmingProblemService) {
+    public ClientProblemAPIControllerV2(ClientChecker clientChecker, UserService userService, ProblemService problemService, ProgrammingProblemService programmingProblemService, BundleItemService bundleItemService) {
         this.clientChecker = clientChecker;
         this.userService = userService;
         this.problemService = problemService;
         this.programmingProblemService = programmingProblemService;
+        this.bundleItemService = bundleItemService;
     }
 
     @Transactional(readOnly = true)
@@ -63,83 +73,33 @@ public final class ClientProblemAPIControllerV2 extends AbstractJudgelsAPIContro
             throw new JudgelsAPINotFoundException();
         }
 
-        ProblemSubmissionConfig.Builder result = new ProblemSubmissionConfig.Builder();
-
-        String gradingEngine;
-        try {
-            gradingEngine = programmingProblemService.getGradingEngine(null, problemJid);
-        } catch (IOException e) {
-            gradingEngine = GradingEngineRegistry.getInstance().getDefaultEngine();
-        }
-        result.gradingEngine(gradingEngine);
-
-        try {
-            result.gradingLanguageRestriction(programmingProblemService.getLanguageRestriction(null, problemJid));
-        } catch (IOException e) {
-            result.gradingLanguageRestriction(LanguageRestriction.noRestriction());
-        }
-
-        BlackBoxGradingConfig config;
-        try {
-            config = (BlackBoxGradingConfig) programmingProblemService.getGradingConfig(null, problemJid);
-        } catch (IOException e) {
-            config = (BlackBoxGradingConfig) GradingEngineRegistry.getInstance().getEngine(gradingEngine).createDefaultGradingConfig();
-        }
-
-        result.sourceKeys(config.getSourceFileFields());
-
-        return okAsJson(result);
+        return okAsJson(getSubmissionConfig(problemJid));
     }
 
     @Transactional(readOnly = true)
-    public Result getProblemWorksheet(String problemJid) {
+    public Result getProgrammingProblemWorksheet(String problemJid) {
         authenticateAsJudgelsAppClient(clientChecker);
 
         if (!problemService.problemExistsByJid(problemJid)) {
             throw new JudgelsAPINotFoundException();
         }
 
-        ProblemSubmissionConfig.Builder submissionConfig = new ProblemSubmissionConfig.Builder();
-
-        String gradingEngine;
-        try {
-            gradingEngine = programmingProblemService.getGradingEngine(null, problemJid);
-        } catch (IOException e) {
-            gradingEngine = GradingEngineRegistry.getInstance().getDefaultEngine();
-        }
-        submissionConfig.gradingEngine(gradingEngine);
-
-        try {
-            submissionConfig.gradingLanguageRestriction(programmingProblemService.getLanguageRestriction(null, problemJid));
-        } catch (IOException e) {
-            submissionConfig.gradingLanguageRestriction(LanguageRestriction.noRestriction());
+        Problem problem = problemService.findProblemByJid(problemJid);
+        if (ProblemType.valueOf(problem.getType().name()) != ProblemType.PROGRAMMING) {
+            throw new JudgelsAPINotFoundException();
         }
 
-        BlackBoxGradingConfig config;
-        try {
-            config = (BlackBoxGradingConfig) programmingProblemService.getGradingConfig(null, problemJid);
-        } catch (IOException e) {
-            config = (BlackBoxGradingConfig) GradingEngineRegistry.getInstance().getEngine(gradingEngine).createDefaultGradingConfig();
-        }
+        ProgrammingProblemWorksheet.Builder result = new ProgrammingProblemWorksheet.Builder();
 
-        submissionConfig.sourceKeys(config.getSourceFileFields());
+        ProblemSubmissionConfig submissionConfig = getSubmissionConfig(problemJid);
+        result.submissionConfig(submissionConfig);
 
-        ProblemWorksheet.Builder result = new ProblemWorksheet.Builder();
-        result.submissionConfig(submissionConfig.build());
-
-        String language = DynamicForm.form().bindFromRequest().get("language");
+        BlackBoxGradingConfig config = getBlackBoxGradingConfig(problemJid, submissionConfig.getGradingEngine());
 
         try {
-            Map<String, StatementLanguageStatus> availableLanguages = problemService.getAvailableLanguages(null, problemJid);
-            Map<String, String> simplifiedLanguages = availableLanguages.entrySet()
-                    .stream()
-                    .collect(Collectors.toMap(e -> simplifyLanguageCode(e.getKey()), e -> e.getKey()));
+            String language = sanitizeLanguageCode(problemJid, DynamicForm.form().bindFromRequest().get("language"));
 
-            if (!simplifiedLanguages.containsKey(language) || availableLanguages.get(simplifiedLanguages.get(language)) == StatementLanguageStatus.DISABLED) {
-                language = simplifyLanguageCode(problemService.getDefaultLanguage(null, problemJid));
-            }
-
-            ProblemStatement statement = problemService.getStatement(null, problemJid, simplifiedLanguages.get(language));
+            ProblemStatement statement = problemService.getStatement(null, problemJid, language);
             result.statement(statement);
 
             ProblemLimits limits = new ProblemLimits.Builder()
@@ -149,8 +109,47 @@ public final class ClientProblemAPIControllerV2 extends AbstractJudgelsAPIContro
             result.limits(limits);
 
             return okAsJson(result.build());
-        } catch (IOException e) {
 
+        } catch (IOException e) {
+            throw new JudgelsAPIInternalServerErrorException(e);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Result getBundleProblemWorksheet(String problemJid) {
+        authenticateAsJudgelsAppClient(clientChecker);
+        if (!problemService.problemExistsByJid(problemJid)) {
+            throw new JudgelsAPINotFoundException();
+        }
+
+        Problem problem = problemService.findProblemByJid(problemJid);
+        if (ProblemType.valueOf(problem.getType().name()) != ProblemType.BUNDLE) {
+            throw new JudgelsAPINotFoundException();
+        }
+
+        try {
+            String language = sanitizeLanguageCode(problemJid, DynamicForm.form().bindFromRequest().get("language"));
+
+            List<BundleItem> items = bundleItemService.getBundleItemsInProblemWithClone(problemJid, null);
+            List<ProblemItem> itemsWithConfig = new ArrayList<>();
+            for (BundleItem item : items) {
+                String itemConfig = bundleItemService.getItemConfInProblemWithCloneByJid(
+                        problemJid, null, item.getJid(), language);
+                ProblemItem itemWithConfig = new ProblemItem.Builder()
+                        .jid(item.getJid())
+                        .type(ProblemItemType.valueOf(item.getType().name()))
+                        .meta(item.getMeta())
+                        .config(itemConfig)
+                        .build();
+                itemsWithConfig.add(itemWithConfig);
+            }
+
+            return okAsJson(
+                    new BundleProblemWorksheet.Builder()
+                            .items(itemsWithConfig)
+                            .build()
+            );
+        } catch (IOException e) {
             throw new JudgelsAPIInternalServerErrorException(e);
         }
     }
@@ -200,8 +199,8 @@ public final class ClientProblemAPIControllerV2 extends AbstractJudgelsAPIContro
             Problem problem = problemService.findProblemByJid(problemJid);
 
             ProblemInfo.Builder res = new ProblemInfo.Builder();
-
             res.slug(problem.getSlug());
+            res.type(ProblemType.valueOf(problem.getType().name()));
             res.defaultLanguage(simplifyLanguageCode(problemService.getDefaultLanguage(null, problemJid)));
             res.titlesByLanguage(problemService.getTitlesByLanguage(null, problemJid).entrySet()
                     .stream()
@@ -216,6 +215,60 @@ public final class ClientProblemAPIControllerV2 extends AbstractJudgelsAPIContro
         return problem.getAuthorJid().equals(userJid)
             || problemService.isUserPartnerForProblem(problem.getJid(), userJid)
             || userService.findUserByJid(userJid).getRoles().contains("admin");
+    }
+
+    private String getGradingEngine(String problemJid) {
+        try {
+            return programmingProblemService.getGradingEngine(null, problemJid);
+        } catch (IOException e) {
+            return GradingEngineRegistry.getInstance().getDefaultEngine();
+        }
+    }
+
+    private LanguageRestriction getLanguageRestriction(String problemJid) {
+        try {
+            return programmingProblemService.getLanguageRestriction(null, problemJid);
+        } catch (IOException e) {
+            return LanguageRestriction.noRestriction();
+        }
+    }
+
+    private BlackBoxGradingConfig getBlackBoxGradingConfig(String problemJid, String gradingEngine) {
+        try {
+            return (BlackBoxGradingConfig) programmingProblemService.getGradingConfig(null, problemJid);
+        } catch (IOException e) {
+            return (BlackBoxGradingConfig) GradingEngineRegistry.getInstance()
+                    .getEngine(gradingEngine)
+                    .createDefaultGradingConfig();
+        }
+    }
+
+    private ProblemSubmissionConfig getSubmissionConfig(String problemJid) {
+        ProblemSubmissionConfig.Builder submissionConfig = new ProblemSubmissionConfig.Builder();
+
+        String gradingEngine = getGradingEngine(problemJid);
+        submissionConfig.gradingEngine(gradingEngine);
+
+        LanguageRestriction languageRestriction = getLanguageRestriction(problemJid);
+        submissionConfig.gradingLanguageRestriction(languageRestriction);
+
+        BlackBoxGradingConfig config = getBlackBoxGradingConfig(problemJid, gradingEngine);
+        submissionConfig.sourceKeys(config.getSourceFileFields());
+
+        return submissionConfig.build();
+    }
+
+    private String sanitizeLanguageCode(String problemJid, String language) throws IOException {
+        Map<String, StatementLanguageStatus> availableLanguages = problemService.getAvailableLanguages(null, problemJid);
+        Map<String, String> simplifiedLanguages = availableLanguages.entrySet()
+                .stream()
+                .collect(Collectors.toMap(e -> simplifyLanguageCode(e.getKey()), e -> e.getKey()));
+
+        if (!simplifiedLanguages.containsKey(language) || availableLanguages.get(simplifiedLanguages.get(language)) == StatementLanguageStatus.DISABLED) {
+            language = simplifyLanguageCode(problemService.getDefaultLanguage(null, problemJid));
+        }
+
+        return simplifiedLanguages.get(language);
     }
 
     private static String simplifyLanguageCode(String code) {

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/base/ProblemService.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/base/ProblemService.java
@@ -1,7 +1,7 @@
 package org.iatoki.judgels.sandalphon.problem.base;
 
 import com.google.inject.ImplementedBy;
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import org.iatoki.judgels.FileInfo;
 import org.iatoki.judgels.GitCommit;
 import org.iatoki.judgels.play.Page;

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/base/ProblemServiceImpl.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/base/ProblemServiceImpl.java
@@ -6,7 +6,7 @@ import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import org.iatoki.judgels.FileInfo;
 import org.iatoki.judgels.FileSystemProvider;
 import org.iatoki.judgels.GitCommit;

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/base/statement/ProblemStatementController.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/base/statement/ProblemStatementController.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 
 @Authenticated(value = {LoggedIn.class, HasRole.class})
 @Singleton

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/BundleProblemController.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/BundleProblemController.java
@@ -1,6 +1,6 @@
 package org.iatoki.judgels.sandalphon.problem.bundle;
 
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import org.iatoki.judgels.jophiel.activity.BasicActivityKeys;
 import org.iatoki.judgels.play.IdentityUtils;
 import org.iatoki.judgels.play.controllers.AbstractJudgelsController;

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/item/BundleItemServiceImpl.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/item/BundleItemServiceImpl.java
@@ -93,9 +93,9 @@ public final class BundleItemServiceImpl implements BundleItemService {
 
         List<BundleItem> bundleItems = bundleItemsConfig.itemList.stream().collect(Collectors.toList());
         long number = 1;
-        for (BundleItem bundleItem : bundleItems) {
-            if (BundleItemAdapters.fromItemType(bundleItem.getType()) instanceof BundleItemHasScore) {
-                bundleItem.setNumber(number++);
+        for (int i = 0; i < bundleItems.size(); i++) {
+            if (BundleItemAdapters.fromItemType(bundleItems.get(i).getType()) instanceof BundleItemHasScore) {
+                bundleItems.get(i).setNumber(number++);
             }
         }
 

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/statement/BundleProblemStatementController.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/statement/BundleProblemStatementController.java
@@ -1,7 +1,7 @@
 package org.iatoki.judgels.sandalphon.problem.bundle.statement;
 
 import com.google.common.collect.ImmutableList;
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import org.iatoki.judgels.play.IdentityUtils;
 import org.iatoki.judgels.play.InternalLink;
 import org.iatoki.judgels.play.LazyHtml;

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/programming/ProgrammingProblemController.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/programming/ProgrammingProblemController.java
@@ -1,7 +1,7 @@
 package org.iatoki.judgels.sandalphon.problem.programming;
 
 import com.google.common.collect.ImmutableList;
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import org.iatoki.judgels.jophiel.activity.BasicActivityKeys;
 import org.iatoki.judgels.play.IdentityUtils;
 import org.iatoki.judgels.play.InternalLink;

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/programming/statement/ProgrammingProblemStatementController.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/programming/statement/ProgrammingProblemStatementController.java
@@ -2,7 +2,7 @@ package org.iatoki.judgels.sandalphon.problem.programming.statement;
 
 import com.google.common.collect.ImmutableList;
 import judgels.gabriel.api.LanguageRestriction;
-import judgels.sandalphon.api.problem.ProblemStatement;
+import judgels.sandalphon.api.problem.programming.ProblemStatement;
 import org.iatoki.judgels.gabriel.GradingConfig;
 import org.iatoki.judgels.gabriel.GradingEngineRegistry;
 import org.iatoki.judgels.play.IdentityUtils;

--- a/judgels-legacy/sandalphon/conf/routes
+++ b/judgels-legacy/sandalphon/conf/routes
@@ -193,8 +193,9 @@ POST        /api/v1/lessons/:lessonJid/statements                               
 # Client API v2
 
 GET         /api/v2/client/problems/:problemJid                                     org.iatoki.judgels.sandalphon.controllers.api.client.v2.ClientProblemAPIControllerV2.getProblem(problemJid)
-GET         /api/v2/client/problems/:problemJid/submission-config                   org.iatoki.judgels.sandalphon.controllers.api.client.v2.ClientProblemAPIControllerV2.getProblemSubmissionConfig(problemJid)
-GET         /api/v2/client/problems/:problemJid/worksheet                           org.iatoki.judgels.sandalphon.controllers.api.client.v2.ClientProblemAPIControllerV2.getProblemWorksheet(problemJid)
+GET         /api/v2/client/problems/:problemJid/programming/submission-config       org.iatoki.judgels.sandalphon.controllers.api.client.v2.ClientProblemAPIControllerV2.getProblemSubmissionConfig(problemJid)
+GET         /api/v2/client/problems/:problemJid/programming/worksheet               org.iatoki.judgels.sandalphon.controllers.api.client.v2.ClientProblemAPIControllerV2.getProgrammingProblemWorksheet(problemJid)
+GET         /api/v2/client/problems/:problemJid/bundle/worksheet                    org.iatoki.judgels.sandalphon.controllers.api.client.v2.ClientProblemAPIControllerV2.getBundleProblemWorksheet(problemJid)
 POST        /api/v2/client/problems/jids                                            org.iatoki.judgels.sandalphon.controllers.api.client.v2.ClientProblemAPIControllerV2.findProblemsByJids()
 POST        /api/v2/client/problems/allowed-slug-to-jid                             org.iatoki.judgels.sandalphon.controllers.api.client.v2.ClientProblemAPIControllerV2.translateAllowedSlugToJids()
 


### PR DESCRIPTION
- Modify legacy Sandalphon endpoint (v2) to support viewing bundle problem items
- Create Uriel endpoint to view bundle problem and items, separate endpoints for bundle and programming problems
- Update Raphael endpoint URL for viewing programming problems (add `/programming/`)