### PR TITLE
feat(client): revamp single course layout

### DIFF
--- a/judgels-client/src/components/ContentCard/ContentCard.jsx
+++ b/judgels-client/src/components/ContentCard/ContentCard.jsx
@@ -1,13 +1,12 @@
 import { Card } from '@blueprintjs/core';
+import classNames from 'classnames';
 
 import './ContentCard.scss';
 
 export function ContentCard({ className, elevation, children }) {
   return (
-    <div className={className}>
-      <Card className="content-card" elevation={elevation}>
-        {children}
-      </Card>
-    </div>
+    <Card className={classNames(className, 'content-card')} elevation={elevation}>
+      {children}
+    </Card>
   );
 }

--- a/judgels-client/src/components/ContentCard/ContentCard.scss
+++ b/judgels-client/src/components/ContentCard/ContentCard.scss
@@ -10,10 +10,6 @@
   }
 }
 
-.bp4-dark .content-card {
-  box-shadow: 0 0 0 1px $gray1 !important;
-}
-
 .content-card__section {
   margin-bottom: 15px;
 }

--- a/judgels-client/src/components/FullWidthPageLayout/FullWidthPageLayout.jsx
+++ b/judgels-client/src/components/FullWidthPageLayout/FullWidthPageLayout.jsx
@@ -1,0 +1,5 @@
+import './FullWidthPageLayout.scss';
+
+export function FullWidthPageLayout({ children }) {
+  return <div className="layout-full-width-page">{children}</div>;
+}

--- a/judgels-client/src/components/FullWidthPageLayout/FullWidthPageLayout.scss
+++ b/judgels-client/src/components/FullWidthPageLayout/FullWidthPageLayout.scss
@@ -1,0 +1,6 @@
+@import '../../styles/base';
+
+.layout-full-width-page {
+  max-width: 1260px;
+  min-height: 100vh;
+}

--- a/judgels-client/src/routes/courses/courses/single/CourseChaptersSidebar/CourseChaptersSidebar.jsx
+++ b/judgels-client/src/routes/courses/courses/single/CourseChaptersSidebar/CourseChaptersSidebar.jsx
@@ -1,11 +1,10 @@
-import { Classes, Tree } from '@blueprintjs/core';
-import { ChevronDown, Selection } from '@blueprintjs/icons';
+import { ChevronDown } from '@blueprintjs/icons';
+import classNames from 'classnames';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { Link } from 'react-router-dom';
 
-import { ContentCard } from '../../../../../components/ContentCard/ContentCard';
 import { ProgressTag } from '../../../../../components/ProgressTag/ProgressTag';
 import { ProgressBar } from '../../../../../components/ProgressBar/ProgressBar';
 import { selectCourse } from '../../modules/courseSelectors';
