### PR TITLE
feat(grader): redirect solution's stderr to file during communication with communicator

### DIFF
--- a/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/source/binsearch-OK.cpp
+++ b/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/source/binsearch-OK.cpp
@@ -13,7 +13,6 @@ int main()
         fflush(stdout);
 
         fprintf(stderr, "debug");
-        fflush(stderr);
 
         scanf("%s", response);
 

--- a/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/source/trigger-solution-sigpipe.cpp
+++ b/judgels-backends/judgels-grader-engines/src/integTest/resources/engines/interactive/source/trigger-solution-sigpipe.cpp
@@ -14,7 +14,6 @@ int main()
         fflush(stdout);
 
         fprintf(stderr, "debug");
-        fflush(stderr);
 
         scanf("%s", response);
 

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/helpers/communicator/Communicator.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/helpers/communicator/Communicator.java
@@ -29,6 +29,7 @@ import org.apache.commons.io.FileUtils;
 
 public class Communicator {
     private static final String COMMUNICATION_OUTPUT_FILENAME = "_communication.out";
+    private static final String SOLUTION_ERROR_FILENAME = "_solution.err";
 
     private final SingleSourceFileCompiler compiler;
     private final TestCaseVerdictParser verdictParser;
@@ -125,6 +126,13 @@ public class Communicator {
                         "Cannot set " + solutionExecutableFile.getAbsolutePath() + " as executable");
             }
         }
+
+        solutionSandbox.resetRedirections();
+
+        // By default, stderr is not buffered.
+        // Writing to the unbuffered stderr sometimes interferes with the interaction.
+        // We redirect the stderr to a file so that it is buffered.
+        solutionSandbox.redirectStandardError(SOLUTION_ERROR_FILENAME);
 
         try {
             FileUtils.cleanDirectory(communicationDir);


### PR DESCRIPTION
By default, stderr is not buffered. When the solution writes to the unbuffered stderr, it sometimes interferes with the interaction.

We redirect the stderr to a file instead so that it is buffered.

### Before

In such case, it could make the grader (even the sandbox) get stuck.

### After

It won't affect the grading anymore.