### PR TITLE
feat: Upgrade mysql-connector-java to 8.0.33

### DIFF
--- a/judgels-backends/gradle.properties
+++ b/judgels-backends/gradle.properties
@@ -20,7 +20,7 @@ immutablesVersion = 2.7.3
 jacksonVersion = 2.10.0
 jaxRsApiVersion = 2.1
 jerseyVersion = 2.30
-mysqlConnectorJavaVersion = 5.1.44
+mysqlConnectorJavaVersion = 8.0.33
 rabbitmqAmqpClientVersion = 4.2.1
 slf4jVersion = 1.7.25
 


### PR DESCRIPTION
mysql 8 change its default authentication from mysql_native_password to caching_sha2_password.

https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password

Upgrading mysql-connector-java will allow seamless connection to the latest MySQL version without the need to set WITH mysql_native_password manually.

Testing:
- Run mysql container such as follow:
```
docker run --name mysql -e MYSQL_ROOT_PASSWORD=judgels-root \
  -e MYSQL_USER=judgels -e MYSQL_PASSWORD=judgels \
  -e MYSQL_DATABASE=judgels -d mysql:8
```
- Successfully run `../gradlew dbMigrate` in devcontainer

Resolve #543