@@ -34,38 +33,32 @@ class CourseChaptersSidebar extends Component {
     const { data: courseChapters, chaptersMap, chapterProgressesMap } = response;
     const activeChapterJid = chapter && chapter.jid;
 
-    let contents = [
-      {
-        id: 0,
-        label: (
-          <Link to={`/courses/${course.slug}`}>
-            <h4>{course.name}</h4>
-          </Link>
-        ),
-        icon: <ChevronDown className={Classes.TREE_NODE_ICON} />,
-        isSelected: !activeChapterJid,
-      },
-    ];
-
-    contents = contents.concat(
-      courseChapters.map(courseChapter => ({
-        id: courseChapter.alias,
-        label: (
-          <Link to={`/courses/${course.slug}/chapters/${courseChapter.alias}`}>
-            {courseChapter.alias}. {chaptersMap[courseChapter.chapterJid].name}
+    return (
+      <div className="course-chapters-sidebar">
+        <Link
+          className={classNames('course-chapters-sidebar__item', 'course-chapters-sidebar__title', {
+            'course-chapters-sidebar__item--selected': !activeChapterJid,
+          })}
+          to={`/courses/${course.slug}`}
+        >
+          <ChevronDown />
+          <h4>{course.name}</h4>
+        </Link>
+        {courseChapters.map(courseChapter => (
+          <Link
+            className={classNames('course-chapters-sidebar__item', {
+              'course-chapters-sidebar__item--selected': courseChapter.chapterJid === activeChapterJid,
+            })}
+            to={`/courses/${course.slug}/chapters/${courseChapter.alias}`}
+          >
+            <div className="course-chapters-sidebar__item-title">
+              {courseChapter.alias}. {chaptersMap[courseChapter.chapterJid].name}
+              {this.renderProgress(chapterProgressesMap[courseChapter.chapterJid])}
+            </div>
             {this.renderProgressBar(chapterProgressesMap[courseChapter.chapterJid])}
           </Link>
-        ),
-        secondaryLabel: this.renderProgress(chapterProgressesMap[courseChapter.chapterJid]),
-        icon: <Selection className={Classes.TREE_NODE_ICON} />,
-        isSelected: courseChapter.chapterJid === activeChapterJid,
-      }))
-    );
-
-    return (
-      <ContentCard className="course-chapters-sidebar">
-        <Tree className="course-chapters-sidebar__chapters" contents={contents} />
-      </ContentCard>
+        ))}
+      </div>
     );
   }
 

--- a/judgels-client/src/routes/courses/courses/single/CourseChaptersSidebar/CourseChaptersSidebar.scss
+++ b/judgels-client/src/routes/courses/courses/single/CourseChaptersSidebar/CourseChaptersSidebar.scss
@@ -1,72 +1,56 @@
 @import '../../../../../styles/base';
 
-.course-chapters-sidebar .content-card {
-  padding-top: 5px;
-  padding-bottom: 0;
-
-  h4 {
-    margin-bottom: 5px;
-  }
-}
-
-.course-chapters-sidebar__chapters {
+.course-chapters-sidebar {
   font-family: $accent-font;
-  margin-left: -15px;
-  margin-right: -15px;
+  background-color: inherit !important;
+  box-shadow: none !important;
+  border-right: 1px solid $border-color;
 
-  .bp4-tree-node-content {
-    align-items: initial;
-    height: inherit;
+}
 
-    a {
-      text-decoration: none;
-      color: inherit;
-      display: block;
-      padding-top: 5px;
-      padding-bottom: 15px;
-    }
-  }
+a.course-chapters-sidebar__item {
+  display: block;
+  padding: 10px;
 
-  .bp4-tree-node-icon {
-    padding-top: 7px;
-  }
+  color: inherit;
+  text-decoration: none;
 
-  .bp4-tree-node-label {
-    text-overflow: initial;
-    white-space: normal;
-  }
-
-  .bp4-tree-node-selected > .bp4-tree-node-content {
+  &:hover {
     color: inherit;
-    background-color: $secondary-background-color !important;
-
-    .bp4-tree-node-icon {
-      color: inherit;
-    }
+    background-color: $tertiary-background-color;
   }
 
-  li {
-    margin-left: -15px;
-  }
-
-  .progress-tag {
-    margin-top: 5px;
-    margin-bottom: 0;
-  }
-
-  .progress-bar {
-    margin-top: 4px;
-    margin-bottom: 0;
+  &--selected {
+    background-color: $tertiary-background-color;
   }
 }
 
-.bp4-dark .course-chapters-sidebar__chapters {
-  .bp4-tree-node-selected > .bp4-tree-node-content {
-    color: inherit;
-    background-color: $dark-secondary-background-color !important;
+.course-chapters-sidebar__title {
+  h4 {
+    display: inline-block;
+  }
 
-    .bp4-tree-node-icon {
-      color: inherit;
+  .bp4-icon {
+    margin-right: 10px;
+  }
+}
+
+.bp4-dark {
+  .course-chapters-sidebar {
+    border-color: $dark-border-color;
+  }
+
+  a.course-chapters-sidebar__item {
+    &:hover {
+      background-color: $dark-tertiary-background-color;
     }
+  
+    &--selected {
+      background-color: $dark-secondary-background-color;
+    }
+  }
+
+  a.course-chapters-sidebar__item:hover.course-chapters-sidebar__item--selected{
+    background-color: $dark-secondary-background-color;
   }
 }

--- a/judgels-client/src/routes/courses/courses/single/CourseOverview/CourseOverview.jsx
+++ b/judgels-client/src/routes/courses/courses/single/CourseOverview/CourseOverview.jsx
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 
-import { ContentCard } from '../../../../../components/ContentCard/ContentCard';
 import { HtmlText } from '../../../../../components/HtmlText/HtmlText';
 import { selectCourse } from '../../modules/courseSelectors';
 
@@ -11,9 +10,7 @@ function CourseOverview({ course }) {
     <div className="course-overview">
       <h2>{course.name}</h2>
       <hr />
-      <ContentCard>
-        <HtmlText>{course.description}</HtmlText>
-      </ContentCard>
+      <HtmlText>{course.description}</HtmlText>
     </div>
   );
 }

--- a/judgels-client/src/routes/courses/courses/single/SingleCourseRoutes.jsx
+++ b/judgels-client/src/routes/courses/courses/single/SingleCourseRoutes.jsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
-import { FullPageLayout } from '../../../../components/FullPageLayout/FullPageLayout';
+import { FullWidthPageLayout } from '../../../../components/FullWidthPageLayout/FullWidthPageLayout';
 import { ScrollToTopOnMount } from '../../../../components/ScrollToTopOnMount/ScrollToTopOnMount';
 import CourseChaptersSidebar from './CourseChaptersSidebar/CourseChaptersSidebar';
 import SingleCourseContentRoutes from './SingleCourseContentRoutes';
@@ -18,7 +18,7 @@ function SingleCourseRoutes({ match, course }) {
   }
 
   return (
-    <FullPageLayout>
+    <FullWidthPageLayout>
       <ScrollToTopOnMount />
       <div className="single-course-routes">
         <div className="single-course-routes__sidebar">
@@ -29,7 +29,7 @@ function SingleCourseRoutes({ match, course }) {
           <SingleCourseContentRoutes />
         </div>
       </div>
-    </FullPageLayout>
+    </FullWidthPageLayout>
   );
 }
 

--- a/judgels-client/src/routes/courses/courses/single/SingleCourseRoutes.scss
+++ b/judgels-client/src/routes/courses/courses/single/SingleCourseRoutes.scss
@@ -3,13 +3,14 @@
 }
 
 .single-course-routes__sidebar {
-  width: 270px;
+  width: 300px;
   margin-right: 25px;
   margin-bottom: 15px;
 }
 
 .single-course-routes__content {
   flex-grow: 1;
+  margin-left: auto;
   max-width: 865px;
 }
 
@@ -17,7 +18,7 @@
   display: none;
 }
 
-@media only screen and (max-width: 750px) {
+@media only screen and (max-width: 780px) {
   .single-course-routes {
     flex-direction: column-reverse;
   }
@@ -25,6 +26,10 @@
   .single-course-routes__sidebar {
     width: inherit;
     margin-right: 0;
+  }
+
+  .single-course-routes__content {
+    margin-left: inherit;
   }
 
   .single-course-routes__divider {

--- a/judgels-client/src/styles/index.scss
+++ b/judgels-client/src/styles/index.scss
@@ -92,11 +92,11 @@ hr {
 }
 
 .bp4-light hr {
-  border-bottom: 1px solid rgba($text-color, 0.15);
+  border-bottom: 1px solid $border-color;
 }
 
 .bp4-dark hr {
-  border-bottom: 1px solid $dark-secondary-text-color;
+  border-bottom: 1px solid $dark-border-color;
 }
 
 a {

--- a/judgels-client/src/styles/variables/_colors.scss
+++ b/judgels-client/src/styles/variables/_colors.scss
@@ -5,6 +5,7 @@ $text-color: #252527;
 $secondary-text-color: #5d5d66;
 $secondary-background-color: #eef2fb;
 $tertiary-background-color: rgba(191, 204, 214, 0.4);
+$border-color: rgba($text-color, 0.15);
 
 $dark-text-color: #c9d1d9;
 $dark-blue-main-background-color: #0c5174;
@@ -12,3 +13,4 @@ $dark-blue-secondary-background-color: #0c5174;
 $dark-secondary-text-color: $gray4;
 $dark-secondary-background-color: $gray1;
 $dark-tertiary-background-color: rgba(92, 112, 128, 0.3);
+$dark-border-color: #5c7080;


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="1282" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/989d2e8f-0149-4202-b677-52fb45e342e8">|<img width="1282" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/8a8e43d2-0d84-4b9b-a57b-b2d8b3c32adf">|
|<img width="1281" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/8e23323f-c4e5-4ecc-875f-b4f2e0373f31">|<img width="1278" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/df311c8a-d400-40eb-a6ae-f45590a4ea0e">|