### PR TITLE
Add filter unanswered clarification for supervisor

### DIFF
--- a/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/clarification/ContestClarificationService.java
+++ b/judgels-backends/uriel/uriel-api/src/main/java/judgels/uriel/api/contest/clarification/ContestClarificationService.java
@@ -32,6 +32,7 @@ public interface ContestClarificationService {
     ContestClarificationsResponse getClarifications(
             @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
             @PathParam("contestJid") String contestJid,
+            @QueryParam("status") Optional<String> status,
             @QueryParam("language") Optional<String> language,
             @QueryParam("page") Optional<Integer> page);
 

--- a/judgels-backends/uriel/uriel-app/src/integTest/java/judgels/uriel/api/contest/ContestServiceDumpIntegrationTests.java
+++ b/judgels-backends/uriel/uriel-app/src/integTest/java/judgels/uriel/api/contest/ContestServiceDumpIntegrationTests.java
@@ -529,7 +529,7 @@ public class ContestServiceDumpIntegrationTests extends AbstractServiceIntegrati
                         .build());
 
         assertThat(contestClarificationService.getClarifications(ADMIN_HEADER, "JIDCONTtest-ioi",
-                Optional.empty(), Optional.empty()).getData().getPage())
+                Optional.empty(), Optional.empty(), Optional.empty()).getData().getPage())
                 .hasSize(2)
                 .usingElementComparatorIgnoringFields("id")
                 .containsOnlyOnce(new ContestClarification.Builder()

--- a/judgels-backends/uriel/uriel-app/src/integTest/java/judgels/uriel/api/contest/clarification/ContestClarificationServiceIntegrationTests.java
+++ b/judgels-backends/uriel/uriel-app/src/integTest/java/judgels/uriel/api/contest/clarification/ContestClarificationServiceIntegrationTests.java
@@ -2,6 +2,7 @@ package judgels.uriel.api.contest.clarification;
 
 import static com.palantir.conjure.java.api.testing.Assertions.assertThatRemoteExceptionThrownBy;
 import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static judgels.uriel.api.mocks.MockJophiel.ADMIN_HEADER;
 import static judgels.uriel.api.mocks.MockJophiel.MANAGER_HEADER;
 import static judgels.uriel.api.mocks.MockJophiel.MANAGER_JID;
@@ -63,7 +64,7 @@ class ContestClarificationServiceIntegrationTests extends AbstractContestService
                 .build());
 
         ContestClarificationsResponse response = clarificationService
-                .getClarifications(USER_A_HEADER, contest.getJid(), empty(), empty());
+                .getClarifications(USER_A_HEADER, contest.getJid(), empty(), empty(), empty());
 
         List<ContestClarification> clarifications = response.getData().getPage();
         assertThat(clarifications.size()).isEqualTo(1);
@@ -86,7 +87,8 @@ class ContestClarificationServiceIntegrationTests extends AbstractContestService
 
         // as supervisor
 
-        response = clarificationService.getClarifications(SUPERVISOR_HEADER, contest.getJid(), empty(), empty());
+        response = clarificationService.getClarifications(SUPERVISOR_HEADER, contest.getJid(),
+                empty(), empty(), empty());
 
         clarifications = response.getData().getPage();
         assertThat(clarifications.size()).isEqualTo(2);
@@ -110,7 +112,7 @@ class ContestClarificationServiceIntegrationTests extends AbstractContestService
 
         // as manager
 
-        response = clarificationService.getClarifications(MANAGER_HEADER, contest.getJid(), empty(), empty());
+        response = clarificationService.getClarifications(MANAGER_HEADER, contest.getJid(), empty(), empty(), empty());
 
         clarifications = response.getData().getPage();
         assertThat(clarifications.size()).isEqualTo(2);
@@ -125,10 +127,20 @@ class ContestClarificationServiceIntegrationTests extends AbstractContestService
 
         clarificationService.answerClarification(MANAGER_HEADER, contest.getJid(), clarification.getJid(), answer);
 
+        response = clarificationService
+                .getClarifications(
+                        MANAGER_HEADER,
+                        contest.getJid(),
+                        of(ContestClarificationStatus.ASKED.name()),
+                        empty(),
+                        empty());
+
+        assertThat(response.getData().getPage().size()).isEqualTo(1);
+
         // as contestant
 
         clarifications = clarificationService
-                .getClarifications(USER_A_HEADER, contest.getJid(), empty(), empty()).getData().getPage();
+                .getClarifications(USER_A_HEADER, contest.getJid(), empty(), empty(), empty()).getData().getPage();
         clarification = clarifications.get(0);
 
         assertThat(clarification.getAnswer()).contains("Yes!");
