### PR TITLE
feat: add filter search on submission page

### DIFF
--- a/judgels-client/src/components/SubmissionFilterWidget/SubmissionFilterForm.scss
+++ b/judgels-client/src/components/SubmissionFilterWidget/SubmissionFilterForm.scss
@@ -1,7 +1,7 @@
 .submission-filter-form {
   .form-username {
     min-width: 250px;
-    button {
+    .form-group__select button {
       width: 200px;
     }
   }

--- a/judgels-client/src/components/forms/FormSelect2/FormSelect2.jsx
+++ b/judgels-client/src/components/forms/FormSelect2/FormSelect2.jsx
@@ -11,6 +11,10 @@ export function FormSelect2({ input, className, label, meta, optionValues, optio
     return <MenuItem active={modifiers.active} key={value} onClick={handleClick} text={optionNamesMap[value]} />;
   };
 
+  const filterOption = (query, option) => {
+    return option.toLowerCase().indexOf(query.toLowerCase()) >= 0;
+  };
+
   const { onChange, ...inputProps } = input;
 
   return (
@@ -18,11 +22,12 @@ export function FormSelect2({ input, className, label, meta, optionValues, optio
       <Select
         className={classNames('form-group__select', getIntentClassName(meta))}
         items={optionValues}
+        itemPredicate={filterOption}
         itemRenderer={renderOption}
         activeItem={inputProps.value}
         onItemSelect={onChange}
-        inputProps={inputProps}
-        filterable={false}
+        inputProps={{ ...inputProps, autoComplete: 'off' }}
+        filterable={true}
         popoverProps={{ usePortal: false }}
       >
         <Button

--- a/judgels-client/src/components/forms/FormSelect2/FormSelect2.jsx
+++ b/judgels-client/src/components/forms/FormSelect2/FormSelect2.jsx
@@ -7,6 +7,8 @@ import { getIntent, getIntentClassName } from '../meta';
 import { FormInputValidation } from '../FormInputValidation/FormInputValidation';
 
 export function FormSelect2({ input, className, label, meta, optionValues, optionNamesMap, small }) {
+  const isUsingFilter = optionValues.length >= 10;
+
   const renderOption = (value, { handleClick, modifiers }) => {
     return <MenuItem active={modifiers.active} key={value} onClick={handleClick} text={optionNamesMap[value]} />;
   };
@@ -22,12 +24,12 @@ export function FormSelect2({ input, className, label, meta, optionValues, optio
       <Select
         className={classNames('form-group__select', getIntentClassName(meta))}
         items={optionValues}
-        itemPredicate={filterOption}
+        itemPredicate={isUsingFilter ? filterOption : undefined}
         itemRenderer={renderOption}
         activeItem={inputProps.value}
         onItemSelect={onChange}
         inputProps={{ ...inputProps, autoComplete: 'off' }}
-        filterable={true}
+        filterable={isUsingFilter}
         popoverProps={{ usePortal: false }}
       >
         <Button


### PR DESCRIPTION
Resolves #288 

Implementation of filtering is done in the front end by allowing case-insensitive.

Added autocomplete props to prevent default autocomplete from HTML input element (see pic).

![photo_2023-11-30_19-32-34](https://github.com/ia-toki/judgels/assets/22031760/71963928-d0db-466b-9d36-7035a6400b5a)

