### PR TITLE
add username profile in submission summary

### DIFF
--- a/judgels-frontends/raphael/src/routes/uriel/contests/single/submissions/Bundle/SubmissionSummaryPage/SubmissionSummaryPage.tsx
+++ b/judgels-frontends/raphael/src/routes/uriel/contests/single/submissions/Bundle/SubmissionSummaryPage/SubmissionSummaryPage.tsx
@@ -10,6 +10,9 @@ import { ProblemSubmissionCard, ProblemSubmissionCardProps } from '../ProblemSub
 import { selectStatementLanguage } from 'modules/webPrefs/webPrefsSelectors';
 
 import './SubmissionSummaryPage.css';
+import { H5 } from '@blueprintjs/core';
+import { UserRef } from 'components/UserRef/UserRef';
+import { Profile } from 'modules/api/jophiel/profile';
 
 interface SubmissionSummaryPageRoute {
   userJid?: string;
@@ -22,11 +25,13 @@ export interface SubmissionSummaryPageProps extends RouteComponentProps<Submissi
 }
 
 export interface SubmissionSummaryPageState {
+  profile?: Profile;
   problemSummaries: ProblemSubmissionCardProps[];
 }
 
 class SubmissionSummaryPage extends React.Component<SubmissionSummaryPageProps, SubmissionSummaryPageState> {
   state: SubmissionSummaryPageState = {
+    profile: undefined,
     problemSummaries: [],
   };
 
@@ -45,12 +50,17 @@ class SubmissionSummaryPage extends React.Component<SubmissionSummaryPageProps, 
         canManage: response.config.canManage,
       });
     }
-    this.setState({ problemSummaries });
+    this.setState({ profile: response.profile, problemSummaries });
   }
 
   render() {
     return (
       <div className="submisions-summary-page">
+        {this.state.profile && (
+          <H5>
+            Submissions of <UserRef profile={this.state.profile} />
+          </H5>
+        )}
         {this.state.problemSummaries.map(props => <ProblemSubmissionCard key={props.alias} {...props} />)}
       </div>
     );


### PR DESCRIPTION
Resolve #143

[#143](https://github.com/ia-toki/judgels/issues/143) Add username information in submission summary page using `UserRef` component.