### PR TITLE
Set security-related HTTP headers except those related to XSS protection

### DIFF
--- a/deployment/ansible/conf/nginx-certbot.conf.j2
+++ b/deployment/ansible/conf/nginx-certbot.conf.j2
@@ -1,3 +1,18 @@
+# Disable disclosing Nginx version in header
+server_tokens off;
+
+# Enable HSTS (prevents malicious users from redirecting site traffic to HTTP after first open, for 1 year)
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+# Disable iframes except if from the same origin
+add_header X-Frame-Options "SAMEORIGIN" always;
+
+# Prevent browsers from guessing the content type of files
+add_header X-Content-Type-Options "nosniff" always;
+
+# Only allow referrer headers to be sent over HTTPS, and also only the domain name (without path)
+add_header Referrer-Policy "strict-origin" always;
+
 {% if jophiel_url is defined %}
 server {
     server_name {{ jophiel_url }};


### PR DESCRIPTION
Remove Nginx version, strict transport security, frame options, content type options, referrer policy