### PR TITLE
feat: accept javascript programming language

### DIFF
--- a/judgels-backends/judgels-grader-app/Dockerfile
+++ b/judgels-backends/judgels-grader-app/Dockerfile
@@ -58,7 +58,7 @@ LABEL org.opencontainers.image.revision $VCS_REF
 COPY --from=0 /isolate/isolate /judgels/isolate/bin/
 COPY --from=0 /usr/local/etc/isolate /usr/local/etc/
 COPY --from=0 /moe/eval/iwrapper /judgels/isolate/bin/
-#COPY build/distributions .
+COPY build/distributions .
 
 ENTRYPOINT ["./init.sh"]
 CMD ["server"]

--- a/judgels-backends/judgels-grader-app/Dockerfile
+++ b/judgels-backends/judgels-grader-app/Dockerfile
@@ -19,11 +19,16 @@ ENV RUSTUP_HOME /usr
 ENV XDG_CACHE_HOME /tmp
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 ENV PATH $JAVA_HOME/bin:$PATH
-ENV NODE_VERSION=18.0.0
-ENV NVM_DIR=/root/.nvm
+ENV NODE_MAJOR 18
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install software-properties-common gpg-agent \
+    && apt-get install -y ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install software-properties-common gpg-agent  \
     && add-apt-repository -y ppa:pypy/ppa \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt-get -y --no-install-recommends install \
@@ -39,12 +44,10 @@ RUN apt-get update \
        openjdk-11-jre \
        pypy3 \
        python3 \
+       nodejs \
     && ln -s /usr/bin/gcc-11 /usr/bin/gcc \
     && ln -s /usr/bin/g++-11 /usr/bin/g++ \
     && curl -sSf https://sh.rustup.rs/ | bash -s -- -y -q --default-toolchain=1.57.0 \
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
-    && . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION} \
-    && cp $NVM_DIR/versions/node/v${NODE_VERSION}/bin/node /usr/bin/ \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /judgels/grader
@@ -58,7 +61,7 @@ LABEL org.opencontainers.image.revision $VCS_REF
 COPY --from=0 /isolate/isolate /judgels/isolate/bin/
 COPY --from=0 /usr/local/etc/isolate /usr/local/etc/
 COPY --from=0 /moe/eval/iwrapper /judgels/isolate/bin/
-COPY build/distributions .
+#COPY build/distributions .
 
 ENTRYPOINT ["./init.sh"]
 CMD ["server"]

--- a/judgels-backends/judgels-grader-app/Dockerfile
+++ b/judgels-backends/judgels-grader-app/Dockerfile
@@ -19,20 +19,18 @@ ENV RUSTUP_HOME /usr
 ENV XDG_CACHE_HOME /tmp
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 ENV PATH $JAVA_HOME/bin:$PATH
-ENV NODE_MAJOR 18
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates curl gnupg \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install software-properties-common gpg-agent  \
     && add-apt-repository -y ppa:pypy/ppa \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt-get -y --no-install-recommends install \
-       curl \
        openssh-client \
        rsync \
     && apt-get -y --no-install-recommends install \
@@ -40,11 +38,11 @@ RUN apt-get update \
        g++-11 \
        golang \
        libcap-dev \
+       nodejs \
        openjdk-11-jdk-headless \
        openjdk-11-jre \
        pypy3 \
        python3 \
-       nodejs \
     && ln -s /usr/bin/gcc-11 /usr/bin/gcc \
     && ln -s /usr/bin/g++-11 /usr/bin/g++ \
     && curl -sSf https://sh.rustup.rs/ | bash -s -- -y -q --default-toolchain=1.57.0 \

--- a/judgels-backends/judgels-grader-app/Dockerfile
+++ b/judgels-backends/judgels-grader-app/Dockerfile
@@ -61,7 +61,7 @@ LABEL org.opencontainers.image.revision $VCS_REF
 COPY --from=0 /isolate/isolate /judgels/isolate/bin/
 COPY --from=0 /usr/local/etc/isolate /usr/local/etc/
 COPY --from=0 /moe/eval/iwrapper /judgels/isolate/bin/
