### PR TITLE
feat(client): remove header widgets on narrow mobile res

### DIFF
--- a/judgels-client/src/components/DarkModeWidget/DarkModeWidget.scss
+++ b/judgels-client/src/components/DarkModeWidget/DarkModeWidget.scss
@@ -3,6 +3,8 @@
   margin-bottom: 0;
 }
 
-.dark-mode-widget__onboarding {
-  margin-right: 10px;
+@media only screen and (max-width: 600px) {
+  .dark-mode-widget__switch {
+    display: none;
+  }
 }

--- a/judgels-client/src/components/UserWidget/UserWidget.scss
+++ b/judgels-client/src/components/UserWidget/UserWidget.scss
@@ -57,6 +57,10 @@
 }
 
 @media only screen and (max-width: 600px) {
+  .widget-user__avatar-wrapper {
+    display: none;
+  }
+
   .widget-user__burger,
   .widget-user__menu-helper {
     display: block !important;


### PR DESCRIPTION
Removing dark mode switch and user avatar.

|Before|After|
|-|-|
|<img width="377" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/3539d9aa-ddf3-440e-8bfb-01412fa7302c">|<img width="375" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/df2e64eb-b335-4819-af8b-f16ddd7c9647">|
