### PR TITLE
feat(client,server): support problem skeletons

### DIFF
--- a/judgels-backends/judgels-server-api/src/main/java/judgels/jerahmeel/api/chapter/problem/programming/ChapterProblemWorksheet.java
+++ b/judgels-backends/judgels-server-api/src/main/java/judgels/jerahmeel/api/chapter/problem/programming/ChapterProblemWorksheet.java
@@ -1,7 +1,9 @@
 package judgels.jerahmeel.api.chapter.problem.programming;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Set;
 import judgels.jerahmeel.api.problem.ProblemProgress;
+import judgels.sandalphon.api.problem.programming.ProblemSkeleton;
 import judgels.sandalphon.api.problem.programming.ProblemWorksheet;
 import org.immutables.value.Value;
 
@@ -9,6 +11,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableChapterProblemWorksheet.class)
 public interface ChapterProblemWorksheet extends judgels.jerahmeel.api.chapter.problem.ChapterProblemWorksheet  {
     ProblemWorksheet getWorksheet();
+    Set<ProblemSkeleton> getSkeletons();
     ProblemProgress getProgress();
 
     class Builder extends ImmutableChapterProblemWorksheet.Builder{}

--- a/judgels-backends/judgels-server-api/src/main/java/judgels/sandalphon/api/problem/programming/ProblemSkeleton.java
+++ b/judgels-backends/judgels-server-api/src/main/java/judgels/sandalphon/api/problem/programming/ProblemSkeleton.java
@@ -1,0 +1,14 @@
+package judgels.sandalphon.api.problem.programming;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Set;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableProblemSkeleton.class)
+public interface ProblemSkeleton {
+    Set<String> getLanguages();
+    byte[] getContent();
+
+    class Builder extends ImmutableProblemSkeleton.Builder {}
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/chapter/problem/ChapterProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/chapter/problem/ChapterProblemResource.java
@@ -144,6 +144,7 @@ public class ChapterProblemResource {
                             .from(sandalphonClient.getProgrammingProblemWorksheet(req, uriInfo, problemJid, language))
                             .reasonNotAllowedToSubmit(reasonNotAllowedToSubmit)
                             .build())
+                    .skeletons(sandalphonClient.getProgrammingProblemSkeletons(problemJid))
                     .progress(statsStore.getProblemProgressesMap(actorJid, Set.of(problemJid)).get(problemJid))
                     .build();
         } else {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/sandalphon/SandalphonClient.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/sandalphon/SandalphonClient.java
@@ -31,6 +31,7 @@ import judgels.sandalphon.api.problem.bundle.BundleItem;
 import judgels.sandalphon.api.problem.bundle.Item;
 import judgels.sandalphon.api.problem.bundle.ItemConfig;
 import judgels.sandalphon.api.problem.programming.ProblemLimits;
+import judgels.sandalphon.api.problem.programming.ProblemSkeleton;
 import judgels.sandalphon.api.problem.programming.ProblemSubmissionConfig;
 import judgels.sandalphon.lesson.LessonStore;
 import judgels.sandalphon.lesson.statement.LessonStatementStore;
@@ -162,6 +163,10 @@ public class SandalphonClient {
                         .build())
                 .submissionConfig(getProgrammingProblemSubmissionConfig(problemJid))
                 .build();
+    }
+
+    public Set<ProblemSkeleton> getProgrammingProblemSkeletons(String problemJid) {
+        return problemStatementStore.getSkeletons(null, problemJid);
     }
 
     public judgels.sandalphon.api.problem.bundle.ProblemWorksheet getBundleProblemWorksheet(

--- a/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionEditor/ProblemSubmissionEditor.jsx
+++ b/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionEditor/ProblemSubmissionEditor.jsx
@@ -11,6 +11,7 @@ import { getAllowedGradingLanguages, gradingLanguageNamesMap } from '../../../..
 import './ProblemSubmissionEditor.scss';
 
 export function ProblemSubmissionEditor({
+  skeletons,
   config: { sourceKeys, gradingEngine, gradingLanguageRestriction },
   onSubmit,
   reasonNotAllowedToSubmit,
@@ -61,6 +62,12 @@ export function ProblemSubmissionEditor({
     const initialValues = {
       gradingLanguage: defaultGradingLanguage,
     };
+
+    (skeletons || []).forEach(skeleton => {
+      if (skeleton.languages.indexOf(defaultGradingLanguage) >= 0) {
+        initialValues.editor = atob(skeleton.content);
+      }
+    });
 
     return (
       <Form onSubmit={onSubmitEditor} initialValues={initialValues}>

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemPage.test.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemPage.test.jsx
@@ -21,6 +21,7 @@ describe('ChapterProblemProgrammingPage', () => {
       },
       defaultLanguage: 'id',
       languages: ['en', 'id'],
+      skeletons: [],
       worksheet: {
         statement: {
           title: 'Problem',

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemWorkspacePage/ChapterProblemWorkspacePage.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemWorkspacePage/ChapterProblemWorkspacePage.jsx
@@ -10,14 +10,15 @@ import * as chapterProblemSubmissionActions from '../submissions/modules/chapter
 import * as webPrefsActions from '../../../../../../../../../../modules/webPrefs/webPrefsActions';
 
 function ChapterProblemWorkspacePage({
-  worksheet: { problem, worksheet },
+  worksheet,
   course,
   chapter,
   gradingLanguage,
   onCreateSubmission,
   onUpdateGradingLanguage,
 }) {
-  const { submissionConfig, reasonNotAllowedToSubmit } = worksheet;
+  const { submissionConfig, reasonNotAllowedToSubmit } = worksheet.worksheet;
+  const { problem, skeletons } = worksheet;
 
   const createSubmission = async data => {
     onUpdateGradingLanguage(data.gradingLanguage);
@@ -27,7 +28,7 @@ function ChapterProblemWorkspacePage({
     sendGAEvent({
       category: 'Courses',
       action: 'Submit problem',
-      label: chapter.name + ': ' + problem.alis,
+      label: chapter.name + ': ' + problem.alias,
     });
     if (getGradingLanguageFamily(data.gradingLanguage)) {
       sendGAEvent({
@@ -42,6 +43,7 @@ function ChapterProblemWorkspacePage({
 
   return (
     <ProblemSubmissionEditor
+      skeletons={skeletons}
       config={submissionConfig}
       onSubmit={createSubmission}
       reasonNotAllowedToSubmit={reasonNotAllowedToSubmit}


### PR DESCRIPTION
By adding a statement media (resource) file called `skeleton.[extension]`, the code will be set as the default code in the sidebar editor when opening a chapter problem.

<img width="1180" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/fccfcc7f-a8d1-4f3c-8d3a-dbf4bf8d8a4a">
