### PR TITLE
hack(jerahmeel): force select filter when problem query will be slow

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/problem/ProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/problem/ProblemResource.java
@@ -45,6 +45,14 @@ public class ProblemResource {
 
         String actorJid = actorChecker.check(authHeader);
 
+        // HACK: the query is very slow. In the meantime, when the number of problems is large,
+        // we return empty and force the user to filter by tags.
+        if (tags.isEmpty() && problemStore.getTotalProblems() > 1000) {
+            return new ProblemsResponse.Builder()
+                    .data(new Page.Builder<ProblemSetProblemInfo>().totalCount(0).build())
+                    .build();
+        }
+
         Set<String> allowedProblemJids = null;
         if (!tags.isEmpty()) {
             allowedProblemJids = sandalphonClient.getProblemJidsByTags(tags);

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/problem/ProblemStore.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/problem/ProblemStore.java
@@ -24,6 +24,10 @@ public class ProblemStore {
         this.problemDao = problemDao;
     }
 
+    public int getTotalProblems() {
+        return problemDao.select().count();
+    }
+
     public Page<ProblemSetProblemInfo> getProblems(Set<String> allowedProblemJids, int pageNumber, int pageSize) {
         Page<ProblemSetProblemModel> models = problemDao.selectPagedByDifficulty(allowedProblemJids, pageNumber, pageSize);
 

--- a/judgels-client/src/routes/problems/problems/ProblemsPage/ProblemsPage.jsx
+++ b/judgels-client/src/routes/problems/problems/ProblemsPage/ProblemsPage.jsx
@@ -52,7 +52,7 @@ class ProblemsPage extends Component {
   };
 
   renderProblems = () => {
-    const { response } = this.state;
+    const { response, filter } = this.state;
     if (!response || !response.data) {
       return <LoadingState />;
     }
@@ -60,6 +60,15 @@ class ProblemsPage extends Component {
     const { data: problems, problemsMap, problemMetadatasMap, problemDifficultiesMap, problemProgressesMap } = response;
 
     if (problems.page.length === 0) {
+      if (filter.tags.length === 0) {
+        return (
+          <>
+            <p>To view problems, select some filters on the left.</p>
+            <p>We will refine this page in the future.</p>
+          </>
+        );
+      }
+
       return (
         <p>
           <small>No problems found.</small>


### PR DESCRIPTION
Currently, the SQL query for selecting problems sorted by difficulty, is very slow.

As a workaround, we will force the user to select some filters, in the hope that it will make the query a bit faster.