### PR TITLE
Custom parameters for superadmin creator

### DIFF
--- a/deployment/ansible/conf/jophiel.yml.j2
+++ b/deployment/ansible/conf/jophiel.yml.j2
@@ -105,3 +105,9 @@ jophiel:
       subject: UNUSED
       body: UNUSED
 {% endif %}
+
+  superadminCreator:
+    enabled: true
+    username: superadmin
+    initialPassword: {{ jophiel_superadmin_initial_password }}
+    initialEmail: superadmin@jophiel.judgels

--- a/deployment/ansible/conf/jophiel.yml.j2
+++ b/deployment/ansible/conf/jophiel.yml.j2
@@ -107,7 +107,4 @@ jophiel:
 {% endif %}
 
   superadminCreator:
-    enabled: true
-    username: superadmin
-    initialPassword: {{ jophiel_superadmin_initial_password }}
-    initialEmail: superadmin@jophiel.judgels
+    initialPassword: {{ jophiel_superadminCreator_initialPassword }}

--- a/deployment/ansible/dist-example/env.yml
+++ b/deployment/ansible/dist-example/env.yml
@@ -83,7 +83,7 @@ jophiel_userResetPassword_requestEmailTemplate_body: xxx
 jophiel_userResetPassword_resetEmailTemplate_subject: xxx
 jophiel_userResetPassword_resetEmailTemplate_body: xxx
 
-jophiel_superadmin_initial_password: xxx
+jophiel_superadminCreator_initialPassword: xxx
 
 ###################################################################################################
 

--- a/deployment/ansible/dist-example/env.yml
+++ b/deployment/ansible/dist-example/env.yml
@@ -83,6 +83,8 @@ jophiel_userResetPassword_requestEmailTemplate_body: xxx
 jophiel_userResetPassword_resetEmailTemplate_subject: xxx
 jophiel_userResetPassword_resetEmailTemplate_body: xxx
 
+jophiel_superadmin_initial_password: xxx
+
 ###################################################################################################
 
 sandalphon_play_crypto_secret: xxx

--- a/judgels-backends/jophiel/jophiel-app/src/integTest/java/judgels/jophiel/api/AbstractServiceIntegrationTests.java
+++ b/judgels-backends/jophiel/jophiel-app/src/integTest/java/judgels/jophiel/api/AbstractServiceIntegrationTests.java
@@ -24,6 +24,7 @@ import judgels.jophiel.mailer.MailerConfiguration;
 import judgels.jophiel.user.account.UserRegistrationConfiguration;
 import judgels.jophiel.user.account.UserResetPasswordConfiguration;
 import judgels.jophiel.user.avatar.UserAvatarConfiguration;
+import judgels.jophiel.user.superadmin.SuperadminCreatorConfiguration;
 import judgels.service.api.actor.AuthHeader;
 import judgels.service.jaxrs.JaxRsClients;
 import org.h2.Driver;
@@ -63,6 +64,7 @@ public abstract class AbstractServiceIntegrationTests {
                 .userRegistrationConfig(UserRegistrationConfiguration.DEFAULT)
                 .userResetPasswordConfig(UserResetPasswordConfiguration.DEFAULT)
                 .userAvatarConfig(UserAvatarConfiguration.DEFAULT)
+                .superadminCreatorConfig(SuperadminCreatorConfiguration.DEFAULT)
                 .build();
 
         JophielApplicationConfiguration config = new JophielApplicationConfiguration(

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/JophielApplication.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/JophielApplication.java
@@ -15,6 +15,7 @@ import judgels.jophiel.user.account.UserRegistrationModule;
 import judgels.jophiel.user.account.UserResetPasswordModule;
 import judgels.jophiel.user.avatar.UserAvatarModule;
 import judgels.jophiel.user.registration.web.UserRegistrationWebConfig;
+import judgels.jophiel.user.superadmin.SuperadminModule;
 import judgels.recaptcha.RecaptchaModule;
 import judgels.service.hibernate.JudgelsHibernateModule;
 import judgels.service.jaxrs.JudgelsObjectMappers;
@@ -52,9 +53,10 @@ public class JophielApplication extends Application<JophielApplicationConfigurat
                         jophielConfig.getUserRegistrationConfig(),
                         UserRegistrationWebConfig.fromServerConfig(jophielConfig)))
                 .userResetPasswordModule(new UserResetPasswordModule(jophielConfig.getUserResetPasswordConfig()))
+                .superadminModule(new SuperadminModule(jophielConfig.getSuperadminCreatorConfig()))
                 .build();
 
-        component.superadminCreator().create();
+        component.superadminCreator().createIfEnabled();
 
         env.jersey().register(JudgelsJerseyFeature.INSTANCE);
 

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/JophielApplication.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/JophielApplication.java
@@ -56,7 +56,7 @@ public class JophielApplication extends Application<JophielApplicationConfigurat
                 .superadminModule(new SuperadminModule(jophielConfig.getSuperadminCreatorConfig()))
                 .build();
 
