### PR TITLE
Fix short answer and essay items UX

### DIFF
--- a/judgels-frontends/raphael/src/components/ProblemWorksheetCard/Bundle/ProblemStatementCard/ItemEssayCard/ItemEssayForm/ItemEssayForm.scss
+++ b/judgels-frontends/raphael/src/components/ProblemWorksheetCard/Bundle/ProblemStatementCard/ItemEssayCard/ItemEssayForm/ItemEssayForm.scss
@@ -9,6 +9,8 @@
 
     &.readonly {
       resize: none;
+      background-color: rgba(206,217,224,.5);
+      cursor: not-allowed;
     }
   }
 

--- a/judgels-frontends/raphael/src/components/ProblemWorksheetCard/Bundle/ProblemStatementCard/ItemShortAnswerCard/ItemShortAnswerForm/ItemShortAnswerForm.scss
+++ b/judgels-frontends/raphael/src/components/ProblemWorksheetCard/Bundle/ProblemStatementCard/ItemShortAnswerCard/ItemShortAnswerForm/ItemShortAnswerForm.scss
@@ -4,7 +4,12 @@
   }
 
   .text-input {
-    width: 70%
+    width: 70%;
+
+    &.readonly {
+      background-color: rgba(206,217,224,.5);
+      cursor: not-allowed;
+    }
   }
 
   .button {

--- a/judgels-frontends/raphael/src/components/ProblemWorksheetCard/Bundle/ProblemStatementCard/ItemShortAnswerCard/ItemShortAnswerForm/ItemShortAnswerForm.tsx
+++ b/judgels-frontends/raphael/src/components/ProblemWorksheetCard/Bundle/ProblemStatementCard/ItemShortAnswerCard/ItemShortAnswerForm/ItemShortAnswerForm.tsx
@@ -100,13 +100,14 @@ export default class ItemShortAnswerForm extends React.PureComponent<
   renderTextInput() {
     const readOnly =
       this.state.answerState === AnswerState.NotAnswered || this.state.answerState === AnswerState.AnswerSaved;
+    const readOnlyClass = readOnly ? 'readonly' : '';
     return (
       <input
         name={this.props.meta}
         value={this.state.answer}
         onChange={this.onTextInputChange}
         readOnly={readOnly}
-        className={`text-input ${classNames(Classes.INPUT)}`}
+        className={`text-input ${readOnlyClass} ${classNames(Classes.INPUT)}`}
       />
     );
   }


### PR DESCRIPTION
Issue #150 

- Add background color to readonly text input and text area
- Add not-allowed cursor to readony text input and text area

Screenshots (see the pointer):

![Screenshot from 2019-03-20 23-04-54](https://user-images.githubusercontent.com/2063523/54722442-d098d300-4b64-11e9-8d95-15c1793f7ac1.png)

![Screenshot from 2019-03-20 23-05-22](https://user-images.githubusercontent.com/2063523/54722450-d4c4f080-4b64-11e9-8c3b-b0cbac049b8e.png)

![Screenshot from 2019-03-20 23-05-42](https://user-images.githubusercontent.com/2063523/54722453-d8587780-4b64-11e9-835c-e679a483efdb.png)

![Screenshot from 2019-03-20 23-06-00](https://user-images.githubusercontent.com/2063523/54722463-dee6ef00-4b64-11e9-804f-3b8808f237a8.png)

![Screenshot from 2019-03-20 23-06-13](https://user-images.githubusercontent.com/2063523/54722468-e4dcd000-4b64-11e9-9198-82110d38e1ab.png)


