### PR TITLE
Add debug option in sandalphon

### DIFF
--- a/judgels-backends/sandalphon/gradle/play.gradle
+++ b/judgels-backends/sandalphon/gradle/play.gradle
@@ -19,4 +19,8 @@ play {
         javaVersion = JavaVersion.VERSION_1_8
     }
     injectedRoutesGenerator = true
+    if (System.getProperty('debug', 'false') == 'true') {
+        def runPlayTask = tasks.findByName('runPlay')
+        runPlayTask.forkOptions.jvmArgs = ['-Xdebug', '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4002']
+    }
 }


### PR DESCRIPTION
With this, we can debug sandalphon by executing `runPlay -Ddebug=true` and attaching a debugger to port 4002.