### PR TITLE
Fix docker-prune-cron task cron job timing

### DIFF
--- a/deployment/ansible/roles/docker-prune-cron/tasks/main.yml
+++ b/deployment/ansible/roles/docker-prune-cron/tasks/main.yml
@@ -2,7 +2,9 @@
   - name: Add cron job to prune docker system
     cron:
       name: Prune docker system
-      weekday: "1"
+      hour: "23"
+      minute: "59"
+      weekday: "0"
       job: docker system prune -a -f
       user: root
       cron_file: docker-prune


### PR DESCRIPTION
Previously run every minute on Monday, now run every 23:59 at Sunday (server timezone is usually UTC).