### PR TITLE
fix answer, use empty string instead of undefined

### DIFF
--- a/judgels-frontends/raphael/src/components/ProblemWorksheetCard/Bundle/ProblemStatementCard/ProblemStatementCard.tsx
+++ b/judgels-frontends/raphael/src/components/ProblemWorksheetCard/Bundle/ProblemStatementCard/ProblemStatementCard.tsx
@@ -13,14 +13,14 @@ export interface ProblemStatementCardProps {
   items: Item[];
   alias: string;
   statement: ProblemStatement;
-  onAnswerItem: (itemJid: string, answer?: string) => any;
+  onAnswerItem: (itemJid: string, answer: string) => any;
   latestSubmission: { [id: string]: ItemSubmission };
 }
 
 export class ProblemStatementCard extends React.Component<ProblemStatementCardProps> {
   generateOnAnswer = (itemJid: string) => {
     return (choice?: string) => {
-      this.props.onAnswerItem(itemJid, choice);
+      this.props.onAnswerItem(itemJid, choice || '');
     };
   };
 

--- a/judgels-frontends/raphael/src/modules/api/uriel/contestSubmissionBundle.ts
+++ b/judgels-frontends/raphael/src/modules/api/uriel/contestSubmissionBundle.ts
@@ -11,7 +11,7 @@ export interface ContestItemSubmissionData {
   contestJid: string;
   problemJid: string;
   itemJid: string;
-  answer?: string;
+  answer: string;
 }
 
 export interface ContestItemSubmissionsResponse {

--- a/judgels-frontends/raphael/src/routes/uriel/contests/single/submissions/Programming/modules/contestBundleSubmissionActions.ts
+++ b/judgels-frontends/raphael/src/routes/uriel/contests/single/submissions/Programming/modules/contestBundleSubmissionActions.ts
@@ -8,7 +8,7 @@ export const contestBundleSubmissionActions = {
     };
   },
 
-  createItemSubmission: (contestJid: string, problemJid: string, itemJid: string, answer?: string) => {
+  createItemSubmission: (contestJid: string, problemJid: string, itemJid: string, answer: string) => {
     return async (dispatch, getState, { contestSubmissionBundleAPI, toastActions }) => {
       const token = selectToken(getState());
       const data = {


### PR DESCRIPTION
Resolve #116

[#116](https://github.com/ia-toki/judgels/issues/116) Cannot reset bundle item answer
This is because raphael send `answer` field as undefined instead of empty string.