-        component.superadminCreator().createIfEnabled();
+        component.superadminCreator().ensureSuperadminExists();
 
         env.jersey().register(JudgelsJerseyFeature.INSTANCE);
 

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/JophielConfiguration.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/JophielConfiguration.java
@@ -9,6 +9,7 @@ import judgels.jophiel.mailer.MailerConfiguration;
 import judgels.jophiel.user.account.UserRegistrationConfiguration;
 import judgels.jophiel.user.account.UserResetPasswordConfiguration;
 import judgels.jophiel.user.avatar.UserAvatarConfiguration;
+import judgels.jophiel.user.superadmin.SuperadminCreatorConfiguration;
 import judgels.recaptcha.RecaptchaConfiguration;
 import org.immutables.value.Value;
 
@@ -34,6 +35,9 @@ public interface JophielConfiguration {
 
     @JsonProperty("userResetPassword")
     UserResetPasswordConfiguration getUserResetPasswordConfig();
+
+    @JsonProperty("superadminCreator")
+    SuperadminCreatorConfiguration getSuperadminCreatorConfig();
 
     @Value.Check
     default void check() {

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/JophielConfiguration.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/JophielConfiguration.java
@@ -37,7 +37,7 @@ public interface JophielConfiguration {
     UserResetPasswordConfiguration getUserResetPasswordConfig();
 
     @JsonProperty("superadminCreator")
-    SuperadminCreatorConfiguration getSuperadminCreatorConfig();
+    Optional<SuperadminCreatorConfiguration> getSuperadminCreatorConfig();
 
     @Value.Check
     default void check() {

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminCreator.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminCreator.java
@@ -12,32 +12,41 @@ import org.slf4j.LoggerFactory;
 public class SuperadminCreator {
     private static final Logger LOGGER = LoggerFactory.getLogger(SuperadminCreator.class);
 
-    public static final String USERNAME = "superadmin";
-    public static final String PASSWORD = "superadmin";
-
     private final UserStore userStore;
     private final SuperadminRoleStore superadminRoleStore;
+    private final SuperadminCreatorConfiguration config;
 
-    public SuperadminCreator(UserStore userStore, SuperadminRoleStore superadminRoleStore) {
+    public SuperadminCreator(
+            UserStore userStore,
+            SuperadminRoleStore superadminRoleStore,
+            SuperadminCreatorConfiguration config) {
+
         this.userStore = userStore;
         this.superadminRoleStore = superadminRoleStore;
+        this.config = config;
     }
 
     @UnitOfWork
-    public void create() {
-        Optional<User> maybeUser = userStore.getUserByUsername(USERNAME);
-        User user;
-        if (maybeUser.isPresent()) {
-            user = maybeUser.get();
-            LOGGER.info("superadmin user already exists");
-        } else {
-            user = userStore.createUser(new UserData.Builder()
-                    .username(USERNAME)
-                    .password(PASSWORD)
-                    .email(USERNAME + "@jophiel.judgels")
-                    .build());
-            LOGGER.info("Created superadmin user");
+    public void createIfEnabled() {
+        if (config.getEnabled()) {
+            String username = config.getUsername().orElse("superadmin");
+            String initialPassword = config.getInitialPassword().orElse(username);
+            String initialEmail = config.getInitialEmail().orElse(username + "@jophiel.judgels");
+
+            Optional<User> maybeUser = userStore.getUserByUsername(username);
+            User user;
+            if (maybeUser.isPresent()) {
+                user = maybeUser.get();
+                LOGGER.info("Superadmin user already exists (username: " + username + ")");
+            } else {
+                user = userStore.createUser(new UserData.Builder()
+                        .username(username)
+                        .password(initialPassword)
+                        .email(initialEmail)
+                        .build());
+                LOGGER.info("Created superadmin user (username: " + username + ", email: " + initialEmail + ")");
+            }
+            superadminRoleStore.setSuperadmin(user.getJid());
         }
-        superadminRoleStore.setSuperadmin(user.getJid());
     }
 }

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminCreatorConfiguration.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminCreatorConfiguration.java
@@ -1,23 +1,16 @@
 package judgels.jophiel.user.superadmin;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(as = ImmutableSuperadminCreatorConfiguration.class)
 public interface SuperadminCreatorConfiguration {
     SuperadminCreatorConfiguration DEFAULT = new SuperadminCreatorConfiguration.Builder()
-            .enabled(true)
-            .username("superadmin")
             .initialPassword("superadmin")
-            .initialEmail("superadmin@jophiel.judgels")
             .build();
 
-    boolean getEnabled();
-    Optional<String> getUsername();
-    Optional<String> getInitialPassword();
-    Optional<String> getInitialEmail();
+    String getInitialPassword();
 
     class Builder extends ImmutableSuperadminCreatorConfiguration.Builder {}
 }

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminCreatorConfiguration.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminCreatorConfiguration.java
@@ -1,0 +1,23 @@
+package judgels.jophiel.user.superadmin;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableSuperadminCreatorConfiguration.class)
+public interface SuperadminCreatorConfiguration {
+    SuperadminCreatorConfiguration DEFAULT = new SuperadminCreatorConfiguration.Builder()
+            .enabled(true)
+            .username("superadmin")
+            .initialPassword("superadmin")
+            .initialEmail("superadmin@jophiel.judgels")
+            .build();
+
+    boolean getEnabled();
+    Optional<String> getUsername();
+    Optional<String> getInitialPassword();
+    Optional<String> getInitialEmail();
+
+    class Builder extends ImmutableSuperadminCreatorConfiguration.Builder {}
+}

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminModule.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminModule.java
@@ -9,18 +9,21 @@ import judgels.jophiel.user.UserStore;
 
 @Module
 public class SuperadminModule {
-    private SuperadminModule() {}
+    private SuperadminCreatorConfiguration config;
+
+    public SuperadminModule(SuperadminCreatorConfiguration config) {
+        this.config = config;
+    }
 
     @Provides
     @Singleton
-    static SuperadminCreator superadminCreator(
+    SuperadminCreator superadminCreator(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             UserStore userStore,
             SuperadminRoleStore superadminRoleStore) {
-
         return unitOfWorkAwareProxyFactory.create(
                 SuperadminCreator.class,
-                new Class<?>[]{UserStore.class, SuperadminRoleStore.class},
-                new Object[]{userStore, superadminRoleStore});
+                new Class<?>[]{UserStore.class, SuperadminRoleStore.class, SuperadminCreatorConfiguration.class},
+                new Object[]{userStore, superadminRoleStore, config});
     }
 }

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminModule.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/superadmin/SuperadminModule.java
@@ -3,15 +3,16 @@ package judgels.jophiel.user.superadmin;
 import dagger.Module;
 import dagger.Provides;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
+import java.util.Optional;
 import javax.inject.Singleton;
 import judgels.jophiel.role.SuperadminRoleStore;
 import judgels.jophiel.user.UserStore;
 
 @Module
 public class SuperadminModule {
-    private SuperadminCreatorConfiguration config;
+    private Optional<SuperadminCreatorConfiguration> config;
 
-    public SuperadminModule(SuperadminCreatorConfiguration config) {
+    public SuperadminModule(Optional<SuperadminCreatorConfiguration> config) {
         this.config = config;
     }
 
@@ -23,7 +24,7 @@ public class SuperadminModule {
             SuperadminRoleStore superadminRoleStore) {
         return unitOfWorkAwareProxyFactory.create(
                 SuperadminCreator.class,
-                new Class<?>[]{UserStore.class, SuperadminRoleStore.class, SuperadminCreatorConfiguration.class},
+                new Class<?>[]{UserStore.class, SuperadminRoleStore.class, Optional.class},
                 new Object[]{userStore, superadminRoleStore, config});
     }
 }

--- a/judgels-backends/jophiel/jophiel-dist/var/conf/jophiel.yml.example
+++ b/judgels-backends/jophiel/jophiel-dist/var/conf/jophiel.yml.example
@@ -88,3 +88,9 @@ jophiel:
       body: |
         <p>Dear {{username}},</p>
         <p>Your password has been reset.</p>
+
+  superadminCreator:
+    enabled: true
+    username: superadmin
+    initialPassword: superadmin
+    initialEmail: superadmin@jophiel.judgels

--- a/judgels-backends/jophiel/jophiel-dist/var/conf/jophiel.yml.example
+++ b/judgels-backends/jophiel/jophiel-dist/var/conf/jophiel.yml.example
@@ -90,7 +90,4 @@ jophiel:
         <p>Your password has been reset.</p>
 
   superadminCreator:
-    enabled: true
-    username: superadmin
     initialPassword: superadmin
-    initialEmail: superadmin@jophiel.judgels

--- a/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/programming/GradingResponsePoller.java
+++ b/judgels-backends/sandalphon/sandalphon-client/src/main/java/judgels/sandalphon/submission/programming/GradingResponsePoller.java
@@ -1,6 +1,5 @@
 package judgels.sandalphon.submission.programming;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;


### PR DESCRIPTION
Implements #170.

Adds configuration for Jophiel's superadmin creator which runs at Jophiel startup.
New options: `superadminCreator.initialPassword`.

Also modified Ansible deploy script so that the Jophiel conf uses the newly added options (using Ansible conf variable `jophiel_superadminCreator_initialPassword`.