### PR TITLE
Add browser notification

### DIFF
--- a/judgels-frontends/raphael/src/components/Header/Header.jsx
+++ b/judgels-frontends/raphael/src/components/Header/Header.jsx
@@ -8,11 +8,12 @@ import UserWidget from '../UserWidget/UserWidget';
 import './Header.css';
 
 import logo from '../../assets/images/logo-header.png';
+import {askNotificationPermission} from '../../modules/notification/notification';
 
 class Header extends React.PureComponent {
   render() {
     const UW = this.props.userWidget;
-
+    askNotificationPermission();
     return (
       <Navbar className="header">
         <div className="header__wrapper">

--- a/judgels-frontends/raphael/src/components/Header/Header.jsx
+++ b/judgels-frontends/raphael/src/components/Header/Header.jsx
@@ -8,12 +8,12 @@ import UserWidget from '../UserWidget/UserWidget';
 import './Header.css';
 
 import logo from '../../assets/images/logo-header.png';
-import { askNotificationPermission } from '../../modules/notification/notification';
+import { askDesktopNotificationPermission } from '../../modules/notification/notification';
 
 class Header extends React.PureComponent {
   render() {
     const UW = this.props.userWidget;
-    askNotificationPermission();
+    askDesktopNotificationPermission();
     return (
       <Navbar className="header">
         <div className="header__wrapper">

--- a/judgels-frontends/raphael/src/components/Header/Header.jsx
+++ b/judgels-frontends/raphael/src/components/Header/Header.jsx
@@ -8,7 +8,7 @@ import UserWidget from '../UserWidget/UserWidget';
 import './Header.css';
 
 import logo from '../../assets/images/logo-header.png';
-import {askNotificationPermission} from '../../modules/notification/notification';
+import { askNotificationPermission } from '../../modules/notification/notification';
 
 class Header extends React.PureComponent {
   render() {

--- a/judgels-frontends/raphael/src/components/Header/Header.jsx
+++ b/judgels-frontends/raphael/src/components/Header/Header.jsx
@@ -4,16 +4,16 @@ import { Link } from 'react-router-dom';
 
 import { APP_CONFIG } from '../../conf';
 import UserWidget from '../UserWidget/UserWidget';
+import { askDesktopNotificationPermission } from '../../modules/notification/notification';
 
 import './Header.css';
 
 import logo from '../../assets/images/logo-header.png';
-import { askDesktopNotificationPermission } from '../../modules/notification/notification';
 
 class Header extends React.PureComponent {
   render() {
     const UW = this.props.userWidget;
-    askDesktopNotificationPermission();
+
     return (
       <Navbar className="header">
         <div className="header__wrapper">
@@ -32,6 +32,10 @@ class Header extends React.PureComponent {
         </div>
       </Navbar>
     );
+  }
+
+  componentDidMount() {
+    askDesktopNotificationPermission();
   }
 }
 

--- a/judgels-frontends/raphael/src/components/Header/Header.jsx
+++ b/judgels-frontends/raphael/src/components/Header/Header.jsx
@@ -11,6 +11,10 @@ import './Header.css';
 import logo from '../../assets/images/logo-header.png';
 
 class Header extends React.PureComponent {
+  componentDidMount() {
+    askDesktopNotificationPermission();
+  }
+
   render() {
     const UW = this.props.userWidget;
 
@@ -32,10 +36,6 @@ class Header extends React.PureComponent {
         </div>
       </Navbar>
     );
-  }
-
-  componentDidMount() {
-    askDesktopNotificationPermission();
   }
 }
 

--- a/judgels-frontends/raphael/src/modules/api/uriel/contestWeb.js
+++ b/judgels-frontends/raphael/src/modules/api/uriel/contestWeb.js
@@ -47,3 +47,5 @@ export const contestWebAPI = {
     return get(`${baseURL}/${contestJid}/config`, token);
   },
 };
+
+export const REFRESH_WEB_CONFIG_INTERVAL = 20000; // 20 seconds

--- a/judgels-frontends/raphael/src/modules/notification/notification.js
+++ b/judgels-frontends/raphael/src/modules/notification/notification.js
@@ -1,9 +1,9 @@
 import logo from '../../assets/images/logo-header.png';
 
-export function showNotification(title, message) {
-  new Notification(title, { body: message, icon: logo });
+export function showDesktopNotification(title, tag, message) {
+  new Notification(title, { body: message, icon: logo, tag: tag });
 }
 
-export function askNotificationPermission() {
+export function askDesktopNotificationPermission() {
   Notification.requestPermission(result => {});
 }

--- a/judgels-frontends/raphael/src/modules/notification/notification.js
+++ b/judgels-frontends/raphael/src/modules/notification/notification.js
@@ -1,7 +1,8 @@
 import logo from '../../assets/images/logo-header.png';
+import { APP_CONFIG } from '../../conf';
 
 export function showDesktopNotification(title, tag, message) {
-  new Notification(title, { body: `${APP_CONFIG.name}: message`, icon: logo, tag: tag });
+  new Notification(title, { body: `${APP_CONFIG.name}: ${message}`, icon: logo, tag: tag });
 }
 
 export function askDesktopNotificationPermission() {

--- a/judgels-frontends/raphael/src/modules/notification/notification.js
+++ b/judgels-frontends/raphael/src/modules/notification/notification.js
@@ -1,0 +1,10 @@
+
+import logo from '../../assets/images/logo-header.png';
+
+export function showNotification(title, message) {
+  new Notification(title, {body: message, icon: logo});
+}
+
+export function askNotificationPermission() {
+  Notification.requestPermission(result => {});
+}

--- a/judgels-frontends/raphael/src/modules/notification/notification.js
+++ b/judgels-frontends/raphael/src/modules/notification/notification.js
@@ -1,7 +1,7 @@
 import logo from '../../assets/images/logo-header.png';
 
 export function showDesktopNotification(title, tag, message) {
-  new Notification(title, { body: message, icon: logo, tag: tag });
+  new Notification(title, { body: `${APP_CONFIG.name}: message`, icon: logo, tag: tag });
 }
 
 export function askDesktopNotificationPermission() {

--- a/judgels-frontends/raphael/src/modules/notification/notification.js
+++ b/judgels-frontends/raphael/src/modules/notification/notification.js
@@ -1,8 +1,7 @@
-
 import logo from '../../assets/images/logo-header.png';
 
 export function showNotification(title, message) {
-  new Notification(title, {body: message, icon: logo});
+  new Notification(title, { body: message, icon: logo });
 }
 
 export function askNotificationPermission() {

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/SingleContestDataRoute.jsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/SingleContestDataRoute.jsx
@@ -9,6 +9,7 @@ import * as contestWebActions from './modules/contestWebActions';
 import * as breadcrumbsActions from '../../../../modules/breadcrumbs/breadcrumbsActions';
 
 class SingleContestDataRoute extends React.Component {
+  static GET_CONFIG_TIMEOUT = REFRESH_WEB_CONFIG_INTERVAL;
 
   currentTimeout;
 
@@ -20,7 +21,7 @@ class SingleContestDataRoute extends React.Component {
     if (contest && contest.slug === match.params.contestSlug) {
       this.currentTimeout = setTimeout(
         () => this.refreshWebConfig(contest.jid),
-        REFRESH_WEB_CONFIG_INTERVAL
+        SingleContestDataRoute.GET_CONFIG_TIMEOUT
       );
     }
 
@@ -31,7 +32,7 @@ class SingleContestDataRoute extends React.Component {
     if (!contest || contest.slug !== match.params.contestSlug) {
       this.currentTimeout = setTimeout(
         () => this.refreshWebConfig(newContest.jid),
-        REFRESH_WEB_CONFIG_INTERVAL
+        SingleContestDataRoute.GET_CONFIG_TIMEOUT
       );
     }
   }
@@ -54,7 +55,7 @@ class SingleContestDataRoute extends React.Component {
     await this.props.onGetContestWebConfig(contestJid);
     this.currentTimeout = setTimeout(
       () => this.refreshWebConfig(contestJid),
-      REFRESH_WEB_CONFIG_INTERVAL
+      SingleContestDataRoute.GET_CONFIG_TIMEOUT
     );
   };
 }

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/SingleContestDataRoute.jsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/SingleContestDataRoute.jsx
@@ -3,12 +3,12 @@ import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 
 import { selectContest } from '../modules/contestSelectors';
+import { REFRESH_WEB_CONFIG_INTERVAL } from '../../../../modules/api/uriel/contestWeb';
 import * as contestActions from '../modules/contestActions';
 import * as contestWebActions from './modules/contestWebActions';
 import * as breadcrumbsActions from '../../../../modules/breadcrumbs/breadcrumbsActions';
 
 class SingleContestDataRoute extends React.Component {
-  static GET_CONFIG_TIMEOUT = 20000;
 
   currentTimeout;
 
@@ -20,7 +20,7 @@ class SingleContestDataRoute extends React.Component {
     if (contest && contest.slug === match.params.contestSlug) {
       this.currentTimeout = setTimeout(
         () => this.refreshWebConfig(contest.jid),
-        SingleContestDataRoute.GET_CONFIG_TIMEOUT
+        REFRESH_WEB_CONFIG_INTERVAL
       );
     }
 
@@ -31,7 +31,7 @@ class SingleContestDataRoute extends React.Component {
     if (!contest || contest.slug !== match.params.contestSlug) {
       this.currentTimeout = setTimeout(
         () => this.refreshWebConfig(newContest.jid),
-        SingleContestDataRoute.GET_CONFIG_TIMEOUT
+        REFRESH_WEB_CONFIG_INTERVAL
       );
     }
   }
@@ -54,7 +54,7 @@ class SingleContestDataRoute extends React.Component {
     await this.props.onGetContestWebConfig(contestJid);
     this.currentTimeout = setTimeout(
       () => this.refreshWebConfig(contestJid),
-      SingleContestDataRoute.GET_CONFIG_TIMEOUT
+      REFRESH_WEB_CONFIG_INTERVAL
     );
   };
 }

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
@@ -14,7 +14,7 @@ export function alertNewAnnouncements(notificationTag) {
   return async () => {
     const message = 'You have new announcement(s).';
     toastActions.showAlertToast(message);
-    showDesktopNotification('TLX New Announcement(s)', notificationTag, message);
+    showDesktopNotification('New announcement(s)', notificationTag, message);
   };
 }
 

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
@@ -10,11 +10,11 @@ export function getAnnouncements(contestJid, page) {
   };
 }
 
-export function alertNewAnnouncements() {
+export function alertNewAnnouncements(notificationTag) {
   return async () => {
     const message = 'You have new announcement(s).';
     toastActions.showAlertToast(message);
-    showNotification('TLX New Announcement(s)', message);
+    showDesktopNotification('TLX New Announcement(s)', notificationTag, message);
   };
 }
 

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
@@ -1,6 +1,7 @@
 import { selectToken } from '../../../../../../modules/session/sessionSelectors';
 import { contestAnnouncementAPI } from '../../../../../../modules/api/uriel/contestAnnouncement';
 import * as toastActions from '../../../../../../modules/toast/toastActions';
+import {showNotification} from '../../../../../../modules/notification/notification';
 
 export function getAnnouncements(contestJid, page) {
   return async (dispatch, getState) => {
@@ -11,7 +12,9 @@ export function getAnnouncements(contestJid, page) {
 
 export function alertNewAnnouncements() {
   return async () => {
-    toastActions.showAlertToast('You have new announcement(s).');
+    const message = 'You have new announcement(s).';
+    toastActions.showAlertToast(message);
+    showNotification('TLX New Announcement(s)', message);
   };
 }
 

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
@@ -1,7 +1,7 @@
 import { selectToken } from '../../../../../../modules/session/sessionSelectors';
 import { contestAnnouncementAPI } from '../../../../../../modules/api/uriel/contestAnnouncement';
 import * as toastActions from '../../../../../../modules/toast/toastActions';
-import {showNotification} from '../../../../../../modules/notification/notification';
+import { showNotification } from '../../../../../../modules/notification/notification';
 
 export function getAnnouncements(contestJid, page) {
   return async (dispatch, getState) => {

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.js
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.js
@@ -40,13 +40,15 @@ export function answerClarification(contestJid, clarificationJid, answer) {
 
 export function alertNewClarifications(status, notificationTag) {
   return async () => {
-    let message;
+    let title, message;
     if (status === ContestClarificationStatus.Answered) {
+      title = 'New answered clarification(s)';
       message = 'You have new answered clarification(s).';
     } else {
+      title = 'New clarification(s)';
       message = 'You have new clarification(s).';
     }
     toastActions.showAlertToast(message);
-    showDesktopNotification('TLX Clarification', notificationTag, message);
+    showDesktopNotification(title, notificationTag, message);
   };
 }

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.js
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.js
@@ -5,6 +5,7 @@ import { BadRequestError } from '../../../../../../modules/api/error';
 import { ContestErrors } from '../../../../../../modules/api/uriel/contest';
 import { contestClarificationAPI } from '../../../../../../modules/api/uriel/contestClarification';
 import * as toastActions from '../../../../../../modules/toast/toastActions';
+import { showNotification } from '../../../../../../modules/notification/notification';
 
 export function createClarification(contestJid, data) {
   return async (dispatch, getState) => {
@@ -39,10 +40,13 @@ export function answerClarification(contestJid, clarificationJid, answer) {
 
 export function alertNewClarifications(status) {
   return async () => {
+    let message;
     if (status === ContestClarificationStatus.Answered) {
-      toastActions.showAlertToast('You have new answered clarification(s).');
+      message = 'You have new answered clarification(s).';
     } else {
-      toastActions.showAlertToast('You have new clarification(s).');
+      message = 'You have new clarification(s).';
     }
+    toastActions.showAlertToast(message);
+    showNotification('TLX Clarification', message);
   };
 }

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.js
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/clarifications/modules/contestClarificationActions.js
@@ -5,7 +5,7 @@ import { BadRequestError } from '../../../../../../modules/api/error';
 import { ContestErrors } from '../../../../../../modules/api/uriel/contest';
 import { contestClarificationAPI } from '../../../../../../modules/api/uriel/contestClarification';
 import * as toastActions from '../../../../../../modules/toast/toastActions';
-import { showNotification } from '../../../../../../modules/notification/notification';
+import { showDesktopNotification } from '../../../../../../modules/notification/notification';
 
 export function createClarification(contestJid, data) {
   return async (dispatch, getState) => {
@@ -38,7 +38,7 @@ export function answerClarification(contestJid, clarificationJid, answer) {
   };
 }
 
-export function alertNewClarifications(status) {
+export function alertNewClarifications(status, notificationTag) {
   return async () => {
     let message;
     if (status === ContestClarificationStatus.Answered) {
@@ -47,6 +47,6 @@ export function alertNewClarifications(status) {
       message = 'You have new clarification(s).';
     }
     toastActions.showAlertToast(message);
-    showNotification('TLX Clarification', message);
+    showDesktopNotification('TLX Clarification', notificationTag, message);
   };
 }

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestAnnouncementsWidget/ContestAnnouncementsWidget.jsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestAnnouncementsWidget/ContestAnnouncementsWidget.jsx
@@ -1,11 +1,12 @@
 import { Tag } from '@blueprintjs/core';
 import * as React from 'react';
 import { connect } from 'react-redux';
+
 import { selectContest } from '../../../modules/contestSelectors';
 import { selectContestWebConfig } from '../../../modules/contestWebConfigSelectors';
 
 import * as contestAnnouncementActions from '../../announcements/modules/contestAnnouncementActions';
-import SingleContestDataRoute from '../../SingleContestDataRoute';
+import { REFRESH_WEB_CONFIG_INTERVAL } from '../../../../../../modules/api/uriel/contestWeb';
 
 class ContestAnnouncementsWidget extends React.Component {
   render() {
@@ -18,7 +19,7 @@ class ContestAnnouncementsWidget extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.announcementCount > prevProps.announcementCount) {
       // TODO(lungsin): change the notification tag to be more proper, e.g. using announcement JID.
-      const timestamp = Math.floor(Date.now() / SingleContestDataRoute.GET_CONFIG_TIMEOUT); // Use timestamp for notification tag
+      const timestamp = Math.floor(Date.now() / REFRESH_WEB_CONFIG_INTERVAL); // Use timestamp for notification tag
       const notificationTag = `announcement_${this.props.contestSlug}_timestamp_${timestamp}`;
       this.props.onAlertNewAnnouncements(notificationTag);
     }

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestAnnouncementsWidget/ContestAnnouncementsWidget.jsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestAnnouncementsWidget/ContestAnnouncementsWidget.jsx
@@ -1,6 +1,7 @@
 import { Tag } from '@blueprintjs/core';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { selectContest } from '../../../modules/contestSelectors';
 
 import { selectContestWebConfig } from '../../../modules/contestWebConfigSelectors';
 import * as contestAnnouncementActions from '../../announcements/modules/contestAnnouncementActions';
@@ -15,12 +16,16 @@ class ContestAnnouncementsWidget extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.announcementCount > prevProps.announcementCount) {
-      this.props.onAlertNewAnnouncements();
+      // TODO(lungsin): change the notification tag to be more proper, e.g. using announcement JID.
+      const timestamp = Math.floor(Date.now() / 1000 / 60); // Use timestamp at nearest 60 seconds for notification tag
+      const notificationTag = `announcement_${this.props.contestSlug}_timestamp_${timestamp}`;
+      this.props.onAlertNewAnnouncements(notificationTag);
     }
   }
 }
 
 const mapStateToProps = state => ({
+  contestSlug: selectContest(state).slug,
   announcementCount: selectContestWebConfig(state).announcementCount,
 });
 const mapDispatchToProps = {

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestAnnouncementsWidget/ContestAnnouncementsWidget.jsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestAnnouncementsWidget/ContestAnnouncementsWidget.jsx
@@ -2,8 +2,8 @@ import { Tag } from '@blueprintjs/core';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { selectContest } from '../../../modules/contestSelectors';
-
 import { selectContestWebConfig } from '../../../modules/contestWebConfigSelectors';
+
 import * as contestAnnouncementActions from '../../announcements/modules/contestAnnouncementActions';
 import SingleContestDataRoute from '../../SingleContestDataRoute';
 

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestAnnouncementsWidget/ContestAnnouncementsWidget.jsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestAnnouncementsWidget/ContestAnnouncementsWidget.jsx
@@ -5,6 +5,7 @@ import { selectContest } from '../../../modules/contestSelectors';
 
 import { selectContestWebConfig } from '../../../modules/contestWebConfigSelectors';
 import * as contestAnnouncementActions from '../../announcements/modules/contestAnnouncementActions';
+import SingleContestDataRoute from '../../SingleContestDataRoute';
 
 class ContestAnnouncementsWidget extends React.Component {
   render() {
@@ -17,7 +18,7 @@ class ContestAnnouncementsWidget extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.announcementCount > prevProps.announcementCount) {
       // TODO(lungsin): change the notification tag to be more proper, e.g. using announcement JID.
-      const timestamp = Math.floor(Date.now() / 1000 / 60); // Use timestamp at nearest 60 seconds for notification tag
+      const timestamp = Math.floor(Date.now() / SingleContestDataRoute.GET_CONFIG_TIMEOUT); // Use timestamp for notification tag
       const notificationTag = `announcement_${this.props.contestSlug}_timestamp_${timestamp}`;
       this.props.onAlertNewAnnouncements(notificationTag);
     }

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestClarificationsWidget/ContestClarificationsWidget.jsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestClarificationsWidget/ContestClarificationsWidget.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 
 import { ContestClarificationStatus } from '../../../../../../modules/api/uriel/contestClarification';
+import { selectContest } from '../../../modules/contestSelectors';
 import { selectContestWebConfig } from '../../../modules/contestWebConfigSelectors';
 import * as contestClarificationActions from '../../clarifications/modules/contestClarificationActions';
 
@@ -21,12 +22,16 @@ class ContestClarificationsWidget extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.clarificationCount > prevProps.clarificationCount) {
-      this.props.onAlertNewClarifications(this.props.clarificationStatus);
+      // TODO(lungsin): change the notification tag to be more proper, e.g. using clarification JID.
+      const timestamp = Math.floor(Date.now() / 1000 / 60); // Use timestamp at nearest 60 seconds for notification tag
+      const notificationTag = `clarification_${this.props.contestSlug}_timestamp_${timestamp}`;
+      this.props.onAlertNewClarifications(this.props.clarificationStatus, notificationTag);
     }
   }
 }
 
 const mapStateToProps = state => ({
+  contestSlug: selectContest(state).slug,
   clarificationCount: selectContestWebConfig(state).clarificationCount,
   clarificationStatus: selectContestWebConfig(state).clarificationStatus,
 });

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestClarificationsWidget/ContestClarificationsWidget.jsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestClarificationsWidget/ContestClarificationsWidget.jsx
@@ -6,7 +6,7 @@ import { ContestClarificationStatus } from '../../../../../../modules/api/uriel/
 import { selectContest } from '../../../modules/contestSelectors';
 import { selectContestWebConfig } from '../../../modules/contestWebConfigSelectors';
 import * as contestClarificationActions from '../../clarifications/modules/contestClarificationActions';
-import SingleContestDataRoute from '../../SingleContestDataRoute';
+import { REFRESH_WEB_CONFIG_INTERVAL } from '../../../../../../modules/api/uriel/contestWeb';
 
 class ContestClarificationsWidget extends React.Component {
   render() {
@@ -24,7 +24,7 @@ class ContestClarificationsWidget extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.clarificationCount > prevProps.clarificationCount) {
       // TODO(lungsin): change the notification tag to be more proper, e.g. using clarification JID.
-      const timestamp = Math.floor(Date.now() / SingleContestDataRoute.GET_CONFIG_TIMEOUT); // Use timestamp for notification tag
+      const timestamp = Math.floor(Date.now() / REFRESH_WEB_CONFIG_INTERVAL); // Use timestamp for notification tag
       const notificationTag = `clarification_${this.props.contestSlug}_timestamp_${timestamp}`;
       this.props.onAlertNewClarifications(this.props.clarificationStatus, notificationTag);
     }

--- a/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestClarificationsWidget/ContestClarificationsWidget.jsx
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/components/ContestClarificationsWidget/ContestClarificationsWidget.jsx
@@ -6,6 +6,7 @@ import { ContestClarificationStatus } from '../../../../../../modules/api/uriel/
 import { selectContest } from '../../../modules/contestSelectors';
 import { selectContestWebConfig } from '../../../modules/contestWebConfigSelectors';
 import * as contestClarificationActions from '../../clarifications/modules/contestClarificationActions';
+import SingleContestDataRoute from '../../SingleContestDataRoute';
 
 class ContestClarificationsWidget extends React.Component {
   render() {
@@ -23,7 +24,7 @@ class ContestClarificationsWidget extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.clarificationCount > prevProps.clarificationCount) {
       // TODO(lungsin): change the notification tag to be more proper, e.g. using clarification JID.
-      const timestamp = Math.floor(Date.now() / 1000 / 60); // Use timestamp at nearest 60 seconds for notification tag
+      const timestamp = Math.floor(Date.now() / SingleContestDataRoute.GET_CONFIG_TIMEOUT); // Use timestamp for notification tag
       const notificationTag = `clarification_${this.props.contestSlug}_timestamp_${timestamp}`;
       this.props.onAlertNewClarifications(this.props.clarificationStatus, notificationTag);
     }


### PR DESCRIPTION
Implements #292

- When an announcement or clarification is made, a browser notification appears in addition to an alert toast. This is tested on Chrome and Safari.

![image](https://user-images.githubusercontent.com/31788267/101354170-ae625e00-38cf-11eb-9610-e279bb0e73f8.png)
![image](https://user-images.githubusercontent.com/31788267/101354297-dea9fc80-38cf-11eb-8113-227631b3ed5a.png)

Notification Flow: 
1. Upon opening TLX, notification permission is asked to the user.
2. If permission is given, whenever an announcement/clarification is made, a browser notification will appear. 

Side effect and known issue:
1. ~If the user opens multiple TLX tabs, he/she will receive multiple notifications (not necessarily simultaneous)~. Multiple tabs announcement is resolved by using notification tag, a timestamp rounding down to the nearest minute is used.
2. For some reason, the notification doesn't have API for sound (nor does it produce any sound during testing). A workaround by using HTML5 Audio was tried but the sound won't be produced until the user interacts with the webpage.
