### PR TITLE
Fix unfiltered submissions on the first view

### DIFF
--- a/judgels-frontends/raphael/src/routes/contests/contests/single/submissions/Programming/ContestSubmissionsPage/ContestSubmissionsPage.tsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/submissions/Programming/ContestSubmissionsPage/ContestSubmissionsPage.tsx
@@ -59,10 +59,11 @@ export class ContestSubmissionsPage extends React.PureComponent<
     this.state = { filter: { username, problemAlias } };
   }
 
-  async componentDidMount() {
-    const { filter } = this.state;
-    if (filter.username || filter.problemAlias) {
-      await this.refreshSubmissions();
+  async componentDidUpdate(prevProps: ContestSubmissionsPageProps, prevState: ContestSubmissionsPageState) {
+    const { response, filter: { username, problemAlias } } = this.state;
+    if (!prevState.response && response && (username || problemAlias)) {
+      this.setState({isFilterLoading: true});
+      this.refreshSubmissions(username, problemAlias);
     }
   }
 

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/submissions/Programming/ContestSubmissionsPage/ContestSubmissionsPage.tsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/submissions/Programming/ContestSubmissionsPage/ContestSubmissionsPage.tsx
@@ -60,9 +60,12 @@ export class ContestSubmissionsPage extends React.PureComponent<
   }
 
   async componentDidUpdate(prevProps: ContestSubmissionsPageProps, prevState: ContestSubmissionsPageState) {
-    const { response, filter: { username, problemAlias } } = this.state;
+    const {
+      response,
+      filter: { username, problemAlias },
+    } = this.state;
     if (!prevState.response && response && (username || problemAlias)) {
-      this.setState({isFilterLoading: true});
+      this.setState({ isFilterLoading: true });
       this.refreshSubmissions(username, problemAlias);
     }
   }

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/submissions/Programming/ContestSubmissionsPage/ContestSubmissionsPage.tsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/submissions/Programming/ContestSubmissionsPage/ContestSubmissionsPage.tsx
@@ -66,7 +66,7 @@ export class ContestSubmissionsPage extends React.PureComponent<
     } = this.state;
     if (!prevState.response && response && (username || problemAlias)) {
       this.setState({ isFilterLoading: true });
-      this.refreshSubmissions(username, problemAlias);
+      await this.refreshSubmissions(username, problemAlias);
     }
   }
 


### PR DESCRIPTION
Resolves #248.

Uriel only provides API for fetching submissions by problem JID, not alias. However,  raphael use problem alias on the url params. Thus, we need to fetch the problems first (including all submissions, unfiltered).

In the original code, submissions are fetched on `componentDidMount` and filtered by `react-paginate`. However, these two tasks are asynchronous, so the filter is not working on the first view, but working when someone open other page.

To handle this, I move the submissions fetching to `componentDidUpdate`, when problem list has already been fetched, but not filtered. Then, we call `refreshSubmissions` to get the matched problem JID.

However, user will be given list of submissions unfiltered first, because we have the unfiltered list. The filter loading is on, so it shows that the filter is still working.
![loading](https://user-images.githubusercontent.com/20378156/74580689-7e14a080-4fd9-11ea-8e73-45293ee1e1e7.png)

Then, the filtered list shown.
![done](https://user-images.githubusercontent.com/20378156/74580693-853bae80-4fd9-11ea-8ae7-6189f70d5b2f.png)

