### PR TITLE
Fix Typo when producing Announcement Desktop Notification

### DIFF
--- a/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
+++ b/judgels-frontends/raphael/src/routes/contests/contests/single/announcements/modules/contestAnnouncementActions.js
@@ -1,7 +1,7 @@
 import { selectToken } from '../../../../../../modules/session/sessionSelectors';
 import { contestAnnouncementAPI } from '../../../../../../modules/api/uriel/contestAnnouncement';
 import * as toastActions from '../../../../../../modules/toast/toastActions';
-import { showNotification } from '../../../../../../modules/notification/notification';
+import { showDesktopNotification } from '../../../../../../modules/notification/notification';
 
 export function getAnnouncements(contestJid, page) {
   return async (dispatch, getState) => {


### PR DESCRIPTION
Fix #370 

Reproduced bug: 
![image](https://user-images.githubusercontent.com/31788267/107883346-80ca0e80-6f29-11eb-979e-ccc28f2b9739.png)

After Fix: 
![image](https://user-images.githubusercontent.com/31788267/107883395-b838bb00-6f29-11eb-91cf-d075d2905f64.png)
