### PR TITLE
fix: last modified at field after uploading files

### DIFF
--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/FileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/FileSystem.java
@@ -28,4 +28,7 @@ public interface FileSystem {
     default String readFromFile(Path filePath) {
         return new String(readByteArrayFromFile(filePath));
     }
+
+    void copyDirectory(Path src, Path dest);
+    void copy(Path src, Path dest);
 }

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/aws/AwsFileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/aws/AwsFileSystem.java
@@ -213,4 +213,14 @@ public final class AwsFileSystem implements FileSystem {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public void copyDirectory(Path src, Path dest) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void copy(Path src, Path dest) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/duplex/DuplexFileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/duplex/DuplexFileSystem.java
@@ -102,4 +102,14 @@ public final class DuplexFileSystem implements FileSystem {
             return aws.readByteArrayFromFile(filePath);
         }
     }
+
+    @Override
+    public void copyDirectory(Path src, Path dest) {
+        local.copyDirectory(src, dest);
+    }
+
+    @Override
+    public void copy(Path src, Path dest) {
+        local.copy(src, dest);
+    }
 }

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/local/LocalFileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/local/LocalFileSystem.java
@@ -1,5 +1,8 @@
 package judgels.fs.local;
 
+import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -23,6 +26,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import judgels.fs.FileInfo;
@@ -211,6 +215,24 @@ public final class LocalFileSystem implements FileSystem {
             return ByteStreams.toByteArray(stream);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void copyDirectory(Path src, Path dest) {
+        try (Stream<Path> stream = Files.walk(src)) {
+            stream.forEach(source -> copy(source, dest.resolve(src.relativize(source))));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void copy(Path src, Path dest) {
+        try {
+            Files.copy(src, dest, REPLACE_EXISTING, COPY_ATTRIBUTES);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 }

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/user/avatar/UserAvatarIntegrationTestModule.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/user/avatar/UserAvatarIntegrationTestModule.java
@@ -78,5 +78,11 @@ public class UserAvatarIntegrationTestModule {
         public byte[] readByteArrayFromFile(Path filePath) {
             return new byte[0];
         }
+
+        @Override
+        public void copyDirectory(Path src, Path dest) {}
+
+        @Override
+        public void copy(Path src, Path dest) {}
     }
 }

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/fs/InMemoryFileSystem.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/fs/InMemoryFileSystem.java
@@ -135,4 +135,10 @@ public class InMemoryFileSystem implements FileSystem {
     public byte[] readByteArrayFromFile(Path filePath) {
         return fs.get(filePath);
     }
+
+    @Override
+    public void copyDirectory(Path src, Path dest) {}
+
+    @Override
+    public void copy(Path src, Path dest) {}
 }


### PR DESCRIPTION
Resolve #540

**Root Cause:**
Git [doesn't actually record timestamps for files](https://stackoverflow.com/questions/2179722/checking-out-old-files-with-original-create-modified-timestamps/2179825#2179825). Consequently, when a repository is cloned, the timestamp becomes the current time.

**Solution:**
Rather than using the git clone API, I utilize the filesystem API to recursively copy one git directory to another and subsequently set the origin URI.
