### PR TITLE
feat(grader): give WA when communicator received signal 13 before writing verdict

### DIFF
--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/BlackboxGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/BlackboxGradingEngineIntegrationTests.java
@@ -149,7 +149,6 @@ public class BlackboxGradingEngineIntegrationTests {
                 .time(100)
                 .memory(1000)
                 .status(s)
-                .message("OK")
                 .build());
         return new TestCaseResult.Builder()
                 .verdict(verdict)

--- a/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/helper/communicator-sigpipe-after-verdict.cpp
+++ b/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/helper/communicator-sigpipe-after-verdict.cpp
@@ -1,0 +1,22 @@
+// This communicator will receive SIGPIPE signal,
+// when paired with trigger-communicator-sigpipe.cpp.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+
+int N;
+
+int main(int argc, char* argv[])
+{
+    FILE* in = fopen(argv[1], "r");
+    fscanf(in, "%d", &N);
+
+    fprintf(stderr, "AC\n");
+
+    usleep(500 * 1000);
+
+    printf("this output will trigger SIGPIPE signal");
+    fflush(stdout);
+}

--- a/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/helper/communicator-sigpipe-before-verdict.cpp
+++ b/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/helper/communicator-sigpipe-before-verdict.cpp
@@ -1,0 +1,33 @@
+// This communicator will receive SIGPIPE signal,
+// when paired with trigger-communicator-sigpipe.cpp.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+
+int N;
+
+int main(int argc, char* argv[])
+{
+    FILE* in = fopen(argv[1], "r");
+    fscanf(in, "%d", &N);
+
+    usleep(500 * 1000);
+
+    printf("this output will trigger SIGPIPE signal");
+    fflush(stdout);
+
+    usleep(500 * 1000);
+
+    printf("this output will trigger SIGPIPE signal");
+    fflush(stdout);
+
+    // Assume that the communicator never reached the following line,
+    // because it would have been killed by the sandbox.
+
+    // We must comment this out explicitly, because the fake sandbox
+    // used in the tests does not actually sandbox the program.
+
+    // fprintf(stderr, "AC\n");
+}

--- a/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/source/trigger-communicator-sigpipe.cpp
+++ b/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/source/trigger-communicator-sigpipe.cpp
@@ -1,0 +1,4 @@
+// This solution does nothing to trigger the communicator to receive SIGPIPE signal,
+// because this solution would have exited while the communicator is still writing output.
+
+int main() {}

--- a/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/source/trigger-solution-sigpipe.cpp
+++ b/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/source/trigger-solution-sigpipe.cpp
@@ -1,0 +1,34 @@
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+
+char response[100];
+
+int main()
+{
+    int lo = 1, hi = 1000;
+    while (lo <= hi)
+    {
+        int mid = (lo + hi) / 2;
+        printf("%d\n", mid);
+        fflush(stdout);
+
+        fprintf(stderr, "debug");
+        fflush(stderr);
+
+        scanf("%s", response);
+
+        if (!strcmp(response, "too_low"))
+            lo = mid+1;
+        else
+            hi = mid-1;
+    }
+
+    // At this point, the communicator will have exited
+    // with AC verdict.
+
+    usleep(500 * 1000);
+
+    printf("this output will trigger SIGPIPE signal");
+    fflush(stdout);
+}

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/sandboxes/fake/FakeSandbox.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/sandboxes/fake/FakeSandbox.java
@@ -15,7 +15,6 @@ import org.apache.commons.io.FileUtils;
 
 public class FakeSandbox implements Sandbox {
     private static final int FAKE_TIMED_OUT_EXIT_CODE = 10;
-    private static final int FAKE_KILLED_ON_SIGNAL_EXIT_CODE = 20;
 
     private final File baseDir;
     private File standardInput;
@@ -157,9 +156,6 @@ public class FakeSandbox implements Sandbox {
             case FAKE_TIMED_OUT_EXIT_CODE:
                 status = SandboxExecutionStatus.TIMED_OUT;
                 break;
-            case FAKE_KILLED_ON_SIGNAL_EXIT_CODE:
-                status = SandboxExecutionStatus.KILLED_ON_SIGNAL;
-                break;
             default:
                 status = SandboxExecutionStatus.NONZERO_EXIT_CODE;
         }
@@ -167,7 +163,6 @@ public class FakeSandbox implements Sandbox {
                 .time(100)
                 .memory(1000)
                 .status(status)
-                .message("OK")
                 .build();
     }
 }

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/sandboxes/isolate/IsolateSandbox.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/sandboxes/isolate/IsolateSandbox.java
@@ -257,6 +257,11 @@ public class IsolateSandbox implements Sandbox {
             executionStatus = SandboxExecutionStatus.INTERNAL_ERROR;
         }
 
+        Optional<Integer> exitSignal = Optional.empty();
+        if (items.containsKey("exitsig")) {
+            exitSignal = Optional.of(Integer.parseInt(items.get("exitsig")));
+        }
+
         boolean isKilled = items.getOrDefault("killed", "0").equals("1");
         Optional<String> message = Optional.ofNullable(items.get("message"));
 
@@ -265,6 +270,7 @@ public class IsolateSandbox implements Sandbox {
                 .wallTime(wallTime)
                 .memory(memory)
                 .status(executionStatus)
+                .exitSignal(exitSignal)
                 .isKilled(isKilled)
                 .message(message)
                 .build();


### PR DESCRIPTION
In interactive problems, when communicator received signal 13, it means it was still writing output while the solution has already exited. If the communicator has not yet written the verdict, it means the solution exited too soon.

### Before

The verdict is `ERR (judgels.gabriel.api.ScoringException: Expected: <code> on the first line)`

### After

We give Wrong Answer verdict instead.