### PR TITLE
Add support for using manual grading for multiple choice/short answer items

### DIFF
--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/MultipleChoiceItemSubmissionGrader.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/MultipleChoiceItemSubmissionGrader.java
@@ -24,8 +24,8 @@ public class MultipleChoiceItemSubmissionGrader implements ItemSubmissionGrader 
                     .build();
         }
 
-        boolean hasCorrectChoice = config.getChoices().stream().anyMatch(c -> c.getIsCorrect().get());
-        if (!hasCorrectChoice) {
+        boolean noCorrectChoice = config.getChoices().stream().noneMatch(c -> c.getIsCorrect().orElse(false));
+        if (noCorrectChoice) {
             return new Grading.Builder()
                     .verdict(Verdict.PENDING_MANUAL_GRADING)
                     .score(Optional.empty())
@@ -36,7 +36,7 @@ public class MultipleChoiceItemSubmissionGrader implements ItemSubmissionGrader 
                 .filter(c -> c.getAlias().equals(answer))
                 .findAny();
 
-        if (matchingChoice.isPresent() && matchingChoice.get().getIsCorrect().get()) {
+        if (matchingChoice.isPresent() && matchingChoice.get().getIsCorrect().orElse(false)) {
             return new Grading.Builder()
                     .verdict(Verdict.ACCEPTED)
                     .score(Optional.of(config.getScore()))

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/MultipleChoiceItemSubmissionGrader.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/MultipleChoiceItemSubmissionGrader.java
@@ -24,6 +24,14 @@ public class MultipleChoiceItemSubmissionGrader implements ItemSubmissionGrader 
                     .build();
         }
 
+        boolean hasCorrectChoice = config.getChoices().stream().anyMatch(c -> c.getIsCorrect().get());
+        if (!hasCorrectChoice) {
+            return new Grading.Builder()
+                    .verdict(Verdict.PENDING_MANUAL_GRADING)
+                    .score(Optional.empty())
+                    .build();
+        }
+
         Optional<MultipleChoiceItemConfig.Choice> matchingChoice = config.getChoices().stream()
                 .filter(c -> c.getAlias().equals(answer))
                 .findAny();

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ShortAnswerItemSubmissionGrader.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ShortAnswerItemSubmissionGrader.java
@@ -14,10 +14,9 @@ public class ShortAnswerItemSubmissionGrader implements ItemSubmissionGrader {
     @Override
     public Grading grade(Item item, String answer) {
         ShortAnswerItemConfig config;
-        String gradingRegex;
         try {
             config = (ShortAnswerItemConfig) item.getConfig();
-            gradingRegex = config.getGradingRegex().orElse("");
+            String gradingRegex = config.getGradingRegex().orElse("");
 
             if (gradingRegex.isEmpty()) {
                 return new Grading.Builder()
@@ -37,7 +36,6 @@ public class ShortAnswerItemSubmissionGrader implements ItemSubmissionGrader {
                         .score(Optional.of(config.getPenalty()))
                         .build();
             }
-
         } catch (RuntimeException e) {
             LOGGER.error("Internal error grading item submission", e);
             return new Grading.Builder()

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ShortAnswerItemSubmissionGrader.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ShortAnswerItemSubmissionGrader.java
@@ -17,24 +17,32 @@ public class ShortAnswerItemSubmissionGrader implements ItemSubmissionGrader {
         String gradingRegex;
         try {
             config = (ShortAnswerItemConfig) item.getConfig();
-            gradingRegex = config.getGradingRegex().get();
+            gradingRegex = config.getGradingRegex().orElse("");
+
+            if (gradingRegex.isEmpty()) {
+                return new Grading.Builder()
+                        .verdict(Verdict.PENDING_MANUAL_GRADING)
+                        .score(Optional.empty())
+                        .build();
+            }
+
+            if (answer.matches(gradingRegex)) {
+                return new Grading.Builder()
+                        .verdict(Verdict.ACCEPTED)
+                        .score(Optional.of(config.getScore()))
+                        .build();
+            } else {
+                return new Grading.Builder()
+                        .verdict(Verdict.WRONG_ANSWER)
+                        .score(Optional.of(config.getPenalty()))
+                        .build();
+            }
+
         } catch (RuntimeException e) {
             LOGGER.error("Internal error grading item submission", e);
             return new Grading.Builder()
                     .verdict(Verdict.INTERNAL_ERROR)
                     .score(Optional.empty())
-                    .build();
-        }
-
-        if (answer.matches(gradingRegex)) {
-            return new Grading.Builder()
-                    .verdict(Verdict.ACCEPTED)
-                    .score(Optional.of(config.getScore()))
-                    .build();
-        } else {
-            return new Grading.Builder()
-                    .verdict(Verdict.WRONG_ANSWER)
-                    .score(Optional.of(config.getPenalty()))
                     .build();
         }
     }

--- a/judgels-backends/sandalphon/sandalphon-client/src/test/java/judgels/sandalphon/submission/bundle/MultipleChoiceItemSubmissionGraderTests.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/test/java/judgels/sandalphon/submission/bundle/MultipleChoiceItemSubmissionGraderTests.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 public class MultipleChoiceItemSubmissionGraderTests {
     private Item testItem1;
     private Item testItem2;
+    private Item testItem3;
 
     @BeforeEach
     void before() {
@@ -61,6 +62,44 @@ public class MultipleChoiceItemSubmissionGraderTests {
                 .type(ItemType.MULTIPLE_CHOICE)
                 .config(new StatementItemConfig.Builder().statement("test statement").build())
                 .build();
+
+        testItem3 = new Item.Builder()
+                .jid("item3jid")
+                .meta("3")
+                .type(ItemType.MULTIPLE_CHOICE)
+                .config(new MultipleChoiceItemConfig.Builder()
+                        .statement("item without correct answer, will be graded manually")
+                        .score(4)
+                        .penalty(-1)
+                        .addChoices(
+                                new MultipleChoiceItemConfig.Choice.Builder()
+                                        .alias("a")
+                                        .content("jawaban a")
+                                        .isCorrect(false)
+                                        .build(),
+                                new MultipleChoiceItemConfig.Choice.Builder()
+                                        .alias("b")
+                                        .content("jawaban b")
+                                        .isCorrect(false)
+                                        .build(),
+                                new MultipleChoiceItemConfig.Choice.Builder()
+                                        .alias("c")
+                                        .content("jawaban c")
+                                        .isCorrect(false)
+                                        .build(),
+                                new MultipleChoiceItemConfig.Choice.Builder()
+                                        .alias("d")
+                                        .content("jawaban d")
+                                        .isCorrect(false)
+                                        .build(),
+                                new MultipleChoiceItemConfig.Choice.Builder()
+                                        .alias("e")
+                                        .content("jawaban e")
+                                        .isCorrect(false)
+                                        .build()
+                        )
+                        .build())
+                .build();
     }
 
     @Test
@@ -100,6 +139,15 @@ public class MultipleChoiceItemSubmissionGraderTests {
 
         Grading grading = grader.grade(testItem2, "b");
         assertThat(grading.getVerdict()).isEqualTo(Verdict.INTERNAL_ERROR);
+        assertThat(grading.getScore()).isEmpty();
+    }
+
+    @Test
+    void pending_manual_grading() {
+        MultipleChoiceItemSubmissionGrader grader = new MultipleChoiceItemSubmissionGrader();
+
+        Grading grading = grader.grade(testItem3, "b");
+        assertThat(grading.getVerdict()).isEqualTo(Verdict.PENDING_MANUAL_GRADING);
         assertThat(grading.getScore()).isEmpty();
     }
 }

--- a/judgels-backends/sandalphon/sandalphon-client/src/test/java/judgels/sandalphon/submission/bundle/ShortAnswerItemSubmissionGraderTests.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/test/java/judgels/sandalphon/submission/bundle/ShortAnswerItemSubmissionGraderTests.java
@@ -16,6 +16,7 @@ public class ShortAnswerItemSubmissionGraderTests {
     private Item testItem2;
     private Item testItem3;
     private Item testItem4;
+    private Item testItem5;
 
     @BeforeEach
     void before() {
@@ -64,6 +65,21 @@ public class ShortAnswerItemSubmissionGraderTests {
                         .score(1)
                         .penalty(-1)
                         .inputValidationRegex("\\d+")
+                        .gradingRegex("(")
+                        .build())
+                .build();
+
+        testItem5 = new Item.Builder()
+                .jid("item5jid")
+                .meta("5")
+                .number(5)
+                .type(ItemType.SHORT_ANSWER)
+                .config(new ShortAnswerItemConfig.Builder()
+                        .statement("test statement")
+                        .score(1)
+                        .penalty(-1)
+                        .inputValidationRegex("\\d+")
+                        .gradingRegex("")
                         .build())
                 .build();
     }
@@ -147,6 +163,16 @@ public class ShortAnswerItemSubmissionGraderTests {
 
         grading = grader.grade(testItem4, "b");
         assertThat(grading.getVerdict()).isEqualTo(Verdict.INTERNAL_ERROR);
+        assertThat(grading.getScore()).isEmpty();
+    }
+
+    @Test
+    void pending_manual_grading() {
+        ShortAnswerItemSubmissionGrader grader = new ShortAnswerItemSubmissionGrader();
+        Grading grading;
+
+        grading = grader.grade(testItem5, "b");
+        assertThat(grading.getVerdict()).isEqualTo(Verdict.PENDING_MANUAL_GRADING);
         assertThat(grading.getScore()).isEmpty();
     }
 }

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/item/ItemShortAnswerConfAdapter.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/item/ItemShortAnswerConfAdapter.java
@@ -48,7 +48,7 @@ public final class ItemShortAnswerConfAdapter implements BundleItemConfAdapter {
             if (!isRegexValid(confForm.inputValidationRegex)) {
                 form.reject(Messages.get("error.problem.bundle.item.shortAnswer.invalidInputValidationRegex"));
             }
-            if (!isRegexValid(confForm.gradingRegex)) {
+            if (!confForm.gradingRegex.isEmpty() && !isRegexValid(confForm.gradingRegex)) {
                 form.reject(Messages.get("error.problem.bundle.item.shortAnswer.invalidGradingRegex"));
             }
         }

--- a/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/item/ItemShortAnswerConfForm.java
+++ b/judgels-legacy/sandalphon/app/org/iatoki/judgels/sandalphon/problem/bundle/item/ItemShortAnswerConfForm.java
@@ -18,7 +18,6 @@ public final class ItemShortAnswerConfForm {
     @Constraints.Required
     public String inputValidationRegex;
 
-    @Constraints.Required
     public String gradingRegex;
 
     public ItemShortAnswerConfForm() {

--- a/judgels-legacy/sandalphon/conf/messages.en-US
+++ b/judgels-legacy/sandalphon/conf/messages.en-US
@@ -120,7 +120,7 @@ problem.bundle.item.meta=Meta
 problem.bundle.item.statement.statement=Statement
 
 problem.bundle.item.multipleChoice.statement=Statement
-problem.bundle.item.multipleChoice.choices=Choices
+problem.bundle.item.multipleChoice.choices=Choices (no correct choice -> manual grading)
 problem.bundle.item.multipleChoice.alias=Alias
 problem.bundle.item.multipleChoice.content=Content
 problem.bundle.item.multipleChoice.isCorrect=Correct?
@@ -135,8 +135,8 @@ problem.bundle.item.multipleChoice.addChoice=Add Choice
 problem.bundle.item.shortAnswer.statement=Statement
 problem.bundle.item.shortAnswer.score=Score
 problem.bundle.item.shortAnswer.penalty=Penalty
-problem.bundle.item.shortAnswer.inputValidationRegex=Input Validation Regex
-problem.bundle.item.shortAnswer.gradingRegex=Grading Regex
+problem.bundle.item.shortAnswer.inputValidationRegex=Input Validation Regex (matches on whole string)
+problem.bundle.item.shortAnswer.gradingRegex=Grading Regex (matches on whole string; empty regex -> manual grading)
 
 problem.bundle.item.essay.statement=Statement
 problem.bundle.item.essay.score=Score


### PR DESCRIPTION
Implements #175.

- Make grading regex not required on Sandalphon
- When grading multiple choice item submission in Uriel, set verdict to PENDING_MANUAL_GRADING if no choice marked as correct
- When grading short answer item submission in Uriel, set verdict to PENDING_MANUAL_GRADING if `gradingRegex` is empty