### PR TITLE
fix: Back not reflect proper state in profile

### DIFF
--- a/judgels-client/src/routes/jophiel/profiles/single/SingleProfileRoutes.jsx
+++ b/judgels-client/src/routes/jophiel/profiles/single/SingleProfileRoutes.jsx
@@ -12,8 +12,8 @@ import ContestHistoryPage from './contestHistory/ContestHistoryPage/ContestHisto
 import SubmissionHistoryPage from './submissionHistory/SubmissionHistoryPage/SubmissionHistoryPage';
 import { selectUserJid, selectUsername } from '../../modules/profileSelectors';
 
-function SingleProfileRoutes({ userJid, username }) {
-  if (!userJid) {
+function SingleProfileRoutes({ match, userJid, username }) {
+  if (!userJid || username !== match.params.username) {
     return <LoadingState large />;
   }
 

--- a/judgels-client/src/routes/jophiel/profiles/single/SingleProfileRoutes.jsx
+++ b/judgels-client/src/routes/jophiel/profiles/single/SingleProfileRoutes.jsx
@@ -13,6 +13,8 @@ import SubmissionHistoryPage from './submissionHistory/SubmissionHistoryPage/Sub
 import { selectUserJid, selectUsername } from '../../modules/profileSelectors';
 
 function SingleProfileRoutes({ match, userJid, username }) {
+  // Optimization:
+  // We wait until we get the username from the backend only if the current username is different from the persisted one.
   if (!userJid || username !== match.params.username) {
     return <LoadingState large />;
   }


### PR DESCRIPTION
Resolves: #405 

Issues happened because the username hadn't properly loaded by `jophiel` causing the API to call the persisted username for `submission-history` and `contest-history`