### PR TITLE
Add UFW firewall config to droplet-provision Ansible role

### DIFF
--- a/deployment/ansible/roles/droplet-provision/meta/main.yml
+++ b/deployment/ansible/roles/droplet-provision/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - docker-prune-cron
+  - ufw

--- a/deployment/ansible/roles/ufw/tasks/main.yml
+++ b/deployment/ansible/roles/ufw/tasks/main.yml
@@ -22,8 +22,6 @@
       to_port: 80
       proto: tcp
       comment: Judgels Raphael/Nginx HTTP
-    tags:
-      - firewall
 
   - name: Allow raphael/Nginx HTTPS traffic through the firewall
     ufw:
@@ -31,8 +29,6 @@
       to_port: 443
       proto: tcp
       comment: Judgels Raphael/Nginx HTTPS
-    tags:
-      - firewall
 
   - name: Allow phpMyAdmin traffic through the firewall
     ufw:
@@ -40,8 +36,6 @@
       to_port: 8080
       proto: tcp
       comment: phpMyAdmin
-    tags:
-      - firewall
 
   - name: Allow jophiel traffic through the firewall
     ufw:
@@ -49,8 +43,6 @@
       to_port: 9001
       proto: tcp
       comment: Judgels Jophiel
-    tags:
-      - firewall
 
   - name: Allow sandalphon traffic through the firewall
     ufw:
@@ -58,8 +50,6 @@
       to_port: 9002
       proto: tcp
       comment: Judgels Sandalphon
-    tags:
-      - firewall
 
   - name: Allow uriel traffic through the firewall
     ufw:
@@ -67,8 +57,6 @@
       to_port: 9004
       proto: tcp
       comment: Judgels Uriel
-    tags:
-      - firewall
 
   tags:
     - firewall

--- a/deployment/ansible/roles/ufw/tasks/main.yml
+++ b/deployment/ansible/roles/ufw/tasks/main.yml
@@ -1,0 +1,74 @@
+- block:
+  - name: Ensure UFW firewall is installed
+    apt:
+      name:
+        - ufw
+      state: present
+
+  - name: Allow SSH traffic through firewall
+    ufw:
+      rule: allow
+      name: OpenSSH
+
+  - name: Block all incoming traffic by default
+    ufw:
+      state: enabled
+      direction: incoming
+      policy: deny
+
+  - name: Allow raphael/Nginx HTTP traffic through the firewall
+    ufw:
+      rule: allow
+      to_port: 80
+      proto: tcp
+      comment: Judgels Raphael/Nginx HTTP
+    tags:
+      - firewall
+
+  - name: Allow raphael/Nginx HTTPS traffic through the firewall
+    ufw:
+      rule: allow
+      to_port: 443
+      proto: tcp
+      comment: Judgels Raphael/Nginx HTTPS
+    tags:
+      - firewall
+
+  - name: Allow phpMyAdmin traffic through the firewall
+    ufw:
+      rule: allow
+      to_port: 8080
+      proto: tcp
+      comment: phpMyAdmin
+    tags:
+      - firewall
+
+  - name: Allow jophiel traffic through the firewall
+    ufw:
+      rule: allow
+      to_port: 9001
+      proto: tcp
+      comment: Judgels Jophiel
+    tags:
+      - firewall
+
+  - name: Allow sandalphon traffic through the firewall
+    ufw:
+      rule: allow
+      to_port: 9002
+      proto: tcp
+      comment: Judgels Sandalphon
+    tags:
+      - firewall
+
+  - name: Allow uriel traffic through the firewall
+    ufw:
+      rule: allow
+      to_port: 9004
+      proto: tcp
+      comment: Judgels Uriel
+    tags:
+      - firewall
+
+  tags:
+    - firewall


### PR DESCRIPTION
Set up `ufw` Ansible role to block all incoming connections except those to port:
- 80, 443: Nginx/Raphael
- 8080: phpMyAdmin
- 9001: Jophiel
- 9002: Sandalphon
- 9004: Uriel

Note: not tested yet. In the future, it is better to make `ufw` role a dependency of other deploy roles, and configure the firewall rules as part of each deploy role (e.g. deploy-uriel should open port 9004 only). The `ufw` role itself should only ensure UFW is installed, set up allow rule for SSH, then block all incoming connections.