### PR TITLE
feat(client): revamp course chapters: smoothen transition between chapters

### DIFF
--- a/judgels-client/src/routes/courses/courses/single/CourseChaptersSidebar/CourseChaptersSidebar.jsx
+++ b/judgels-client/src/routes/courses/courses/single/CourseChaptersSidebar/CourseChaptersSidebar.jsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import { ProgressTag } from '../../../../../components/ProgressTag/ProgressTag';
 import { ProgressBar } from '../../../../../components/ProgressBar/ProgressBar';
 import { selectCourse } from '../../modules/courseSelectors';
+import { PutCourseChapter } from '../chapters/modules/courseChapterReducer';
 import * as courseChapterActions from '../chapters/modules/courseChapterActions';
 
 import './CourseChaptersSidebar.scss';
@@ -22,7 +23,19 @@ class CourseChaptersSidebar extends Component {
   }
 
   render() {
-    const { course, match } = this.props;
+    return (
+      <div
+        className={classNames('course-chapters-sidebar', {
+          'course-chapters-sidebar--compact': this.isInProblemPath(),
+        })}
+      >
+        {this.renderChapters()}
+      </div>
+    );
+  }
+
+  renderChapters = () => {
+    const { course, match, onPutCourseChapter } = this.props;
     const { response } = this.state;
     if (!course || !response) {
       return null;
@@ -30,30 +43,30 @@ class CourseChaptersSidebar extends Component {
 
     const { data: courseChapters, chaptersMap, chapterProgressesMap } = response;
 
-    return (
-      <div
-        className={classNames('course-chapters-sidebar', {
-          'course-chapters-sidebar--compact': this.isInProblemPath(),
+    return courseChapters.map(courseChapter => (
+      <Link
+        className={classNames('course-chapters-sidebar__item', {
+          'course-chapters-sidebar__item--selected': this.isInChapterPath(courseChapter.alias),
         })}
+        to={`${match.url}/chapters/${courseChapter.alias}`}
+        onClick={() =>
+          onPutCourseChapter({
+            jid: courseChapter.chapterJid,
+            name: chaptersMap[courseChapter.chapterJid].name,
+            alias: courseChapter.alias,
+            courseSlug: course.slug,
+          })
+        }
       >
-        {courseChapters.map(courseChapter => (
-          <Link
-            className={classNames('course-chapters-sidebar__item', {
-              'course-chapters-sidebar__item--selected': this.isInChapterPath(courseChapter.alias),
-            })}
-            to={`${match.url}/chapters/${courseChapter.alias}`}
-          >
-            <div className="course-chapters-sidebar__item-title">
-              {courseChapter.alias}{' '}
-              {this.isInProblemPath() ? <>&nbsp;</> : <>. {chaptersMap[courseChapter.chapterJid].name}</>}
-              {this.renderProgress(chapterProgressesMap[courseChapter.chapterJid])}
-            </div>
-            {!this.isInProblemPath() && this.renderProgressBar(chapterProgressesMap[courseChapter.chapterJid])}
-          </Link>
-        ))}
-      </div>
-    );
-  }
+        <div className="course-chapters-sidebar__item-title">
+          {courseChapter.alias}{' '}
+          {this.isInProblemPath() ? <>&nbsp;</> : <>. {chaptersMap[courseChapter.chapterJid].name}</>}
+          {this.renderProgress(chapterProgressesMap[courseChapter.chapterJid])}
+        </div>
+        {!this.isInProblemPath() && this.renderProgressBar(chapterProgressesMap[courseChapter.chapterJid])}
+      </Link>
+    ));
+  };
 
   isInChapterPath = chapterAlias => {
     return (this.props.location.pathname + '/')
@@ -92,6 +105,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   onGetChapters: courseChapterActions.getChapters,
+  onPutCourseChapter: PutCourseChapter,
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(CourseChaptersSidebar));


### PR DESCRIPTION
- Render empty sidebar when loading chapters to prevent "blinking"
- Put the current chapter to redux store immediately when switching chapter,
   to avoid having to wait to fetch the chapter again