### PR TITLE
Server perfomance fixes

### DIFF
--- a/deployment/ansible/conf/nginx-certbot.conf.j2
+++ b/deployment/ansible/conf/nginx-certbot.conf.j2
@@ -13,6 +13,9 @@ add_header X-Content-Type-Options "nosniff" always;
 # Only allow referrer headers to be sent over HTTPS, and also only the domain name (without path)
 add_header Referrer-Policy "strict-origin" always;
 
+# Configuration for Sandalphon cache
+proxy_cache_path /tmp/sandalphon_cache levels=1:2 keys_zone=sandalphon_cache:10m max_size=2g inactive=15m use_temp_path=off;
+
 {% if jophiel_url is defined %}
 server {
     server_name {{ jophiel_url }};
@@ -57,6 +60,18 @@ server {
     }
 
     location / {
+        # Use cache for Sandalphon
+        # (Sandalphon is prone to high CPU usage if serving many asset files concurrently)
+        proxy_cache sandalphon_cache;
+
+        # On cache miss, block incoming connections while waiting for a response from Sandalphon
+        # (otherwise all incoming requests are directed to Sandalphon until Sandalphon responds,
+        # which causes a short high CPU initial burst)
+        proxy_cache_lock on;
+
+        # Try to serve Sandalphon responses from cache if Sandalphon is down
+        proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+
         proxy_pass              http://localhost:9002;
         proxy_set_header        Host $host;
         proxy_set_header        X-Real-IP $remote_addr;

--- a/deployment/ansible/conf/nginx-certbot.conf.j2
+++ b/deployment/ansible/conf/nginx-certbot.conf.j2
@@ -13,9 +13,6 @@ add_header X-Content-Type-Options "nosniff" always;
 # Only allow referrer headers to be sent over HTTPS, and also only the domain name (without path)
 add_header Referrer-Policy "strict-origin" always;
 
-# Configuration for Sandalphon cache
-proxy_cache_path /tmp/sandalphon_cache levels=1:2 keys_zone=sandalphon_cache:10m max_size=2g inactive=15m use_temp_path=off;
-
 {% if jophiel_url is defined %}
 server {
     server_name {{ jophiel_url }};
@@ -46,6 +43,10 @@ server {
 {% endif %}
 
 {% if sandalphon_url is defined %}
+
+# Configuration for Sandalphon cache
+proxy_cache_path /tmp/sandalphon_cache levels=1:2 keys_zone=sandalphon_cache:10m max_size=2g inactive=15m use_temp_path=off;
+
 server {
     server_name {{ sandalphon_url }};
 

--- a/deployment/ansible/roles/nginx-certbot-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/nginx-certbot-deploy/tasks/main.yml
@@ -1,4 +1,18 @@
 - block:
+  - name: Add or modify nofile hard limit for the user root
+    pam_limits:
+      domain: root
+      limit_type: soft
+      limit_item: nofile
+      value: 1048576
+
+  - name: Add or modify nofile soft limit for the user root
+    pam_limits:
+      domain: root
+      limit_type: soft
+      limit_item: nofile
+      value: 1048576
+
   - name: Create nginx-cerbot container mount volume
     file:
       path: "{{ item }}"

--- a/deployment/ansible/roles/nginx-certbot-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/nginx-certbot-deploy/tasks/main.yml
@@ -2,7 +2,7 @@
   - name: Add or modify nofile hard limit for the user root
     pam_limits:
       domain: root
-      limit_type: soft
+      limit_type: hard
       limit_item: nofile
       value: 1048576
 

--- a/deployment/nginx-certbot/nginx.conf
+++ b/deployment/nginx-certbot/nginx.conf
@@ -1,12 +1,12 @@
 user  nginx;
-worker_processes  1;
+worker_processes  auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
 
 events {
-    worker_connections  1024;
+    worker_connections  32768;
 }
 
 


### PR DESCRIPTION
To prevent bursts of high CPU usage caused by Sandalphon when many users try to open problems containing many images simultaneously, the following things are modified for the deployment configuration:
- Increase file descriptor limit to 1048576 (previously 1024) in the host machine (Docker limit is already 1048576)
- Set Nginx worker threads count to `auto` (previously 1)
- Add Nginx cache for Sandalphon