### PR TITLE
Optimize mass regrade of bundle items

### DIFF
--- a/judgels-backends/judgels-commons/judgels-persistence-core/src/main/java/judgels/persistence/UnmodifiableDao.java
+++ b/judgels-backends/judgels-commons/judgels-persistence-core/src/main/java/judgels/persistence/UnmodifiableDao.java
@@ -10,6 +10,7 @@ import judgels.persistence.api.SelectionOptions;
 import judgels.persistence.api.dump.UnmodifiableDump;
 
 public interface UnmodifiableDao<M extends UnmodifiableModel> {
+    void flush();
     void clear();
     M insert(M model);
     M persist(M model);

--- a/judgels-backends/judgels-commons/judgels-persistence-core/src/main/java/judgels/persistence/hibernate/UnmodifiableHibernateDao.java
+++ b/judgels-backends/judgels-commons/judgels-persistence-core/src/main/java/judgels/persistence/hibernate/UnmodifiableHibernateDao.java
@@ -41,6 +41,11 @@ public abstract class UnmodifiableHibernateDao<M extends UnmodifiableModel> exte
     }
 
     @Override
+    public void flush() {
+        currentSession().flush();
+    }
+
+    @Override
     public void clear() {
         currentSession().clear();
     }

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/hibernate/AbstractBundleItemSubmissionHibernateDao.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/hibernate/AbstractBundleItemSubmissionHibernateDao.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import judgels.persistence.FilterOptions;
 import judgels.persistence.JudgelsModel_;
+import judgels.persistence.api.OrderDir;
 import judgels.persistence.api.Page;
 import judgels.persistence.api.SelectionOptions;
 import judgels.persistence.hibernate.HibernateDaoData;
@@ -68,15 +69,18 @@ public abstract class AbstractBundleItemSubmissionHibernateDao<M extends Abstrac
     }
 
     @Override
-    public List<M> selectAllByContainerJidAndProblemJidAndCreatedBy(
-            String containerJid, Optional<String> problemJid, Optional<String> createdBy) {
+    public List<M> selectAllForRegrade(
+            Optional<String> containerJid, Optional<String> problemJid, Optional<String> createdBy) {
 
         FilterOptions.Builder<M> filterOptions = new FilterOptions.Builder<>();
-        filterOptions.putColumnsEq(AbstractBundleItemSubmissionModel_.containerJid, containerJid);
+        containerJid.ifPresent(jid -> filterOptions.putColumnsEq(AbstractBundleItemSubmissionModel_.containerJid, jid));
         createdBy.ifPresent(jid -> filterOptions.putColumnsEq(JudgelsModel_.createdBy, jid));
         problemJid.ifPresent(jid -> filterOptions.putColumnsEq(AbstractBundleItemSubmissionModel_.problemJid, jid));
 
-        return selectAll(filterOptions.build());
+        return selectAll(
+                filterOptions.build(),
+                new SelectionOptions.Builder().orderBy("problemJid").orderDir(OrderDir.ASC).build()
+        );
     }
 
     @Override

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/persistence/BaseBundleItemSubmissionDao.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/persistence/BaseBundleItemSubmissionDao.java
@@ -27,8 +27,9 @@ public interface BaseBundleItemSubmissionDao<M extends AbstractBundleItemSubmiss
             String containerJid,
             String problemJid,
             String createdBy);
