### PR TITLE
Fix issue where GIF image is not playing

### DIFF
--- a/judgels-legacy/play-commons/app/org/iatoki/judgels/play/controllers/apis/AbstractJudgelsAPIController.java
+++ b/judgels-legacy/play-commons/app/org/iatoki/judgels/play/controllers/apis/AbstractJudgelsAPIController.java
@@ -107,16 +107,14 @@ public abstract class AbstractJudgelsAPIController extends Controller {
             try {
                 BufferedImage in = ImageIO.read(imageFile);
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                baos.write(Files.toByteArray(imageFile));
 
                 if (in == null) {
-                    baos.write(Files.toByteArray(imageFile));
                     response().setContentType(URLConnection.guessContentTypeFromName(imageFile.getName()));
                     return ok(baos.toByteArray());
                 }
 
                 String type = FilenameUtils.getExtension(imageFile.getAbsolutePath());
-
-                ImageIO.write(in, type, baos);
 
                 response().setContentType("image/" + type);
                 return ok(baos.toByteArray());


### PR DESCRIPTION
The issue was caused by ImageIO unable to read GIF files
properly due to image type issue.
The solution is to return the file's byte array directly
and only use ImageIO for image checking.

Reference:
https://stackoverflow.com/questions/592032/imageio-write-not-saving-out-as-gif-but-works-for-jpgs-and-pngs

Resolves: #245