@@ -139,7 +151,7 @@ class ContestClarificationServiceIntegrationTests extends AbstractContestService
         moduleService.enableModule(MANAGER_HEADER, contest.getJid(), ContestModuleType.REGISTRATION);
 
         assertThatRemoteExceptionThrownBy(
-                () -> clarificationService.getClarifications(USER_HEADER, contest.getJid(), empty(), empty()))
+                () -> clarificationService.getClarifications(USER_HEADER, contest.getJid(), empty(), empty(), empty()))
                 .isGeneratedFromErrorType(ErrorType.PERMISSION_DENIED);
 
         assertThatRemoteExceptionThrownBy(() -> clarificationService.createClarification(

--- a/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/contest/clarification/ContestClarificationResource.java
+++ b/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/contest/clarification/ContestClarificationResource.java
@@ -83,6 +83,7 @@ public class ContestClarificationResource implements ContestClarificationService
     public ContestClarificationsResponse getClarifications(
             AuthHeader authHeader,
             String contestJid,
+            Optional<String> status,
             Optional<String> language,
             Optional<Integer> page) {
 
@@ -92,7 +93,7 @@ public class ContestClarificationResource implements ContestClarificationService
 
         boolean canSupervise = clarificationRoleChecker.canSupervise(actorJid, contest);
         Page<ContestClarification> clarifications = canSupervise
-                ? clarificationStore.getClarifications(contestJid, page)
+                ? clarificationStore.getClarifications(contestJid, status, page)
                 : clarificationStore.getClarifications(contestJid, actorJid, page);
 
         List<String> problemJidsSortedByAlias;

--- a/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/contest/clarification/ContestClarificationStore.java
+++ b/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/contest/clarification/ContestClarificationStore.java
@@ -59,11 +59,24 @@ public class ContestClarificationStore {
                 p -> Lists.transform(p, ContestClarificationStore::fromModel));
     }
 
-    public Page<ContestClarification> getClarifications(String contestJid, Optional<Integer> page) {
+    public Page<ContestClarification> getClarifications(
+            String contestJid,
+            Optional<String> status,
+            Optional<Integer> page) {
         SelectionOptions.Builder options = new SelectionOptions.Builder().from(SelectionOptions.DEFAULT_PAGED);
         page.ifPresent(options::page);
 
-        return clarificationDao.selectPagedByContestJid(contestJid, options.build()).mapPage(
+        Page<ContestClarificationModel> contestClarificationModelPage;
+        if (status.isPresent()) {
+            contestClarificationModelPage = clarificationDao.selectPagedByContestJidAndStatus(
+                    contestJid,
+                    status.get(),
+                    options.build());
+        } else {
+            contestClarificationModelPage = clarificationDao.selectPagedByContestJid(contestJid, options.build());
+        }
+
+        return contestClarificationModelPage.mapPage(
                 p -> Lists.transform(p, ContestClarificationStore::fromModel));
     }
 

--- a/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/hibernate/ContestClarificationHibernateDao.java
+++ b/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/hibernate/ContestClarificationHibernateDao.java
@@ -44,6 +44,15 @@ public class ContestClarificationHibernateDao extends JudgelsHibernateDao<Contes
     }
 
     @Override
+    public Page<ContestClarificationModel> selectPagedByContestJidAndStatus(
+            String contestJid, String status, SelectionOptions options) {
+        return selectPaged(new FilterOptions.Builder<ContestClarificationModel>()
+                .putColumnsEq(ContestClarificationModel_.contestJid, contestJid)
+                .putColumnsEq(ContestClarificationModel_.status, status)
+                .build(), options);
+    }
+
+    @Override
     public Set<ContestClarificationModel> selectAllByContestJid(String contestJid, SelectionOptions options) {
         return ImmutableSet.copyOf(selectAll(new FilterOptions.Builder<ContestClarificationModel>()
                 .putColumnsEq(ContestClarificationModel_.contestJid, contestJid)

--- a/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/persistence/ContestClarificationDao.java
+++ b/judgels-backends/uriel/uriel-app/src/main/java/judgels/uriel/persistence/ContestClarificationDao.java
@@ -14,6 +14,11 @@ public interface ContestClarificationDao extends JudgelsDao<ContestClarification
 
     Page<ContestClarificationModel> selectPagedByContestJid(String contestJid, SelectionOptions options);
 
+    Page<ContestClarificationModel> selectPagedByContestJidAndStatus(
+            String contestJid,
+            String status,
+            SelectionOptions options);
+
     Set<ContestClarificationModel> selectAllByContestJid(String contestJid, SelectionOptions options);
 
     Optional<ContestClarificationModel> selectByContestJidAndClarificationJid(

--- a/judgels-frontends/raphael/src/components/ClarificationFilterWidget/ClarificationFilterForm.scss
+++ b/judgels-frontends/raphael/src/components/ClarificationFilterWidget/ClarificationFilterForm.scss
@@ -1,0 +1,26 @@
+.clarification-filter-form {
+  .form-status {
+    min-width: 250px;
+    button {
+      width: 200px;
+    }
+  }
+
+  .form-status {
+    float: right;
+    label {
+      float: left;
+      width: initial;
+      line-height: 30px;
+      margin-right: 5px;
+    }
+    .form-group-select {
+      float: left;
+      width: initial;
+    }
+  }
+
+  button {
+    float: right;
+  }
+}

--- a/judgels-frontends/raphael/src/components/ClarificationFilterWidget/ClarificationFilterForm.tsx
+++ b/judgels-frontends/raphael/src/components/ClarificationFilterWidget/ClarificationFilterForm.tsx
@@ -1,0 +1,42 @@
+import { Button, Intent } from '@blueprintjs/core';
+import * as React from 'react';
+import { Field, InjectedFormProps, reduxForm } from 'redux-form';
+
+import { Required } from '../../components/forms/validations';
+import { FormSelect2 } from '../../components/forms/FormSelect2/FormSelect2';
+
+import './ClarificationFilterForm.css';
+
+export interface ClarificationFilterFormData {
+  status: string;
+}
+
+export interface ClarificationFilterFormProps extends InjectedFormProps<ClarificationFilterFormData> {
+  statuses?: string[];
+  isLoading: boolean;
+}
+
+const ClarificationFilterForm = (props: ClarificationFilterFormProps) => {
+  const { statuses } = props;
+  const statusField: any = {
+    className: 'form-status',
+    name: 'status',
+    label: 'Status',
+    validate: [Required],
+    optionValues: statuses,
+    optionNamesMap: Object.assign({}, ...statuses.map(status => ({ [status]: status }))),
+  };
+
+  return (
+    <form onSubmit={props.handleSubmit} className="clarification-filter-form">
+      <Button type="submit" text="Filter" intent={Intent.PRIMARY} loading={props.isLoading} />
+      {<Field component={FormSelect2} {...statusField} />}
+    </form>
+  );
+};
+
+export default reduxForm<ClarificationFilterFormData>({
+  form: 'clarification-filter',
+  touchOnBlur: false,
+  enableReinitialize: true,
+})(ClarificationFilterForm);

--- a/judgels-frontends/raphael/src/components/ClarificationFilterWidget/ClarificationFilterWidget.tsx
+++ b/judgels-frontends/raphael/src/components/ClarificationFilterWidget/ClarificationFilterWidget.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+import ClarificationFilterForm, { ClarificationFilterFormData } from './ClarificationFilterForm';
+
+export interface ClarificationFilterWidgetProps {
+  statuses?: string[];
+  onFilter: (filter: any) => Promise<void>;
+  isLoading: boolean;
+
+  status?: string;
+}
+
+export class ClarificationFilterWidget extends React.Component<ClarificationFilterWidgetProps> {
+  render() {
+    const { statuses, isLoading, status } = this.props;
+    const formProps = {
+      statuses: ['-', ...statuses],
+      isLoading,
+      initialValues: {
+        status: status || '-',
+      },
+    };
+
+    return <ClarificationFilterForm onSubmit={this.onFilter} {...formProps} />;
+  }
+
+  private onFilter = async (data: ClarificationFilterFormData) => {
+    const status = data.status === '-' ? undefined : data.status;
+    return await this.props.onFilter({ status });
+  };
+}

--- a/judgels-frontends/raphael/src/modules/api/uriel/contestClarification.ts
+++ b/judgels-frontends/raphael/src/modules/api/uriel/contestClarification.ts
@@ -61,10 +61,11 @@ export const contestClarificationAPI = {
   getClarifications: (
     token: string,
     contestJid: string,
+    status?: string,
     language?: string,
     page?: number
   ): Promise<ContestClarificationsResponse> => {
-    const params = stringify({ language, page });
+    const params = stringify({ status, language, page });
     return get(`${baseURL(contestJid)}?${params}`, token);
   },
 

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.test.ts
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.test.ts
@@ -42,6 +42,7 @@ describe('contestClarificationActions', () => {
   });
 
   describe('getClarifications()', () => {
+    const status = undefined;
     const language = 'id';
     const page = 3;
     const responseBody = {
@@ -55,7 +56,9 @@ describe('contestClarificationActions', () => {
         .query({ language, page })
         .reply(200, responseBody);
 
-      const response = await store.dispatch(contestClarificationActions.getClarifications(contestJid, language, page));
+      const response = await store.dispatch(
+        contestClarificationActions.getClarifications(contestJid, status, language, page)
+      );
       expect(response).toEqual(responseBody);
     });
   });

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.ts
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.ts
@@ -17,10 +17,10 @@ export function createClarification(contestJid: string, data: ContestClarificati
   };
 }
 
-export function getClarifications(contestJid: string, language?: string, page?: number) {
+export function getClarifications(contestJid: string, status?: string, language?: string, page?: number) {
   return async (dispatch, getState) => {
     const token = selectToken(getState());
-    return await contestClarificationAPI.getClarifications(token, contestJid, language, page);
+    return await contestClarificationAPI.getClarifications(token, contestJid, status, language, page);
   };
 }
 


### PR DESCRIPTION
We add filter to help contest supervisor prioritize on
answering unanswered clarifications.

The change is tested locally.