### PR TITLE
Use utf8mb4_unicode_ci collation when creating DB

### DIFF
--- a/deployment/ansible/roles/mysql-install/tasks/main.yml
+++ b/deployment/ansible/roles/mysql-install/tasks/main.yml
@@ -56,6 +56,7 @@
       login_user: root
       login_password: "{{ db_root_password }}"
       name: "{{ item }}"
+      collation: utf8mb4_unicode_ci
       state: present
     with_items:
       - judgels_jophiel


### PR DESCRIPTION
Make clarifications, descriptions etc. support Unicode (previously, default MySQL collation is used)