-#COPY build/distributions .
+COPY build/distributions .
 
 ENTRYPOINT ["./init.sh"]
 CMD ["server"]

--- a/judgels-backends/judgels-grader-app/Dockerfile
+++ b/judgels-backends/judgels-grader-app/Dockerfile
@@ -19,6 +19,8 @@ ENV RUSTUP_HOME /usr
 ENV XDG_CACHE_HOME /tmp
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 ENV PATH $JAVA_HOME/bin:$PATH
+ENV NODE_VERSION=18.0.0
+ENV NVM_DIR=/root/.nvm
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install software-properties-common gpg-agent \
@@ -40,6 +42,9 @@ RUN apt-get update \
     && ln -s /usr/bin/gcc-11 /usr/bin/gcc \
     && ln -s /usr/bin/g++-11 /usr/bin/g++ \
     && curl -sSf https://sh.rustup.rs/ | bash -s -- -y -q --default-toolchain=1.57.0 \
+    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
+    && . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION} \
+    && cp $NVM_DIR/versions/node/v${NODE_VERSION}/bin/node /usr/bin/ \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /judgels/grader
@@ -53,7 +58,7 @@ LABEL org.opencontainers.image.revision $VCS_REF
 COPY --from=0 /isolate/isolate /judgels/isolate/bin/
 COPY --from=0 /usr/local/etc/isolate /usr/local/etc/
 COPY --from=0 /moe/eval/iwrapper /judgels/isolate/bin/
-COPY build/distributions .
+#COPY build/distributions .
 
 ENTRYPOINT ["./init.sh"]
 CMD ["server"]

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/GradingLanguageRegistry.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/GradingLanguageRegistry.java
@@ -30,11 +30,11 @@ public class GradingLanguageRegistry {
             new Cpp20GradingLanguage(),
             new GoGradingLanguage(),
             new JavaGradingLanguage(),
+            new JavaScriptNode18GradingLanguage(),
             new PascalGradingLanguage(),
             new PyPy3GradingLanguage(),
             new Python3GradingLanguage(),
             new Rust2021GradingLanguage(),
-            new JavaScriptNode18GradingLanguage(),
             new OutputOnlyGradingLanguage());
 
     private static final List<GradingLanguage> VISIBLE_LANGUAGES = LANGUAGES.stream()

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/GradingLanguageRegistry.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/GradingLanguageRegistry.java
@@ -13,7 +13,7 @@ import judgels.gabriel.languages.cpp.Cpp20GradingLanguage;
 import judgels.gabriel.languages.cpp.CppGradingLanguage;
 import judgels.gabriel.languages.go.GoGradingLanguage;
 import judgels.gabriel.languages.java.JavaGradingLanguage;
-import judgels.gabriel.languages.javascript.JavascriptNode18GradingLanguage;
+import judgels.gabriel.languages.javascript.JavaScriptNode18GradingLanguage;
 import judgels.gabriel.languages.pascal.PascalGradingLanguage;
 import judgels.gabriel.languages.python.PyPy3GradingLanguage;
 import judgels.gabriel.languages.python.Python3GradingLanguage;
@@ -34,7 +34,7 @@ public class GradingLanguageRegistry {
             new PyPy3GradingLanguage(),
             new Python3GradingLanguage(),
             new Rust2021GradingLanguage(),
-            new JavascriptNode18GradingLanguage(),
+            new JavaScriptNode18GradingLanguage(),
             new OutputOnlyGradingLanguage());
 
     private static final List<GradingLanguage> VISIBLE_LANGUAGES = LANGUAGES.stream()

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/GradingLanguageRegistry.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/GradingLanguageRegistry.java
@@ -13,6 +13,7 @@ import judgels.gabriel.languages.cpp.Cpp20GradingLanguage;
 import judgels.gabriel.languages.cpp.CppGradingLanguage;
 import judgels.gabriel.languages.go.GoGradingLanguage;
 import judgels.gabriel.languages.java.JavaGradingLanguage;