-    List<M> selectAllByContainerJidAndProblemJidAndCreatedBy(
-            String containerJid,
+
+    List<M> selectAllForRegrade(
+            Optional<String> containerJid,
             Optional<String> problemJid,
             Optional<String> createdBy);
 

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ItemSubmissionRegrader.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ItemSubmissionRegrader.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 public class ItemSubmissionRegrader {
     private static final Logger LOGGER = LoggerFactory.getLogger(ItemSubmissionRegrader.class);
+    private static final int BATCH_SIZE = 50;
 
     private final ItemSubmissionStore itemSubmissionStore;
     private final ExecutorService executorService;
@@ -31,17 +32,21 @@ public class ItemSubmissionRegrader {
     }
 
     public void regradeSubmissions(
-            String containerJid,
+            Optional<String> containerJid,
             Optional<String> userJid,
             Optional<String> problemJid) {
 
         List<ItemSubmission> itemSubmissions = itemSubmissionStore.markSubmissionsForRegrade(
-                containerJid, userJid, problemJid);
+                containerJid, userJid, problemJid, Optional.of(BATCH_SIZE));
 
-        CompletableFuture.runAsync(() -> processor.process(itemSubmissions), executorService)
-                .exceptionally(e -> {
-                    LOGGER.error("Failed to regrade submissions", e);
-                    return null;
-                });
+        for (int i = 0; i < itemSubmissions.size(); i += BATCH_SIZE) {
+            int batchEndIndex = Math.min(i + BATCH_SIZE, itemSubmissions.size());
+            List<ItemSubmission> itemSubmissionsBatch = itemSubmissions.subList(i, batchEndIndex);
+            CompletableFuture.runAsync(() -> processor.process(itemSubmissionsBatch), executorService)
+                    .exceptionally(e -> {
+                        LOGGER.error("Failed to regrade submissions", e);
+                        return null;
+                    });
+        }
     }
 }

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ItemSubmissionRegrader.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ItemSubmissionRegrader.java
@@ -1,6 +1,7 @@
 package judgels.sandalphon.submission.bundle;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -39,9 +40,8 @@ public class ItemSubmissionRegrader {
         List<ItemSubmission> itemSubmissions = itemSubmissionStore.markSubmissionsForRegrade(
                 containerJid, userJid, problemJid, Optional.of(BATCH_SIZE));
 
-        for (int i = 0; i < itemSubmissions.size(); i += BATCH_SIZE) {
-            int batchEndIndex = Math.min(i + BATCH_SIZE, itemSubmissions.size());
-            List<ItemSubmission> itemSubmissionsBatch = itemSubmissions.subList(i, batchEndIndex);
+        List<List<ItemSubmission>> itemSubmissionsBatches = Lists.partition(itemSubmissions, BATCH_SIZE);
+        for (List<ItemSubmission> itemSubmissionsBatch : itemSubmissionsBatches) {
             CompletableFuture.runAsync(() -> processor.process(itemSubmissionsBatch), executorService)
                     .exceptionally(e -> {
                         LOGGER.error("Failed to regrade submissions", e);

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ItemSubmissionStore.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/bundle/ItemSubmissionStore.java
@@ -35,9 +35,10 @@ public interface ItemSubmissionStore {
     List<ItemSubmission> getSubmissionsForScoreboard(String containerJid);
 
     List<ItemSubmission> markSubmissionsForRegrade(
-            String containerJid,
+            Optional<String> containerJid,
             Optional<String> userJid,
-            Optional<String> problemJid);
+            Optional<String> problemJid,
+            Optional<Integer> batchSize);
 
     void updateGrading(String submissionJid, Grading grading);
 }

--- a/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/submission/bundle/ContestItemSubmissionService.java
+++ b/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/submission/bundle/ContestItemSubmissionService.java
@@ -61,7 +61,7 @@ public interface ContestItemSubmissionService {
     @Path("/regrade")
     void regradeSubmissions(
             @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
-            @QueryParam("contestJid") String contestJid,
+            @QueryParam("contestJid") Optional<String> contestJid,
             @QueryParam("userJid") Optional<String> userJid,
             @QueryParam("problemJid") Optional<String> problemJid);
 }


### PR DESCRIPTION
Optimizes bundle item submission regrade (#193).

- Add option to regrade all item submission in all contests (make `contestJid` param optional)
- Run regrade in batches
- Sort submissions-to-be-regraded list by problem to better utilize `ProblemClient` cache