### PR TITLE
Add backslash at the end of the contest URL.

### DIFF
--- a/judgels-frontends/raphael/src/routes/contests/contests/ContestCard/ContestCard.tsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/ContestCard/ContestCard.tsx
@@ -20,7 +20,7 @@ export class ContestCard extends React.PureComponent<ContestCardProps> {
     const { contest, role } = this.props;
 
     return (
-      <ContentCardLink to={`/contests/${contest.slug}`}>
+      <ContentCardLink to={`/contests/${contest.slug}/`}>
         <h4 className="contest-card-name">
           {contest.name}
           <div className="contest-card-role">


### PR DESCRIPTION
Add backslash at the end of the contest URL when clicking the contest card.

This is done since there will be a backslash appended at the end of the contest
URL when clicking the 'Overview' button in the contest page. To ensure that
relative URL destination is consistent whether the contest overview is visited
before or after clicking any contest button, we also append a backslash at the
end of the contest URL before clicking any contest button.