### PR TITLE
fix(gabriel): run DiffScorer in different working directory per thread

### DIFF
--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/BlackboxGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/BlackboxGradingEngine.java
@@ -49,7 +49,6 @@ public abstract class BlackboxGradingEngine implements GradingEngine {
     private File gradingDir;
     private File compilationDir;
     private File evaluationDir;
-    private File scoringDir;
 
     private GradingConfig config;
     private GradingLanguage language;
@@ -141,8 +140,6 @@ public abstract class BlackboxGradingEngine implements GradingEngine {
             FileUtils.forceMkdir(compilationDir);
             evaluationDir = new File(gradingDir, "evaluation");
             FileUtils.forceMkdir(evaluationDir);
-            scoringDir = new File(gradingDir, "scoring");
-            FileUtils.forceMkdir(scoringDir);
         } catch (IOException e) {
             throw new PreparationException(e);
         }

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/helpers/scorer/DiffScorer.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/helpers/scorer/DiffScorer.java
@@ -9,6 +9,12 @@ import judgels.gabriel.api.TestCaseVerdict;
 import judgels.gabriel.api.Verdict;
 
 public class DiffScorer implements Scorer {
+    private final File evaluationDir;
+
+    public DiffScorer(File evaluationDir) {
+        this.evaluationDir = evaluationDir;
+    }
+
     @Override
     public ScoringResult score(File input, File output, File evaluationOutput) throws ScoringException {
         String[] scoringCommand = new String[]{"/bin/bash", "-c", String.format(""
@@ -16,11 +22,13 @@ public class DiffScorer implements Scorer {
                 + "cat \"%s\" | tr '[\\t\\r\\n]' ' ' | xargs > _evaluation_tokenized.out; "
                 + "diff --brief _output_tokenized.out _evaluation_tokenized.out; result=$?; "
                 + "rm _output_tokenized.out _evaluation_tokenized.out; "
-                + "exit $result;",
+                + "exit $result",
                 output.getAbsolutePath(),
                 evaluationOutput.getAbsolutePath())};
 
         ProcessBuilder pb = new ProcessBuilder(scoringCommand);
+        pb.directory(evaluationDir);
+
         int exitCode;
         try {
             exitCode = pb.start().waitFor();

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/helpers/scorer/ScorerRegistry.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/helpers/scorer/ScorerRegistry.java
@@ -18,7 +18,7 @@ public class ScorerRegistry {
     public static Scorer getAndPrepare(
             Optional<String> customScorer,
             Map<String, File> helperFiles,
-            @Nullable  Sandbox sandbox,
+            @Nullable Sandbox sandbox,
             File evaluationDir) throws PreparationException {
 
         if (customScorer.isPresent()) {
@@ -27,7 +27,7 @@ public class ScorerRegistry {
             scorer.prepare(sandbox, evaluationDir, language, scorerFile);
             return scorer;
         } else {
-            return new DiffScorer();
+            return new DiffScorer(evaluationDir);
         }
     }
 }


### PR DESCRIPTION
In c253962, we replaced process substitution with real files, to avoid zombie process when the ProcessBuilder is done (observed in Ubuntu 22.04).

However, this might lead in several threads trying to create and remove the same files, leading to race condition.

This PR makes sure that the files are created in separate working directory per thread.