### PR TITLE
Add optional JID column when batch upserting user

### DIFF
--- a/judgels-backends/jophiel/jophiel-app/src/integTest/java/judgels/jophiel/user/UserStoreIntegrationTests.java
+++ b/judgels-backends/jophiel/jophiel-app/src/integTest/java/judgels/jophiel/user/UserStoreIntegrationTests.java
@@ -77,8 +77,20 @@ class UserStoreIntegrationTests extends AbstractIntegrationTests {
 
         User budi = store.getUserByUsername("budi").get();
 
+        UserData foxtrotData = new UserData.Builder()
+                .username("foxtrot")
+                .password("pass")
+                .email("foxtrot@domain.com")
+                .build();
+        store.createUserWithJid("JIDUSERfoxtrot", foxtrotData);
+
+        User foxtrot = store.getUserByUsername("foxtrot").get();
+        assertThat(foxtrot.getJid()).isEqualTo("JIDUSERfoxtrot");
+        assertThat(foxtrot.getUsername()).isEqualTo("foxtrot");
+        assertThat(foxtrot.getEmail()).isEqualTo("foxtrot@domain.com");
+
         Page<User> users = store.getUsers(Optional.empty(), Optional.empty(), Optional.empty());
-        assertThat(users.getPage()).containsExactly(budi, nano, user);
+        assertThat(users.getPage()).containsExactly(budi, foxtrot, nano, user);
     }
 
     @Test

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/UserResource.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/UserResource.java
@@ -114,12 +114,22 @@ public class UserResource implements UserService {
                     .password(line[headerMap.get("password")])
                     .email(line[headerMap.get("email")])
                     .build();
-            Optional<User> maybeUser = userStore.getUserByUsername(username);
-            if (maybeUser.isPresent()) {
-                user = userStore.updateUser(maybeUser.get().getJid(), userData).get();
+
+            Optional<User> existingUser;
+            Optional<String> jid = getCsvValue(headerMap, line, "jid");
+            if (jid.isPresent()) {
+                existingUser = userStore.getUserByJid(jid.get());
+            } else {
+                existingUser = userStore.getUserByUsername(username);
+            }
+
+            if (existingUser.isPresent()) {
+                user = userStore.updateUser(existingUser.get().getJid(), userData).get();
                 updatedUsernames.add(username);
             } else {
-                user = userStore.createUser(userData);
+                user = jid.isPresent()
+                        ? userStore.createUserWithJid(jid.get(), userData)
+                        : userStore.createUser(userData);
                 createdUsernames.add(username);
             }
 

--- a/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/UserStore.java
+++ b/judgels-backends/jophiel/jophiel-app/src/main/java/judgels/jophiel/user/UserStore.java
@@ -39,6 +39,12 @@ public class UserStore {
         return fromModel(userDao.insert(model));
     }
 
+    public User createUserWithJid(String jid, UserData userData) {
+        UserModel model = new UserModel();
+        toModel(userData, model);
+        return fromModel(userDao.insertWithJid(jid, model));
+    }
+
     public List<User> createUsers(List<UserData> data) {
         List<UserModel> usersModel = Lists.transform(data, userData -> {
             UserModel model = new UserModel();

--- a/judgels-backends/judgels-commons/judgels-persistence-core/src/integTest/java/judgels/persistence/hibernate/JudgelsHibernateDaoIntegrationTests.java
+++ b/judgels-backends/judgels-commons/judgels-persistence-core/src/integTest/java/judgels/persistence/hibernate/JudgelsHibernateDaoIntegrationTests.java
@@ -66,6 +66,16 @@ class JudgelsHibernateDaoIntegrationTests {
         assertThat(model.column).isEqualTo("value3");
 
         assertThat(dao.selectByJid("JIDEXAMnotfound")).isEmpty();
+
+        model = new ExampleModel();
+        model.column = "value4";
+        jid = "JIDMANUALCatDog";
+        dao.insertWithJid(jid, model);
+
+        model = dao.selectByJid(jid).get();
+
+        assertThat(model.jid).isEqualTo(jid);
+        assertThat(model.column).isEqualTo("value4");
     }
 
     @Test

--- a/judgels-backends/judgels-commons/judgels-persistence-core/src/main/java/judgels/persistence/JudgelsDao.java
+++ b/judgels-backends/judgels-commons/judgels-persistence-core/src/main/java/judgels/persistence/JudgelsDao.java
@@ -11,6 +11,7 @@ import judgels.persistence.api.dump.JudgelsDump;
 public interface JudgelsDao<M extends JudgelsModel> extends Dao<M> {
     Optional<M> selectByJid(String jid);
     Map<String, M> selectByJids(Set<String> jids);
+    M insertWithJid(String jid, M model);
     M updateByJid(String jid, M model);
     boolean existsByJid(String jid);
 

--- a/judgels-backends/judgels-commons/judgels-persistence-core/src/main/java/judgels/persistence/hibernate/JudgelsHibernateDao.java
+++ b/judgels-backends/judgels-commons/judgels-persistence-core/src/main/java/judgels/persistence/hibernate/JudgelsHibernateDao.java
@@ -36,6 +36,12 @@ public abstract class JudgelsHibernateDao<M extends JudgelsModel> extends Hibern
     }
 
     @Override
+    public M insertWithJid(String jid, M model) {
+        model.jid = jid;
+        return super.insert(model);
+    }
+
+    @Override
     public Map<String, M> selectByJids(Set<String> jids) {
         if (jids.isEmpty()) {
             return ImmutableMap.of();


### PR DESCRIPTION
Allow the CSV to have jid column.
This column can be used to migrate user from other Judgels instances.

resolves #320 

Insert:
![image](https://user-images.githubusercontent.com/9874779/94982483-fc23b880-0564-11eb-956d-8b933e1ce582.png)

![image](https://user-images.githubusercontent.com/9874779/94982486-02b23000-0565-11eb-9d55-d2c36bcc5905.png)

Update:
![image](https://user-images.githubusercontent.com/9874779/94982498-1b224a80-0565-11eb-967a-77d55fa40ec7.png)

![image](https://user-images.githubusercontent.com/9874779/94982495-15c50000-0565-11eb-89a4-fd49160065a4.png)

