### PR TITLE
refactor(server): decouple Dropwizard resources from JAX-RS contract interfaces

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/archive/ArchiveResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/archive/ArchiveResource.java
@@ -1,38 +1,40 @@
 package judgels.jerahmeel.archive;
 
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static judgels.service.ServiceUtils.checkAllowed;
 import static judgels.service.ServiceUtils.checkFound;
 
 import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import judgels.jerahmeel.api.archive.Archive;
 import judgels.jerahmeel.api.archive.ArchiveCreateData;
-import judgels.jerahmeel.api.archive.ArchiveService;
 import judgels.jerahmeel.api.archive.ArchiveUpdateData;
 import judgels.jerahmeel.api.archive.ArchivesResponse;
 import judgels.jerahmeel.role.RoleChecker;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 
-public class ArchiveResource implements ArchiveService {
-    private final ActorChecker actorChecker;
-    private final RoleChecker roleChecker;
-    private final ArchiveStore archiveStore;
+@Path("/api/v2/archives")
+public class ArchiveResource {
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected RoleChecker roleChecker;
+    @Inject protected ArchiveStore archiveStore;
 
-    @Inject
-    public ArchiveResource(
-            ActorChecker actorChecker,
-            RoleChecker roleChecker,
-            ArchiveStore archiveStore) {
-        this.actorChecker = actorChecker;
-        this.roleChecker = roleChecker;
-        this.archiveStore = archiveStore;
-    }
+    @Inject public ArchiveResource() {}
 
-    @Override
+    @GET
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public ArchivesResponse getArchives(Optional<AuthHeader> authHeader) {
+    public ArchivesResponse getArchives(@HeaderParam(AUTHORIZATION) Optional<AuthHeader> authHeader) {
         actorChecker.check(authHeader);
 
         return new ArchivesResponse.Builder()
@@ -40,18 +42,30 @@ public class ArchiveResource implements ArchiveService {
                 .build();
     }
 
-    @Override
+    @POST
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     @UnitOfWork
-    public Archive createArchive(AuthHeader authHeader, ArchiveCreateData data) {
+    public Archive createArchive(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            ArchiveCreateData data) {
+
         String actorJid = actorChecker.check(authHeader);
         checkAllowed(roleChecker.isAdmin(actorJid));
 
         return archiveStore.createArchive(data);
     }
 
-    @Override
+    @POST
+    @Path("/{archiveJid}")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     @UnitOfWork
-    public Archive updateArchive(AuthHeader authHeader, String archiveJid, ArchiveUpdateData data) {
+    public Archive updateArchive(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("archiveJid") String archiveJid,
+            ArchiveUpdateData data) {
+
         String actorJid = actorChecker.check(authHeader);
         checkFound(archiveStore.getArchiveByJid(archiveJid));
         checkAllowed(roleChecker.isAdmin(actorJid));

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/curriculum/CurriculumResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/curriculum/CurriculumResource.java
@@ -1,19 +1,22 @@
 package judgels.jerahmeel.curriculum;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
 import io.dropwizard.hibernate.UnitOfWork;
 import javax.inject.Inject;
-import judgels.jerahmeel.api.curriculum.CurriculumService;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import judgels.jerahmeel.api.curriculum.CurriculumsResponse;
 
-public class CurriculumResource implements CurriculumService {
-    private final CurriculumStore curriculumStore;
+@Path("/api/v2/curriculums")
+public class CurriculumResource {
+    @Inject protected CurriculumStore curriculumStore;
 
-    @Inject
-    public CurriculumResource(CurriculumStore curriculumStore) {
-        this.curriculumStore = curriculumStore;
-    }
+    @Inject public CurriculumResource() {}
 
-    @Override
+    @GET
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
     public CurriculumsResponse getCurriculums() {
         return new CurriculumsResponse.Builder()

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/problem/ProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/problem/ProblemResource.java
@@ -1,11 +1,18 @@
 package judgels.jerahmeel.problem;
 
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
 import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
-import judgels.jerahmeel.api.problem.ProblemService;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import judgels.jerahmeel.api.problem.ProblemSetProblemInfo;
 import judgels.jerahmeel.api.problem.ProblemsResponse;
 import judgels.jerahmeel.difficulty.ProblemDifficultyStore;
@@ -15,36 +22,25 @@ import judgels.sandalphon.problem.ProblemClient;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 
-public class ProblemResource implements ProblemService {
+@Path("/api/v2/problems")
+public class ProblemResource {
     private static final int PAGE_SIZE = 20;
 
-    private final ActorChecker actorChecker;
-    private final ProblemStore problemStore;
-    private final StatsStore statsStore;
-    private final ProblemDifficultyStore difficultyStore;
-    private final ProblemClient problemClient;
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected ProblemStore problemStore;
+    @Inject protected StatsStore statsStore;
+    @Inject protected ProblemDifficultyStore difficultyStore;
+    @Inject protected ProblemClient problemClient;
 
-    @Inject
-    public ProblemResource(
-            ActorChecker actorChecker,
-            ProblemStore problemStore,
-            StatsStore statsStore,
-            ProblemDifficultyStore difficultyStore,
-            ProblemClient problemClient) {
+    @Inject public ProblemResource() {}
 
-        this.actorChecker = actorChecker;
-        this.problemStore = problemStore;
-        this.statsStore = statsStore;
-        this.difficultyStore = difficultyStore;
-        this.problemClient = problemClient;
-    }
-
-    @Override
+    @GET
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
     public ProblemsResponse getProblems(
-            Optional<AuthHeader> authHeader,
-            Set<String> tags,
-            Optional<Integer> pageNumber) {
+            @HeaderParam(AUTHORIZATION) Optional<AuthHeader> authHeader,
+            @QueryParam("tags") Set<String> tags,
+            @QueryParam("page") Optional<Integer> pageNumber) {
 
         String actorJid = actorChecker.check(authHeader);
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/problem/ProblemTagResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/problem/ProblemTagResource.java
@@ -1,24 +1,27 @@
 package judgels.jerahmeel.problem;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
 import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import judgels.jerahmeel.api.problem.ProblemTagCategory;
 import judgels.jerahmeel.api.problem.ProblemTagOption;
-import judgels.jerahmeel.api.problem.ProblemTagService;
 import judgels.jerahmeel.api.problem.ProblemTagsResponse;
 import judgels.sandalphon.problem.base.tag.ProblemTagStore;
 
-public class ProblemTagResource implements ProblemTagService {
-    private final ProblemTagStore tagStore;
+@Path("/api/v2/problems/tags")
+public class ProblemTagResource {
+    @Inject protected ProblemTagStore tagStore;
 
-    @Inject
-    public ProblemTagResource(ProblemTagStore tagStore) {
-        this.tagStore = tagStore;
-    }
+    @Inject public ProblemTagResource() {}
 
-    @Override
+    @GET
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
     public ProblemTagsResponse getProblemTags() {
         Map<String, Integer> tagCounts = tagStore.getPublicTagCounts();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/info/UserInfoResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/info/UserInfoResource.java
@@ -1,40 +1,42 @@
 package judgels.jophiel.user.info;
 
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static judgels.service.ServiceUtils.checkAllowed;
 import static judgels.service.ServiceUtils.checkFound;
 
 import io.dropwizard.hibernate.UnitOfWork;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import judgels.jophiel.api.user.User;
 import judgels.jophiel.api.user.info.UserInfo;
-import judgels.jophiel.api.user.info.UserInfoService;
 import judgels.jophiel.user.UserRoleChecker;
 import judgels.jophiel.user.UserStore;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 
-public class UserInfoResource implements UserInfoService {
-    private final ActorChecker actorChecker;
-    private final UserRoleChecker roleChecker;
-    private final UserStore userStore;
-    private final UserInfoStore infoStore;
+@Path("/api/v2/users/{userJid}/info")
+public class UserInfoResource {
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected UserRoleChecker roleChecker;
+    @Inject protected UserStore userStore;
+    @Inject protected UserInfoStore infoStore;
 
-    @Inject
-    public UserInfoResource(
-            ActorChecker actorChecker,
-            UserRoleChecker roleChecker,
-            UserStore userStore,
-            UserInfoStore infoStore) {
+    @Inject public UserInfoResource() {}
 
-        this.actorChecker = actorChecker;
-        this.roleChecker = roleChecker;
-        this.userStore = userStore;
-        this.infoStore = infoStore;
-    }
-
-    @Override
+    @GET
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public UserInfo getInfo(AuthHeader authHeader, String userJid) {
+    public UserInfo getInfo(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("userJid") String userJid) {
+
         String actorJid = actorChecker.check(authHeader);
         checkAllowed(roleChecker.canManage(actorJid, userJid));
 
@@ -42,9 +44,15 @@ public class UserInfoResource implements UserInfoService {
         return infoStore.getInfo(user.getJid());
     }
 
-    @Override
+    @PUT
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     @UnitOfWork
-    public UserInfo updateInfo(AuthHeader authHeader, String userJid, UserInfo userInfo) {
+    public UserInfo updateInfo(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("userJid") String userJid,
+            UserInfo userInfo) {
+
         String actorJid = actorChecker.check(authHeader);
         checkAllowed(roleChecker.canManage(actorJid, userJid));
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/me/MyUserResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/me/MyUserResource.java
@@ -1,49 +1,60 @@
 package judgels.jophiel.user.me;
 
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static judgels.service.ServiceUtils.checkFound;
 
 import io.dropwizard.hibernate.UnitOfWork;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import judgels.jophiel.api.role.UserRole;
 import judgels.jophiel.api.user.User;
-import judgels.jophiel.api.user.me.MyUserService;
 import judgels.jophiel.api.user.me.PasswordUpdateData;
 import judgels.jophiel.role.UserRoleStore;
 import judgels.jophiel.user.UserStore;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 
-public class MyUserResource implements MyUserService {
-    private final ActorChecker actorChecker;
-    private final UserRoleStore roleStore;
-    private final UserStore userStore;
+@Path("/api/v2/users/me")
+public class MyUserResource {
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected UserRoleStore roleStore;
+    @Inject protected UserStore userStore;
 
-    @Inject
-    public MyUserResource(ActorChecker actorChecker, UserRoleStore roleStore, UserStore userStore) {
-        this.actorChecker = actorChecker;
-        this.roleStore = roleStore;
-        this.userStore = userStore;
-    }
+    @Inject public MyUserResource() {}
 
-    @Override
+    @GET
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public User getMyself(AuthHeader authHeader) {
+    public User getMyself(@HeaderParam(AUTHORIZATION) AuthHeader authHeader) {
         String actorJid = actorChecker.check(authHeader);
         return checkFound(userStore.getUserByJid(actorJid));
     }
 
-    @Override
+    @POST
+    @Path("/password")
+    @Consumes(APPLICATION_JSON)
     @UnitOfWork
-    public void updateMyPassword(AuthHeader authHeader, PasswordUpdateData data) {
+    public void updateMyPassword(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            PasswordUpdateData data) {
+
         String actorJid = actorChecker.check(authHeader);
 
         userStore.validateUserPassword(actorJid, data.getOldPassword());
         userStore.updateUserPassword(actorJid, data.getNewPassword());
     }
 
-    @Override
+    @GET
+    @Path("/role")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public UserRole getMyRole(AuthHeader authHeader) {
+    public UserRole getMyRole(@HeaderParam(AUTHORIZATION) AuthHeader authHeader) {
         String actorJid = actorChecker.check(authHeader);
         return roleStore.getRole(actorJid);
     }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/rating/UserRatingResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/rating/UserRatingResource.java
@@ -1,53 +1,59 @@
 package judgels.jophiel.user.rating;
 
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static judgels.service.ServiceUtils.checkAllowed;
 
 import io.dropwizard.hibernate.UnitOfWork;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import judgels.jophiel.api.user.rating.RatingEvent;
 import judgels.jophiel.api.user.rating.UserRatingEvent;
-import judgels.jophiel.api.user.rating.UserRatingService;
 import judgels.jophiel.api.user.rating.UserRatingUpdateData;
 import judgels.jophiel.user.UserRoleChecker;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 
-public class UserRatingResource implements UserRatingService {
-    private final ActorChecker actorChecker;
-    private final UserRoleChecker roleChecker;
-    private final UserRatingStore ratingStore;
+@Path("/api/v2/user-rating")
+public class UserRatingResource {
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected UserRoleChecker roleChecker;
+    @Inject protected UserRatingStore ratingStore;
 
-    @Inject
-    public UserRatingResource(
-            ActorChecker actorChecker,
-            UserRoleChecker roleChecker,
-            UserRatingStore ratingStore) {
+    @Inject public UserRatingResource() {}
 
-        this.actorChecker = actorChecker;
-        this.roleChecker = roleChecker;
-        this.ratingStore = ratingStore;
-    }
-
-    @Override
+    @POST
+    @Consumes(APPLICATION_JSON)
     @UnitOfWork
-    public void updateRatings(AuthHeader authHeader, UserRatingUpdateData data) {
+    public void updateRatings(@HeaderParam(AUTHORIZATION) AuthHeader authHeader, UserRatingUpdateData data) {
         String actorJid = actorChecker.check(authHeader);
         checkAllowed(roleChecker.canAdminister(actorJid));
 
         ratingStore.updateRatings(data.getTime(), data.getEventJid(), data.getRatingsMap());
     }
 
-    @Override
+    @GET
+    @Path("/events/latest")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
     public Optional<RatingEvent> getLatestRatingEvent() {
         return ratingStore.getLatestRatingEvent();
     }
 
-    @Override
+    @GET
+    @Path("/history")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public List<UserRatingEvent> getRatingHistory(String userJid) {
+    public List<UserRatingEvent> getRatingHistory(@QueryParam("userJid") String userJid) {
         return ratingStore.getUserRatingEvents(userJid);
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/registration/web/UserRegistrationWebResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/registration/web/UserRegistrationWebResource.java
@@ -9,12 +9,9 @@ import javax.ws.rs.Produces;
 
 @Path("/api/v2/users/registration/web")
 public class UserRegistrationWebResource {
-    private final UserRegistrationWebConfig config;
+    @Inject protected UserRegistrationWebConfig config;
 
-    @Inject
-    public UserRegistrationWebResource(UserRegistrationWebConfig config) {
-        this.config = config;
-    }
+    @Inject public UserRegistrationWebResource() {}
 
     @GET
     @Path("/config")

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/search/UserSearchResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/search/UserSearchResource.java
@@ -1,33 +1,45 @@
 package judgels.jophiel.user.search;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
 import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
-import judgels.jophiel.api.user.search.UserSearchService;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import judgels.jophiel.user.UserStore;
 
-public class UserSearchResource implements UserSearchService {
-    private final UserStore userStore;
+@Path("/api/v2/user-search")
+public class UserSearchResource {
+    @Inject protected UserStore userStore;
 
-    @Inject
-    public UserSearchResource(UserStore userStore) {
-        this.userStore = userStore;
-    }
+    @Inject public UserSearchResource() {}
 
-    @Override
+    @GET
+    @Path("/username-exists/{username}")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public boolean usernameExists(String username) {
+    public boolean usernameExists(@PathParam("username") String username) {
         return userStore.getUserByUsername(username).isPresent();
     }
 
-    @Override
+    @GET
+    @Path("/email-exists/{email}")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public boolean emailExists(String email) {
+    public boolean emailExists(@PathParam("email") String email) {
         return userStore.getUserByEmail(email).isPresent();
     }
 
-    @Override
+    @POST
+    @Path("/username-to-jid")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
     public Map<String, String> translateUsernamesToJids(Set<String> usernames) {
         return userStore.translateUsernamesToJids(usernames);

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/web/UserWebResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/web/UserWebResource.java
@@ -1,38 +1,37 @@
 package judgels.jophiel.user.web;
 
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
 import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import judgels.jophiel.api.role.JophielRole;
 import judgels.jophiel.api.role.UserRole;
 import judgels.jophiel.api.user.web.UserWebConfig;
-import judgels.jophiel.api.user.web.UserWebService;
 import judgels.jophiel.profile.ProfileResource;
 import judgels.jophiel.user.me.MyUserResource;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 
-public class UserWebResource implements UserWebService {
-    private final ActorChecker actorChecker;
-    private final MyUserResource myResource;
-    private final ProfileResource profileResource;
-    private final WebConfiguration webConfig;
+@Path("/api/v2/user-web")
+public class UserWebResource {
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected MyUserResource myResource;
+    @Inject protected ProfileResource profileResource;
+    @Inject protected WebConfiguration webConfig;
 
-    @Inject
-    public UserWebResource(
-            ActorChecker actorChecker,
-            MyUserResource myResource,
-            ProfileResource profileResource,
-            WebConfiguration webConfig) {
-        this.actorChecker = actorChecker;
-        this.myResource = myResource;
-        this.profileResource = profileResource;
-        this.webConfig = webConfig;
-    }
+    @Inject public UserWebResource() {}
 
-    @Override
+    @GET
+    @Path("/config")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public UserWebConfig getWebConfig(Optional<AuthHeader> authHeader) {
+    public UserWebConfig getWebConfig(@HeaderParam(AUTHORIZATION) Optional<AuthHeader> authHeader) {
         UserWebConfig.Builder config = new UserWebConfig.Builder()
                 .announcements(webConfig.getAnnouncements());
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/michael/problem/editorial/ProblemEditorialResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/michael/problem/editorial/ProblemEditorialResource.java
@@ -42,7 +42,6 @@ public class ProblemEditorialResource extends BaseProblemResource {
     @Inject public ProblemEditorialResource() {}
 
     @GET
-    @Path("")
     @UnitOfWork(readOnly = true)
     public View viewEditorial(@Context HttpServletRequest req, @PathParam("problemId") int problemId) {
         Actor actor = actorChecker.check(req);
@@ -67,7 +66,6 @@ public class ProblemEditorialResource extends BaseProblemResource {
     }
 
     @POST
-    @Path("")
     @UnitOfWork
     public Response createEditorial(
             @Context HttpServletRequest req,

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/editorial/ContestEditorialResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/editorial/ContestEditorialResource.java
@@ -1,5 +1,6 @@
 package judgels.uriel.contest.editorial;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static judgels.service.ServiceUtils.checkAllowed;
 import static judgels.service.ServiceUtils.checkFound;
 
@@ -12,6 +13,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.UriInfo;
 import judgels.jophiel.api.profile.Profile;
 import judgels.jophiel.user.UserClient;
@@ -21,7 +28,6 @@ import judgels.sandalphon.api.problem.ProblemMetadata;
 import judgels.sandalphon.problem.ProblemClient;
 import judgels.uriel.api.contest.Contest;
 import judgels.uriel.api.contest.editorial.ContestEditorialResponse;
-import judgels.uriel.api.contest.editorial.ContestEditorialService;
 import judgels.uriel.api.contest.module.EditorialModuleConfig;
 import judgels.uriel.api.contest.problem.ContestProblem;
 import judgels.uriel.contest.ContestStore;
@@ -29,35 +35,26 @@ import judgels.uriel.contest.log.ContestLogger;
 import judgels.uriel.contest.module.ContestModuleStore;
 import judgels.uriel.contest.problem.ContestProblemStore;
 
-public class ContestEditorialResource implements ContestEditorialService {
-    private final ContestLogger contestLogger;
-    private final ContestEditorialRoleChecker roleChecker;
-    private final ContestStore contestStore;
-    private final ContestModuleStore contestModuleStore;
-    private final ContestProblemStore problemStore;
-    private final UserClient userClient;
-    private final ProblemClient problemClient;
+@Path("/api/v2/contests/{contestJid}/editorial")
+public class ContestEditorialResource {
+    @Inject protected ContestLogger contestLogger;
+    @Inject protected ContestEditorialRoleChecker roleChecker;
+    @Inject protected ContestStore contestStore;
+    @Inject protected ContestModuleStore contestModuleStore;
+    @Inject protected ContestProblemStore problemStore;
+    @Inject protected UserClient userClient;
+    @Inject protected ProblemClient problemClient;
 
-    @Inject
-    public ContestEditorialResource(
-            ContestLogger contestLogger,
-            ContestEditorialRoleChecker roleChecker,
-            ContestStore contestStore,
-            ContestModuleStore contestModuleStore,
-            ContestProblemStore problemStore,
-            UserClient userClient, ProblemClient problemClient) {
-        this.contestLogger = contestLogger;
-        this.roleChecker = roleChecker;
-        this.contestStore = contestStore;
-        this.contestModuleStore = contestModuleStore;
-        this.problemStore = problemStore;
-        this.userClient = userClient;
-        this.problemClient = problemClient;
-    }
+    @Inject public ContestEditorialResource() {}
 
-    @Override
+    @GET
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public ContestEditorialResponse getEditorial(UriInfo uriInfo, String contestJid, Optional<String> language) {
+    public ContestEditorialResponse getEditorial(
+            @Context UriInfo uriInfo,
+            @PathParam("contestJid") String contestJid,
+            @QueryParam("language") Optional<String> language) {
+
         Contest contest = checkFound(contestStore.getContestByJid(contestJid));
         checkAllowed(roleChecker.canView(contest));
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/history/ContestHistoryResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/history/ContestHistoryResource.java
@@ -1,5 +1,6 @@
 package judgels.uriel.contest.history;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static judgels.service.ServiceUtils.checkFound;
 
 import io.dropwizard.hibernate.UnitOfWork;
@@ -8,6 +9,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import judgels.jophiel.api.user.rating.UserRating;
 import judgels.jophiel.api.user.rating.UserRatingEvent;
 import judgels.jophiel.user.UserClient;
@@ -15,29 +20,22 @@ import judgels.uriel.api.contest.Contest;
 import judgels.uriel.api.contest.ContestInfo;
 import judgels.uriel.api.contest.history.ContestHistoryEvent;
 import judgels.uriel.api.contest.history.ContestHistoryResponse;
-import judgels.uriel.api.contest.history.ContestHistoryService;
 import judgels.uriel.contest.ContestStore;
 import judgels.uriel.contest.contestant.ContestContestantStore;
 
-public class ContestHistoryResource implements ContestHistoryService {
-    private final ContestStore contestStore;
-    private final ContestContestantStore contestantStore;
-    private final UserClient userClient;
+@Path("/api/v2/contest-history")
+public class ContestHistoryResource {
+    @Inject protected ContestStore contestStore;
+    @Inject protected ContestContestantStore contestantStore;
+    @Inject protected UserClient userClient;
 
-    @Inject
-    public ContestHistoryResource(
-            ContestStore contestStore,
-            ContestContestantStore contestantStore,
-            UserClient userClient) {
+    @Inject public ContestHistoryResource() {}
 
-        this.contestStore = contestStore;
-        this.contestantStore = contestantStore;
-        this.userClient = userClient;
-    }
-
-    @Override
+    @GET
+    @Path("/public")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public ContestHistoryResponse getPublicHistory(String username) {
+    public ContestHistoryResponse getPublicHistory(@QueryParam("username") String username) {
         String userJid = checkFound(userClient.translateUsernameToJid(username));
 
         List<Contest> contests = contestStore.getPubliclyParticipatedContests(userJid);

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/log/ContestLogResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/log/ContestLogResource.java
@@ -1,5 +1,7 @@
 package judgels.uriel.contest.log;
 
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static judgels.service.ServiceUtils.checkAllowed;
 import static judgels.service.ServiceUtils.checkFound;
 
@@ -11,6 +13,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import judgels.jophiel.api.profile.Profile;
 import judgels.jophiel.user.UserClient;
 import judgels.persistence.api.Page;
@@ -19,7 +27,6 @@ import judgels.service.api.actor.AuthHeader;
 import judgels.uriel.api.contest.Contest;
 import judgels.uriel.api.contest.log.ContestLog;
 import judgels.uriel.api.contest.log.ContestLogConfig;
-import judgels.uriel.api.contest.log.ContestLogService;
 import judgels.uriel.api.contest.log.ContestLogsResponse;
 import judgels.uriel.api.contest.problem.ContestProblem;
 import judgels.uriel.contest.ContestRoleChecker;
@@ -28,47 +35,30 @@ import judgels.uriel.contest.contestant.ContestContestantStore;
 import judgels.uriel.contest.problem.ContestProblemStore;
 import judgels.uriel.contest.supervisor.ContestSupervisorStore;
 
-public class ContestLogResource implements ContestLogService {
+@Path("/api/v2/contests/{contestJid}/logs")
+public class ContestLogResource {
     private static final int PAGE_SIZE = 100;
 
-    private final ActorChecker actorChecker;
-    private final ContestRoleChecker contestRoleChecker;
-    private final ContestStore contestStore;
-    private final ContestLogStore logStore;
-    private final ContestContestantStore contestantStore;
-    private final ContestSupervisorStore supervisorStore;
-    private final ContestProblemStore problemStore;
-    private final UserClient userClient;
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected ContestRoleChecker contestRoleChecker;
+    @Inject protected ContestStore contestStore;
+    @Inject protected ContestLogStore logStore;
+    @Inject protected ContestContestantStore contestantStore;
+    @Inject protected ContestSupervisorStore supervisorStore;
+    @Inject protected ContestProblemStore problemStore;
+    @Inject protected UserClient userClient;
 
-    @Inject
-    public ContestLogResource(
-            ActorChecker actorChecker,
-            ContestRoleChecker contestRoleChecker,
-            ContestStore contestStore,
-            ContestLogStore logStore,
-            ContestContestantStore contestantStore,
-            ContestSupervisorStore supervisorStore,
-            ContestProblemStore problemStore,
-            UserClient userClient) {
+    @Inject public ContestLogResource() {}
 
-        this.actorChecker = actorChecker;
-        this.contestRoleChecker = contestRoleChecker;
-        this.contestStore = contestStore;
-        this.logStore = logStore;
-        this.contestantStore = contestantStore;
-        this.supervisorStore = supervisorStore;
-        this.problemStore = problemStore;
-        this.userClient = userClient;
-    }
-
-    @Override
+    @GET
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
     public ContestLogsResponse getLogs(
-            AuthHeader authHeader,
-            String contestJid,
-            Optional<String> username,
-            Optional<String> problemAlias,
-            Optional<Integer> pageNumber) {
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("contestJid") String contestJid,
+            @QueryParam("username") Optional<String> username,
+            @QueryParam("problemAlias") Optional<String> problemAlias,
+            @QueryParam("page") Optional<Integer> pageNumber) {
 
         String actorJid = actorChecker.check(authHeader);
         Contest contest = checkFound(contestStore.getContestByJid(contestJid));

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/module/ContestModuleResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/module/ContestModuleResource.java
@@ -1,50 +1,49 @@
 package judgels.uriel.contest.module;
 
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static judgels.service.ServiceUtils.checkAllowed;
 import static judgels.service.ServiceUtils.checkFound;
 
 import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Set;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import judgels.jophiel.user.UserClient;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.uriel.api.contest.Contest;
-import judgels.uriel.api.contest.module.ContestModuleService;
 import judgels.uriel.api.contest.module.ContestModuleType;
 import judgels.uriel.api.contest.module.ContestModulesConfig;
 import judgels.uriel.contest.ContestRoleChecker;
 import judgels.uriel.contest.ContestStore;
 import judgels.uriel.contest.log.ContestLogger;
 
-public class ContestModuleResource implements ContestModuleService {
-    private final ActorChecker actorChecker;
-    private final ContestRoleChecker contestRoleChecker;
-    private final ContestStore contestStore;
-    private final ContestLogger contestLogger;
-    private final ContestModuleStore moduleStore;
-    private final UserClient userClient;
+@Path("/api/v2/contests/{contestJid}/modules")
+public class ContestModuleResource {
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected ContestRoleChecker contestRoleChecker;
+    @Inject protected ContestStore contestStore;
+    @Inject protected ContestLogger contestLogger;
+    @Inject protected ContestModuleStore moduleStore;
+    @Inject protected UserClient userClient;
 
-    @Inject
-    public ContestModuleResource(
-            ActorChecker actorChecker,
-            ContestRoleChecker contestRoleChecker,
-            ContestStore contestStore,
-            ContestLogger contestLogger,
-            ContestModuleStore moduleStore,
-            UserClient userClient) {
+    @Inject public ContestModuleResource() {}
 
-        this.actorChecker = actorChecker;
-        this.contestRoleChecker = contestRoleChecker;
-        this.contestStore = contestStore;
-        this.contestLogger = contestLogger;
-        this.moduleStore = moduleStore;
-        this.userClient = userClient;
-    }
-
-    @Override
+    @GET
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public Set<ContestModuleType> getModules(AuthHeader authHeader, String contestJid) {
+    public Set<ContestModuleType> getModules(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("contestJid") String contestJid) {
+
         String actorJid = actorChecker.check(authHeader);
         Contest contest = checkFound(contestStore.getContestByJid(contestJid));
 
@@ -55,9 +54,14 @@ public class ContestModuleResource implements ContestModuleService {
         return moduleStore.getEnabledModules(contest.getJid());
     }
 
-    @Override
+    @PUT
+    @Path("/{type}")
     @UnitOfWork
-    public void enableModule(AuthHeader authHeader, String contestJid, ContestModuleType type) {
+    public void enableModule(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("contestJid") String contestJid,
+            @PathParam("type") ContestModuleType type) {
+
         String actorJid = actorChecker.check(authHeader);
         Contest contest = checkFound(contestStore.getContestByJid(contestJid));
 
@@ -67,9 +71,14 @@ public class ContestModuleResource implements ContestModuleService {
         contestLogger.log(contestJid, "ENABLE_MODULE", type.name());
     }
 
-    @Override
+    @DELETE
+    @Path("/{type}")
     @UnitOfWork
-    public void disableModule(AuthHeader authHeader, String contestJid, ContestModuleType type) {
+    public void disableModule(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("contestJid") String contestJid,
+            @PathParam("type") ContestModuleType type) {
+
         String actorJid = actorChecker.check(authHeader);
         Contest contest = checkFound(contestStore.getContestByJid(contestJid));
 
@@ -79,9 +88,14 @@ public class ContestModuleResource implements ContestModuleService {
         contestLogger.log(contestJid, "DISABLE_MODULE", type.name());
     }
 
-    @Override
+    @GET
+    @Path("/config")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork
-    public ContestModulesConfig getConfig(AuthHeader authHeader, String contestJid) {
+    public ContestModulesConfig getConfig(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("contestJid") String contestJid) {
+
         String actorJid = actorChecker.check(authHeader);
         Contest contest = checkFound(contestStore.getContestByJid(contestJid));
 
@@ -96,9 +110,15 @@ public class ContestModuleResource implements ContestModuleService {
         return config;
     }
 
-    @Override
+    @PUT
+    @Path("/config")
+    @Consumes(APPLICATION_JSON)
     @UnitOfWork
-    public void upsertConfig(AuthHeader authHeader, String contestJid, ContestModulesConfig config) {
+    public void upsertConfig(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("contestJid") String contestJid,
+            ContestModulesConfig config) {
+
         String actorJid = actorChecker.check(authHeader);
         Contest contest = checkFound(contestStore.getContestByJid(contestJid));
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/web/ContestWebResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/web/ContestWebResource.java
@@ -1,42 +1,43 @@
 package judgels.uriel.contest.web;
 
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static judgels.service.ServiceUtils.checkAllowed;
 import static judgels.service.ServiceUtils.checkFound;
 
 import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.uriel.api.contest.Contest;
 import judgels.uriel.api.contest.web.ContestWebConfig;
-import judgels.uriel.api.contest.web.ContestWebService;
 import judgels.uriel.api.contest.web.ContestWithWebConfig;
 import judgels.uriel.contest.ContestRoleChecker;
 import judgels.uriel.contest.ContestStore;
 
-public class ContestWebResource implements ContestWebService {
-    private final ActorChecker actorChecker;
-    private final ContestRoleChecker contestRoleChecker;
-    private final ContestStore contestStore;
-    private final ContestWebConfigFetcher webConfigFetcher;
+@Path("/api/v2/contest-web")
+public class ContestWebResource {
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected ContestRoleChecker contestRoleChecker;
+    @Inject protected ContestStore contestStore;
+    @Inject protected ContestWebConfigFetcher webConfigFetcher;
 
-    @Inject
-    public ContestWebResource(
-            ActorChecker actorChecker,
-            ContestRoleChecker contestRoleChecker,
-            ContestStore contestStore,
-            ContestWebConfigFetcher webConfigFetcher) {
+    @Inject public ContestWebResource() {}
 
-        this.actorChecker = actorChecker;
-        this.contestRoleChecker = contestRoleChecker;
-        this.contestStore = contestStore;
-        this.webConfigFetcher = webConfigFetcher;
-    }
-
-    @Override
+    @GET
+    @Path("/slug/{contestSlug}/with-config")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public ContestWithWebConfig getContestBySlugWithWebConfig(Optional<AuthHeader> authHeader, String contestSlug) {
+    public ContestWithWebConfig getContestBySlugWithWebConfig(
+            @HeaderParam(AUTHORIZATION) Optional<AuthHeader> authHeader,
+            @PathParam("contestSlug") String contestSlug) {
+
         String actorJid = actorChecker.check(authHeader);
         Contest contest = checkFound(contestStore.getContestBySlug(contestSlug));
         checkAllowed(contestRoleChecker.canView(actorJid, contest));
@@ -46,9 +47,14 @@ public class ContestWebResource implements ContestWebService {
                 .build();
     }
 
-    @Override
+    @GET
+    @Path("/{contestJid}/with-config")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public ContestWithWebConfig getContestByJidWithWebConfig(Optional<AuthHeader> authHeader, String contestJid) {
+    public ContestWithWebConfig getContestByJidWithWebConfig(
+            @HeaderParam(AUTHORIZATION) Optional<AuthHeader> authHeader,
+            @PathParam("contestJid") String contestJid) {
+
         String actorJid = actorChecker.check(authHeader);
         Contest contest = checkFound(contestStore.getContestByJid(contestJid));
         checkAllowed(contestRoleChecker.canView(actorJid, contest));
@@ -58,9 +64,14 @@ public class ContestWebResource implements ContestWebService {
                 .build();
     }
 
-    @Override
+    @GET
+    @Path("/{contestJid}/config")
+    @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
-    public ContestWebConfig getWebConfig(Optional<AuthHeader> authHeader, String contestJid) {
+    public ContestWebConfig getWebConfig(
+            @HeaderParam(AUTHORIZATION) Optional<AuthHeader> authHeader,
+            @PathParam("contestJid") String contestJid) {
+
         String actorJid = actorChecker.check(authHeader);
         Contest contest = checkFound(contestStore.getContestByJid(contestJid));
         checkAllowed(contestRoleChecker.canView(actorJid, contest));


### PR DESCRIPTION
Currently, each Dropwizard resource implements a corresponding interface, which declare the endpoint using JAX-RS contract. This was primarily so that the integration tests can just create a Feign client using the same contract easily.

There are some problems with it:

- Feign clients do not support all JAX-RS contract features
- Recently, we saw a need to add `@Context UriInfo` to the resources, which had no corresponding JAX-RS contract (of course)

To alleviate the problem, and to future-proof the resources, this PR decouples them.

The next step is to just use Feign contract in the integration tests (not JAX-RS).