### PR TITLE
feat: add devcontainer support for judgels development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:22.04
+
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN apt-get update \
+    && apt-get install -y sudo git \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
+    && addgroup --gid "${USER_GID}" tokidev \
+    && adduser --uid "${USER_UID}" --gid "${USER_GID}" --disabled-password --gecos '' tokidev \
+    && echo 'tokidev ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+EXPOSE 9101
+EXPOSE 3000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Judgels Dev",
+  "dockerFile": "Dockerfile",
+  "runArgs": [
+    "--privileged"
+  ],
+  "remoteUser": "tokidev",
+  "containerUser": "tokidev",
+  "postCreateCommand": "echo 'yes' | bin/bootstrap_system.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack"
+      ]
+    }
+  }
+}

--- a/bin/bootstrap_system.sh
+++ b/bin/bootstrap_system.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# This script is intended to install the minimum requirement to start
+# developing judgels in ubuntu22.04
+
+set -eu -o pipefail
+
+: ${JUDGELS_HOME:=$(cd "$(dirname $0)"/..; pwd)}
+export JUDGELS_HOME
+
+if [[ -t 1 ]] # if on an interactive terminal
+then
+  echo "This script will clobber some system settings. Are you sure you want to"
+  echo -n "continue? "
+  while true
+  do
+    read -p "[yes/no] " ANSWER
+    ANSWER=$(echo "$ANSWER" | tr /a-z/ /A-Z/)
+    if [[ $ANSWER = YES ]]
+    then
+      break
+    elif [[ $ANSWER = NO ]]
+    then
+      echo "OK, Bye!"
+      exit 1
+    fi
+  done
+fi
+
+set -x
+
+# install tools via apt-get
+UBUNTU_JAVA_VERSION="11"
+sudo apt-get --yes install git ssh wget curl unzip vim-common \
+  openjdk-${UBUNTU_JAVA_VERSION}-jdk openjdk-${UBUNTU_JAVA_VERSION}-source \
+  openjdk-${UBUNTU_JAVA_VERSION}-dbg npm mysql-client
+
+# install yarn
+sudo npm install --global yarn
+
+java --version
+npm --version
+yarn --version
+
+# assemble judgels-server-app
+cd $JUDGELS_HOME/judgels-backends/judgels-server-app
+cp var/conf/judgels-server.yml.example var/conf/judgels-server.yml
+../gradlew assemble
+# extract sample data
+mkdir -p var/data
+tar -xf ../../seeds/problems.tar.gz -C var/data/
+tar -xf ../../seeds/lessons.tar.gz -C var/data/
+tar -xf ../../seeds/submissions.tar.gz -C var/data/
+
+# build judgels-client
+cd $JUDGELS_HOME/judgels-client
+cp public/var/conf/judgels-client.js.example public/var/conf/judgels-client.js
+yarn install
+
+
+# mysql server still require its own setup.
+# Installing in localhost ubuntu is trivial:
+# sudo apt-get --yes mysql-server
+#
+# If using docker, a mysql container can be started as follow:
+# docker run --name mysql -e MYSQL_ROOT_PASSWORD=judgels-root \
+#   -e MYSQL_USER=judgels -e MYSQL_PASSWORD=judgels \
+#   -e MYSQL_DATABASE=judgels -d mysql:8
+#
+# After mysql server is up, insert sample data into judgels db.
+# mysql -h ${MYSQL_HOST} -u judgels -p judgels < $JUDGELS_HOME/seeds/judgels.sql
+#
+# Point judgels-server.yml to the mysql host/ip as needed.
+# sed -i "s|jdbc:mysql://localhost|jdbc:mysql://${MYSQL_HOST}|g" \
+#   $JUDGELS_HOME/judgels-backends/judgels-server-app/var/conf/judgels-server.yml
+#
+# The remaining instructions to start the app is available at:
+# https://github.com/ia-toki/judgels/wiki/Dev's-Guide:-Running-from-source

--- a/bin/create-mysql-user.sql
+++ b/bin/create-mysql-user.sql
@@ -1,0 +1,3 @@
+CREATE USER 'judgels'@'%' IDENTIFIED BY 'judgels';
+GRANT ALL PRIVILEGES ON * . * TO 'judgels'@'%';
+FLUSH PRIVILEGES;

--- a/judgels-backends/.gitignore
+++ b/judgels-backends/.gitignore
@@ -8,6 +8,7 @@ generated_tests/
 
 data/
 
+.devcontainer/*
 .idea/
 .ideaDataSources/
 *.iml


### PR DESCRIPTION
This patch add initial configs for devcontainer, development inside container using vscode.
https://code.visualstudio.com/docs/devcontainers/containers

To use it, simply open judgels as follow:

```
$ git clone https://github.com/ia-toki/judgels.git
$ cd judgels
$ code .
```

Different container runtimes might need additional step. For example, with colima on macOS, the source code directory need to be mounted on start such as follow:

```
$ colima start --cpu 6 --memory 16 --mount $JUDGELS_HOME:$JUDGELS_HOME:w
```

Where $JUDGELS_HOME is an environment variable to judgels source code path in host filesystem.

Testing:
- Successfully compile the code with devcontainer on macOS

Resolve #541 