### PR TITLE
Explicitly set mode option to 0644 on Ansible template tasks

### DIFF
--- a/deployment/ansible/roles/gabriel-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/gabriel-deploy/tasks/main.yml
@@ -13,11 +13,13 @@
     template:
       src: "{{ playbook_dir }}/../conf/gabriel.yml.j2"
       dest: /judgels/gabriel/var/conf/gabriel.yml
+      mode: '0644'
 
   - name: Generate gabriel launcher config
     template:
       src: "{{ playbook_dir }}/../conf/gabriel-launcher.yml.j2"
       dest: /judgels/gabriel/var/conf/launcher-custom.yml
+      mode: '0644'
 
   - name: Pull gabriel image
     docker_image:

--- a/deployment/ansible/roles/gabriel-reload/tasks/main.yml
+++ b/deployment/ansible/roles/gabriel-reload/tasks/main.yml
@@ -3,11 +3,13 @@
     template:
       src: "{{ playbook_dir }}/../conf/gabriel.yml.j2"
       dest: /judgels/gabriel/var/conf/gabriel.yml
+      mode: '0644'
 
   - name: Generate gabriel launcher config
     template:
       src: "{{ playbook_dir }}/../conf/gabriel-launcher.yml.j2"
       dest: /judgels/gabriel/var/conf/launcher-custom.yml
+      mode: '0644'
 
   - name: Restart gabriel
     docker_container:

--- a/deployment/ansible/roles/jerahmeel-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/jerahmeel-deploy/tasks/main.yml
@@ -13,11 +13,13 @@
     template:
       src: "{{ playbook_dir }}/../conf/jerahmeel.yml.j2"
       dest: /judgels/jerahmeel/var/conf/jerahmeel.yml
+      mode: '0644'
 
   - name: Generate jerahmeel launcher config
     template:
       src: "{{ playbook_dir }}/../conf/jerahmeel-launcher.yml.j2"
       dest: /judgels/jerahmeel/var/conf/launcher-custom.yml
+      mode: '0644'
 
   - name: Pull jerahmeel image
     docker_image:

--- a/deployment/ansible/roles/jerahmeel-migrate/tasks/main.yml
+++ b/deployment/ansible/roles/jerahmeel-migrate/tasks/main.yml
@@ -12,6 +12,7 @@
     template:
       src: "{{ playbook_dir }}/../conf/jerahmeel.yml.j2"
       dest: /judgels/jerahmeel/var/conf/jerahmeel.yml
+      mode: '0644'
 
   - name: Pull jerahmeel image
     docker_image:

--- a/deployment/ansible/roles/jerahmeel-reload/tasks/main.yml
+++ b/deployment/ansible/roles/jerahmeel-reload/tasks/main.yml
@@ -3,6 +3,7 @@
     template:
       src: "{{ playbook_dir }}/../conf/jerahmeel.yml.j2"
       dest: /judgels/jerahmeel/var/conf/jerahmeel.yml
+      mode: '0644'
 
   - name: Restart jerahmeel
     docker_container:

--- a/deployment/ansible/roles/jophiel-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/jophiel-deploy/tasks/main.yml
@@ -13,11 +13,13 @@
     template:
       src: "{{ playbook_dir }}/../conf/jophiel.yml.j2"
       dest: /judgels/jophiel/var/conf/jophiel.yml
+      mode: '0644'
 
   - name: Generate jophiel launcher config
     template:
       src: "{{ playbook_dir }}/../conf/jophiel-launcher.yml.j2"
       dest: /judgels/jophiel/var/conf/launcher-custom.yml
+      mode: '0644'
 
   - name: Pull jophiel image
     docker_image:

--- a/deployment/ansible/roles/jophiel-migrate/tasks/main.yml
+++ b/deployment/ansible/roles/jophiel-migrate/tasks/main.yml
@@ -12,6 +12,7 @@
     template:
       src: "{{ playbook_dir }}/../conf/jophiel.yml.j2"
       dest: /judgels/jophiel/var/conf/jophiel.yml
+      mode: '0644'
 
   - name: Pull jophiel image
     docker_image:

--- a/deployment/ansible/roles/jophiel-reload/tasks/main.yml
+++ b/deployment/ansible/roles/jophiel-reload/tasks/main.yml
@@ -3,11 +3,13 @@
     template:
       src: "{{ playbook_dir }}/../conf/jophiel.yml.j2"
       dest: /judgels/jophiel/var/conf/jophiel.yml
+      mode: '0644'
 
   - name: Generate jophiel launcher config
     template:
       src: "{{ playbook_dir }}/../conf/jophiel-launcher.yml.j2"
       dest: /judgels/jophiel/var/conf/launcher-custom.yml
+      mode: '0644'
 
   - name: Restart jophiel
     docker_container:

--- a/deployment/ansible/roles/nginx-certbot-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/nginx-certbot-deploy/tasks/main.yml
@@ -26,6 +26,7 @@
     template:
       src: "{{ playbook_dir }}/../conf/nginx-certbot.conf.j2"
       dest: /judgels/sites/default.conf
