### PR TITLE
Fix MathJax bug: Move MathJax config to MathjaxText Component

### DIFF
--- a/judgels-frontends/raphael/public/var/conf/mathjax-config.js
+++ b/judgels-frontends/raphael/public/var/conf/mathjax-config.js
@@ -1,9 +1,0 @@
-window.MathJax = {
-  tex: {
-    inlineMath: [['$', '$'], ['\\(', '\\)']],
-    displayMath: [['$$', '$$'], ['\\[', '\\]']],
-  },
-  svg: {
-    fontCache: 'global',
-  },
-};

--- a/judgels-frontends/raphael/src/components/MathjaxText/MathjaxText.tsx
+++ b/judgels-frontends/raphael/src/components/MathjaxText/MathjaxText.tsx
@@ -25,15 +25,43 @@ export class MathjaxText extends React.Component<MathjaxTextProps, MathjaxTextSt
 
   componentDidMount() {
     if (this.state.containsMathJax) {
-      const publicUrl = process.env.PUBLIC_URL;
-      this.insertScript('MathJax-config', publicUrl + '/var/conf/mathjax-config.js');
-      this.insertScript('MathJax-script', publicUrl + '/mathjax/tex-svg.js');
+      this.typesetMathJax();
     }
   }
 
   componentDidUpdate() {
     if (this.state.containsMathJax) {
+      this.typesetMathJax();
+    }
+  }
+
+  private setupMathjaxConfig() {
+    window.MathJax = {
+      tex: {
+        inlineMath: [
+          ['$$$', '$$$'],
+          ['\\(', '\\)'],
+        ],
+        displayMath: [
+          ['$$$$', '$$$$'],
+          ['\\[', '\\]'],
+        ],
+      },
+      svg: {
+        fontCache: 'global',
+      },
+    };
+  }
+
+  private typesetMathJax() {
+    if (window.MathJax) {
+      // if the script already exists, typeset directly.
       window.MathJax.typeset();
+    } else {
+      // otherwise setup the mathjax.
+      const publicUrl = process.env.PUBLIC_URL;
+      this.setupMathjaxConfig();
+      this.insertScript('MathJax-script', publicUrl + '/mathjax/tex-svg.js');
     }
   }
 
@@ -44,11 +72,11 @@ export class MathjaxText extends React.Component<MathjaxTextProps, MathjaxTextSt
     script.src = url;
     script.defer = true;
 
-    document.body.appendChild(script);
+    document.head.appendChild(script);
   }
 
   private containsMathjaxSyntax(text: string) {
-    const mathjaxDelimitters = ['$', '\\(', '\\)', '\\[', '\\]'];
+    const mathjaxDelimitters = ['$$$', '$$$$', '\\(', '\\)', '\\[', '\\]'];
     for (let delimitter of mathjaxDelimitters) {
       if (text.includes(delimitter)) {
         return true;

--- a/judgels-frontends/raphael/src/components/MathjaxText/MathjaxText.tsx
+++ b/judgels-frontends/raphael/src/components/MathjaxText/MathjaxText.tsx
@@ -35,6 +35,18 @@ export class MathjaxText extends React.Component<MathjaxTextProps, MathjaxTextSt
     }
   }
 
+  private typesetMathJax() {
+    if (window.MathJax) {
+      // if the script already exists, typeset directly.
+      window.MathJax.typeset();
+    } else {
+      // otherwise setup the mathjax.
+      const publicUrl = process.env.PUBLIC_URL;
+      this.setupMathjaxConfig();
+      this.insertScript('MathJax-script', publicUrl + '/mathjax/tex-svg.js');
+    }
+  }
+
   private setupMathjaxConfig() {
     window.MathJax = {
       tex: {
@@ -51,18 +63,6 @@ export class MathjaxText extends React.Component<MathjaxTextProps, MathjaxTextSt
         fontCache: 'global',
       },
     };
-  }
-
-  private typesetMathJax() {
-    if (window.MathJax) {
-      // if the script already exists, typeset directly.
-      window.MathJax.typeset();
-    } else {
-      // otherwise setup the mathjax.
-      const publicUrl = process.env.PUBLIC_URL;
-      this.setupMathjaxConfig();
-      this.insertScript('MathJax-script', publicUrl + '/mathjax/tex-svg.js');
-    }
   }
 
   private insertScript(id: string, url: string) {


### PR DESCRIPTION
In this PR: 
- move mathjax config from public folder to MathjaxText Component
- optimize the loading script, only load mathjax script when it's not inserted yet.