### PR TITLE
feat(client): remove hardcoded course info

### DIFF
--- a/judgels-client/src/routes/courses/courses/CourseCard/CourseCard.jsx
+++ b/judgels-client/src/routes/courses/courses/CourseCard/CourseCard.jsx
@@ -1,5 +1,3 @@
-import { Tag } from '@blueprintjs/core';
-import { Globe } from '@blueprintjs/icons';
 import { HtmlText } from '../../../../components/HtmlText/HtmlText';
 import { ProgressTag } from '../../../../components/ProgressTag/ProgressTag';
 import { ProgressBar } from '../../../../components/ProgressBar/ProgressBar';
@@ -35,12 +33,6 @@ export function CourseCard({ course: { slug, name, description }, progress }) {
         {`${name}`}
         {renderProgress()}
       </h4>
-      <p className="course-card__subtitle">
-        <Globe />
-        &nbsp;&nbsp;Bahasa Indonesia&nbsp;&nbsp;&middot;&nbsp;&nbsp;
-        <Tag minimal>Free</Tag>
-        &nbsp;&nbsp;&middot;&nbsp;&nbsp;Ikatan Alumni TOKI
-      </p>
       <hr />
       {description && (
         <small className="course-card__description">


### PR DESCRIPTION
So that it can be used outside TLX.

|Before|After|
|-|-|
|<img width="585" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/e12818ef-29fa-4356-aa3e-3462b8d14c23">|<img width="588" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/4c46d002-8206-4a6d-9d61-dbe28ca91449">|