+      mode: '0644'
 
   - name: Pull nginx-certbot image
     docker_image:

--- a/deployment/ansible/roles/raphael-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/raphael-deploy/tasks/main.yml
@@ -12,6 +12,7 @@
     template:
       src: "{{ playbook_dir }}/../conf/raphael.js.j2"
       dest: /judgels/raphael/var/conf/raphael.js
+      mode: '0644'
 
   - name: Pull raphael image
     docker_image:

--- a/deployment/ansible/roles/raphael-reload/tasks/main.yml
+++ b/deployment/ansible/roles/raphael-reload/tasks/main.yml
@@ -3,6 +3,7 @@
     template:
       src: "{{ playbook_dir }}/../conf/raphael.js.j2"
       dest: /judgels/raphael/var/conf/raphael.js
+      mode: '0644'
 
   - name: Restart raphael
     docker_container:

--- a/deployment/ansible/roles/sandalphon-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/sandalphon-deploy/tasks/main.yml
@@ -13,6 +13,7 @@
     template:
       src: "{{ playbook_dir }}/../conf/sandalphon.conf.j2"
       dest: /judgels/sandalphon/var/conf/sandalphon.conf
+      mode: '0644'
 
   - name: Pull sandalphon image
     docker_image:

--- a/deployment/ansible/roles/sandalphon-reload/tasks/main.yml
+++ b/deployment/ansible/roles/sandalphon-reload/tasks/main.yml
@@ -3,6 +3,7 @@
     template:
       src: "{{ playbook_dir }}/../conf/sandalphon.conf.j2"
       dest: /judgels/sandalphon/var/conf/sandalphon.conf
+      mode: '0644'
 
   - name: Restart sandalphon
     docker_container:

--- a/deployment/ansible/roles/sealtiel-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/sealtiel-deploy/tasks/main.yml
@@ -12,11 +12,13 @@
     template:
       src: "{{ playbook_dir }}/../conf/sealtiel.yml.j2"
       dest: /judgels/sealtiel/var/conf/sealtiel.yml
+      mode: '0644'
   
   - name: Generate sealtiel launcher config
     template:
       src: "{{ playbook_dir }}/../conf/sealtiel-launcher.yml.j2"
       dest: /judgels/sealtiel/var/conf/launcher-custom.yml
+      mode: '0644'
 
   - name: Pull sealtiel image
     docker_image:

--- a/deployment/ansible/roles/sealtiel-reload/tasks/main.yml
+++ b/deployment/ansible/roles/sealtiel-reload/tasks/main.yml
@@ -3,11 +3,13 @@
     template:
       src: "{{ playbook_dir }}/../conf/sealtiel.yml.j2"
       dest: /judgels/sealtiel/var/conf/sealtiel.yml
+      mode: '0644'
 
   - name: Generate sealtiel launcher config
     template:
       src: "{{ playbook_dir }}/../conf/sealtiel-launcher.yml.j2"
       dest: /judgels/sealtiel/var/conf/launcher-custom.yml
+      mode: '0644'
 
   - name: Restart sealtiel
     docker_container:

--- a/deployment/ansible/roles/uriel-deploy/tasks/main.yml
+++ b/deployment/ansible/roles/uriel-deploy/tasks/main.yml
@@ -13,11 +13,13 @@
     template:
       src: "{{ playbook_dir }}/../conf/uriel.yml.j2"
       dest: /judgels/uriel/var/conf/uriel.yml
+      mode: '0644'
 
   - name: Generate uriel launcher config
     template:
       src: "{{ playbook_dir }}/../conf/uriel-launcher.yml.j2"
       dest: /judgels/uriel/var/conf/launcher-custom.yml
+      mode: '0644'
 
   - name: Pull uriel image
     docker_image:

--- a/deployment/ansible/roles/uriel-migrate/tasks/main.yml
+++ b/deployment/ansible/roles/uriel-migrate/tasks/main.yml
@@ -12,6 +12,7 @@
     template:
       src: "{{ playbook_dir }}/../conf/uriel.yml.j2"
       dest: /judgels/uriel/var/conf/uriel.yml
+      mode: '0644'
 
   - name: Pull uriel image
     docker_image:

--- a/deployment/ansible/roles/uriel-reload/tasks/main.yml
+++ b/deployment/ansible/roles/uriel-reload/tasks/main.yml
@@ -3,11 +3,13 @@
     template:
       src: "{{ playbook_dir }}/../conf/uriel.yml.j2"
       dest: /judgels/uriel/var/conf/uriel.yml
+      mode: '0644'
 
   - name: Generate uriel launcher config
     template:
       src: "{{ playbook_dir }}/../conf/uriel-launcher.yml.j2"
       dest: /judgels/uriel/var/conf/launcher-custom.yml
+      mode: '0644'
 
   - name: Restart uriel
     docker_container:


### PR DESCRIPTION
Ansible 2.9 now sets file permissions to `0600` by default (previously the default is `0666`). This causes permission errors when accessing config files.

See https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.9.html#change-to-default-file-permissions