### PR TITLE
Fix #250 pushed breadcrumb on changing problem language

### DIFF
--- a/judgels-frontends/raphael/src/routes/contests/contests/single/problems/single/ContestProblemPage/Programming/ContestProblemPage.tsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/problems/single/ContestProblemPage/Programming/ContestProblemPage.tsx
@@ -56,6 +56,19 @@ export class ContestProblemPage extends React.Component<ContestProblemPageProps,
   state: ContestProblemPageState = {};
 
   async componentDidMount() {
+    await this.fetchProblemWorksheet();
+    this.props.onPushBreadcrumb(this.props.match.url, 'Problem ' + this.state.problem.alias);
+  }
+
+  async componentDidUpdate(prevProps: ContestProblemPageProps, prevState: ContestProblemPageState) {
+    if (this.props.statementLanguage !== prevProps.statementLanguage && prevState.worksheet) {
+      this.setState({ worksheet: undefined });
+    } else if (!this.state.worksheet && prevState.worksheet) {
+      await this.fetchProblemWorksheet();
+    }
+  }
+
+  async fetchProblemWorksheet() {
     const { defaultLanguage, languages, problem, totalSubmissions, worksheet } = await this.props.onGetProblemWorksheet(
       this.props.contest.jid,
       this.props.match.params.problemAlias,
@@ -69,16 +82,6 @@ export class ContestProblemPage extends React.Component<ContestProblemPageProps,
       totalSubmissions,
       worksheet,
     });
-
-    this.props.onPushBreadcrumb(this.props.match.url, 'Problem ' + problem.alias);
-  }
-
-  async componentDidUpdate(prevProps: ContestProblemPageProps, prevState: ContestProblemPageState) {
-    if (this.props.statementLanguage !== prevProps.statementLanguage && prevState.worksheet) {
-      this.setState({ worksheet: undefined });
-    } else if (!this.state.worksheet && prevState.worksheet) {
-      await this.componentDidMount();
-    }
   }
 
   async componentWillUnmount() {


### PR DESCRIPTION
As mentioned in #250, when the statement language updated, props are changing, and componentDidUpdate rerun the componentDidMount.

However, componentDidMount not only fetching the problem worksheet, but also pushing the problem alias to breadcrumb.

So, we separate the fetching to fetchProblemWorksheet.

Fixes #250