### PR TITLE
[Backend] bump test-containers version to 1.11.1

### DIFF
--- a/judgels-backends/gradle.properties
+++ b/judgels-backends/gradle.properties
@@ -27,6 +27,6 @@ awaitilityVersion = 3.0.0
 junitJupiterVersion = 5.3.1
 mockitoVersion = 2.10.0
 servletApiVersion = 3.1.0
-testContainersVersion = 1.5.1
+testContainersVersion = 1.11.1
 wiremockVersion = 2.14.0
 wiserVersion = 1.2


### PR DESCRIPTION
 ## Problem
- There is a known issue in docker-java which is one of the
  dependency of test-containers related to auth config file
  used in docker.
  (https://github.com/testcontainers/testcontainers-java/issues/396)
- The issue cause some workstations failed in test because
  can't connect to docker driver.

 ## Solution
- Just bump test-containers version to 1.11.1 as the issue has been
  fixed in later version.