### PR TITLE
fallback to textarea when loading

### DIFF
--- a/judgels-frontends/raphael/src/components/forms/FormRichTextArea/FormRichTextArea.tsx
+++ b/judgels-frontends/raphael/src/components/forms/FormRichTextArea/FormRichTextArea.tsx
@@ -1,17 +1,10 @@
 import { FormGroup } from '@blueprintjs/core';
 import * as React from 'react';
-
 import * as Loadable from 'react-loadable';
-import { LoadingState } from 'components/LoadingState/LoadingState';
 
 import { getIntent } from '../meta';
 import { FormInputProps } from '../props';
 import { FormInputValidation } from '../FormInputValidation/FormInputValidation';
-
-const LoadableTinyMCETextArea = Loadable({
-  loader: () => import('./TinyMCETextArea'),
-  loading: () => <LoadingState large />,
-});
 
 export interface FormRichTextAreaProps extends FormInputProps {
   rows: number;
@@ -20,6 +13,12 @@ export interface FormRichTextAreaProps extends FormInputProps {
 export class FormRichTextArea extends React.PureComponent<FormRichTextAreaProps> {
   render() {
     const { rows, input, label, meta } = this.props;
+
+    const LoadableTinyMCETextArea = Loadable({
+      loader: () => import('./TinyMCETextArea'),
+      loading: () => <textarea {...input} rows={rows} onChange={input.onChange} />,
+    });
+
     return (
       <FormGroup labelFor={input.name} label={label} intent={getIntent(meta)}>
         <LoadableTinyMCETextArea {...input} rows={rows} onChange={input.onChange} />


### PR DESCRIPTION
Tests are failing after add lazy loading to tinymce because textarea cannot be found when loading. This PR fixed it by rendering textarea when loading