### PR TITLE
update contest submission route

### DIFF
--- a/judgels-frontends/raphael/src/routes/uriel/contests/single/submissions/Bundle/ContestSubmissionRoutes.tsx
+++ b/judgels-frontends/raphael/src/routes/uriel/contests/single/submissions/Bundle/ContestSubmissionRoutes.tsx
@@ -2,12 +2,34 @@ import * as React from 'react';
 import { withRouter, Route } from 'react-router';
 import ContestSubmissionsPage from './ContestSubmissionsPage/ContestSubmissionsPage';
 import SubmissionSummaryPage from './SubmissionSummaryPage/SubmissionSummaryPage';
+import { selectContestWebConfig } from 'routes/uriel/contests/modules/contestWebConfigSelectors';
+import { connect } from 'react-redux';
+import { ContestWebConfig, ContestRole } from 'modules/api/uriel/contestWeb';
 
-const ContestSubmissionRoutes = () => (
-  <div>
-    <Route path="/contests/:contestSlug/submissions/users/:userJid" component={SubmissionSummaryPage} />
-    <Route exact path="/contests/:contestSlug/submissions" component={ContestSubmissionsPage} />
-  </div>
-);
+export interface ContestSubmissionRoutesProps {
+  webConfig?: ContestWebConfig;
+}
 
-export default withRouter<any>(ContestSubmissionRoutes);
+const ContestSubmissionRoutes: React.FunctionComponent<ContestSubmissionRoutesProps> = ({ webConfig }) => {
+  if (!webConfig) {
+    return null;
+  }
+  if (webConfig.role === ContestRole.Contestant) {
+    return <SubmissionSummaryPage />;
+  }
+  return (
+    <div>
+      <Route path="/contests/:contestSlug/submissions/users/:userJid" component={SubmissionSummaryPage} />
+      <Route exact path="/contests/:contestSlug/submissions" component={ContestSubmissionsPage} />
+    </div>
+  );
+};
+
+export const createContestSubmissionRoutes = () => {
+  const mapStateToProps = state => ({
+    webConfig: selectContestWebConfig(state),
+  });
+  return withRouter(connect(mapStateToProps)(ContestSubmissionRoutes));
+};
+
+export default createContestSubmissionRoutes();

--- a/judgels-frontends/raphael/src/routes/uriel/contests/single/submissions/Bundle/SubmissionSummaryPage/SubmissionSummaryPage.tsx
+++ b/judgels-frontends/raphael/src/routes/uriel/contests/single/submissions/Bundle/SubmissionSummaryPage/SubmissionSummaryPage.tsx
@@ -12,7 +12,7 @@ import { selectStatementLanguage } from 'modules/webPrefs/webPrefsSelectors';
 import './SubmissionSummaryPage.css';
 
 interface SubmissionSummaryPageRoute {
-  userJid: string;
+  userJid?: string;
 }
 
 export interface SubmissionSummaryPageProps extends RouteComponentProps<SubmissionSummaryPageRoute> {


### PR DESCRIPTION
Resolve #139

[#139](https://github.com/ia-toki/judgels/issues/139) Update `ContestSubmissionRoutes` to render summary page when user's is contestant.