+import judgels.gabriel.languages.javascript.JavascriptNode18GradingLanguage;
 import judgels.gabriel.languages.pascal.PascalGradingLanguage;
 import judgels.gabriel.languages.python.PyPy3GradingLanguage;
 import judgels.gabriel.languages.python.Python3GradingLanguage;
@@ -33,6 +34,7 @@ public class GradingLanguageRegistry {
             new PyPy3GradingLanguage(),
             new Python3GradingLanguage(),
             new Rust2021GradingLanguage(),
+            new JavascriptNode18GradingLanguage(),
             new OutputOnlyGradingLanguage());
 
     private static final List<GradingLanguage> VISIBLE_LANGUAGES = LANGUAGES.stream()

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/javascript/JavaScriptNode18GradingLanguage.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/javascript/JavaScriptNode18GradingLanguage.java
@@ -4,10 +4,10 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import judgels.gabriel.api.GradingLanguage;
 
-public class JavascriptNode18GradingLanguage implements GradingLanguage {
+public class JavaScriptNode18GradingLanguage implements GradingLanguage {
     @Override
     public String getName() {
-        return "Javascript (Node.js 18)";
+        return "JavaScript (Node 18)";
     }
 
     @Override

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/javascript/JavascriptNode18GradingLanguage.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/languages/javascript/JavascriptNode18GradingLanguage.java
@@ -1,0 +1,37 @@
+package judgels.gabriel.languages.javascript;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import judgels.gabriel.api.GradingLanguage;
+
+public class JavascriptNode18GradingLanguage implements GradingLanguage {
+    @Override
+    public String getName() {
+        return "Javascript (Node.js 18)";
+    }
+
+    @Override
+    public boolean isVisible() {
+        return true;
+    }
+
+    @Override
+    public List<String> getAllowedExtensions() {
+        return ImmutableList.of("js");
+    }
+
+    @Override
+    public List<String> getCompilationCommand(String sourceFilename, String... sourceFilenames) {
+        return ImmutableList.of("/bin/true");
+    }
+
+    @Override
+    public String getExecutableFilename(String sourceFilename) {
+        return sourceFilename;
+    }
+
+    @Override
+    public List<String> getExecutionCommand(String sourceFilename) {
+        return ImmutableList.of("/usr/bin/node", sourceFilename);
+    }
+}

--- a/judgels-client/src/modules/api/gabriel/language.js
+++ b/judgels-client/src/modules/api/gabriel/language.js
@@ -14,6 +14,7 @@ export const gradingLanguageNamesMap = {
   Python3: 'Python 3',
   PyPy3: 'PyPy 3',
   Rust2021: 'Rust 2021',
+  JavascriptNode18: 'Javascript (Node.js 18)',
   OutputOnly: '-',
 };
 
@@ -28,6 +29,7 @@ export const gradingLanguageFamiliesMap = {
   Python3: 'Python',
   PyPy3: 'Python',
   Rust2021: 'Rust',
+  JavascriptNode18: 'Javascript',
 };
 
 export const gradingLanguageFilenameExtensionsMap = {
@@ -41,6 +43,7 @@ export const gradingLanguageFilenameExtensionsMap = {
   Python3: ['py'],
   PyPy3: ['py'],
   Rust2021: ['rs'],
+  JavascriptNode18: ['js'],
   OutputOnly: ['zip'],
 };
 
@@ -55,6 +58,7 @@ export const gradingLanguageSyntaxHighlighterValueMap = {
   Python3: 'python',
   PyPy3: 'python',
   Rust2021: 'rust',
+  JavascriptNode18: 'javascript',
   OutputOnly: '',
 };
 
@@ -69,6 +73,7 @@ export const gradingLanguageEditorSubmissionFilenamesMap = {
   Python3: 'solution.py',
   PyPy3: 'solution.py',
   Rust2021: 'solution.rs',
+  JavascriptNode18: 'solution.js',
 };
 
 export const gradingLanguageEditorSubmissionHintsMap = {

--- a/judgels-client/src/modules/api/gabriel/language.js
+++ b/judgels-client/src/modules/api/gabriel/language.js
@@ -10,11 +10,11 @@ export const gradingLanguageNamesMap = {
   Cpp20: 'C++20',
   Go: 'Go',
   Java: 'Java 11',
+  JavaScriptNode18: 'JavaScript (Node 18)',
   Pascal: 'Pascal',
   Python3: 'Python 3',
   PyPy3: 'PyPy 3',
   Rust2021: 'Rust 2021',
-  JavascriptNode18: 'Javascript (Node.js 18)',
   OutputOnly: '-',
 };
 
@@ -25,11 +25,11 @@ export const gradingLanguageFamiliesMap = {
   Cpp20: 'C++',
   Go: 'Go',
   Java: 'Java',
+  JavaScriptNode18: 'JavaScript',
   Pascal: 'Pascal',
   Python3: 'Python',
   PyPy3: 'Python',
   Rust2021: 'Rust',
-  JavascriptNode18: 'Javascript',
 };
 
 export const gradingLanguageFilenameExtensionsMap = {
@@ -39,11 +39,11 @@ export const gradingLanguageFilenameExtensionsMap = {
   Cpp20: ['cc', 'cpp'],
   Go: ['go'],
   Java: ['java'],
+  JavaScriptNode18: ['js'],
   Pascal: ['pas'],
   Python3: ['py'],
   PyPy3: ['py'],
   Rust2021: ['rs'],
-  JavascriptNode18: ['js'],
   OutputOnly: ['zip'],
 };
 
@@ -54,11 +54,11 @@ export const gradingLanguageSyntaxHighlighterValueMap = {
   Cpp20: 'cpp',
   Go: 'go',
   Java: 'java',
+  JavaScriptNode18: 'JavaScript',
   Pascal: 'pascal',
   Python3: 'python',
   PyPy3: 'python',
   Rust2021: 'rust',
-  JavascriptNode18: 'javascript',
   OutputOnly: '',
 };
 
@@ -69,11 +69,11 @@ export const gradingLanguageEditorSubmissionFilenamesMap = {
   Cpp20: 'solution.cpp',
   Go: 'solution.go',
   Java: 'Solution.java',
+  JavaScriptNode18: 'solution.js',
   Pascal: 'solution.pas',
   Python3: 'solution.py',
   PyPy3: 'solution.py',
   Rust2021: 'solution.rs',
-  JavascriptNode18: 'solution.js',
 };
 
 export const gradingLanguageEditorSubmissionHintsMap = {


### PR DESCRIPTION
Resolve #439 

For now, I choose to use Node.js version v18 as the Grader Runtime.

Local Testing:
![image](https://github.com/ia-toki/judgels/assets/21070615/ef00f8b0-4731-4b51-b20d-75e3813fedfd)

Example submission file for the A+A problem:
```
"use strict";
 
process.stdin.resume();
process.stdin.setEncoding("utf-8");
 
let inputString = "";
let currentLine = 0;
 
process.stdin.on("data", (inputStdin) => {
    inputString += inputStdin;
});
 
process.stdin.on("end", (_) => {
    inputString = inputString
        .trim()
        .split("\n")
        .map((string) => {
            return string.trim();
        });
 
    main();
});
 
function readline() {
    return inputString[currentLine++];
}
 
function print(data) {
    console.log(data);
}
 
function main() {
    let n = Number(readline());

    print(n*2);
}
```
