### PR TITLE
Reduce mathjax font size #251

### DIFF
--- a/judgels-frontends/raphael/src/components/MathjaxText/MathjaxText.scss
+++ b/judgels-frontends/raphael/src/components/MathjaxText/MathjaxText.scss
@@ -1,0 +1,7 @@
+@import '../../styles/base';
+
+.mathjax-wrapper {
+    svg {
+        font-size: 0.9em;
+    }
+}

--- a/judgels-frontends/raphael/src/components/MathjaxText/MathjaxText.tsx
+++ b/judgels-frontends/raphael/src/components/MathjaxText/MathjaxText.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { HtmlText } from '../HtmlText/HtmlText';
+import './MathjaxText.scss';
 
 declare global {
   interface Window {


### PR DESCRIPTION
We have tried to change the `scale` option from [Mathjax](http://docs.mathjax.org/en/latest/options/output/index.html), but it doesn't do anything. The only thing I can found is to change the font size manually.

Sebelum:

![before](https://user-images.githubusercontent.com/20378156/74584743-1590e800-5008-11ea-8d41-a4d885c7371b.png)

Sesudah:

![after](https://user-images.githubusercontent.com/20378156/74584744-17f34200-5008-11ea-957a-49d4de4fecec.png)
