### PR TITLE
feat(client): Simplify chapter problem worksheet header

### DIFF
--- a/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemStatementCard/ProblemStatementCard.jsx
+++ b/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemStatementCard/ProblemStatementCard.jsx
@@ -5,7 +5,13 @@ import RichStatementText from '../../../RichStatementText/RichStatementText';
 
 import './ProblemStatementCard.scss';
 
-export function ProblemStatementCard({ alias, statement: { title, text }, limits: { timeLimit, memoryLimit } }) {
+export function ProblemStatementCard({
+  alias,
+  statement: { title, text },
+  limits: { timeLimit, memoryLimit },
+  showTitle = true,
+  showLimits = true,
+}) {
   const renderTimeLimit = timeLimit => {
     if (!timeLimit) {
       return '-';
@@ -28,22 +34,26 @@ export function ProblemStatementCard({ alias, statement: { title, text }, limits
 
   return (
     <ContentCard>
-      <h2 className="programming-problem-statement__name">
-        {alias ? `${alias}. ` : ''}
-        {title}
-      </h2>
-      <HTMLTable compact className="programming-problem-statement__limits">
-        <tbody>
-          <tr>
-            <td>Time limit</td>
-            <td>{renderTimeLimit(timeLimit)}</td>
-          </tr>
-          <tr>
-            <td>Memory limit</td>
-            <td>{renderMemoryLimit(memoryLimit)}</td>
-          </tr>
-        </tbody>
-      </HTMLTable>
+      {showTitle && (
+        <h2 className="programming-problem-statement__name">
+          {alias ? `${alias}. ` : ''}
+          {title}
+        </h2>
+      )}
+      {showLimits && (
+        <HTMLTable compact className="programming-problem-statement__limits">
+          <tbody>
+            <tr>
+              <td>Time limit</td>
+              <td>{renderTimeLimit(timeLimit)}</td>
+            </tr>
+            <tr>
+              <td>Memory limit</td>
+              <td>{renderMemoryLimit(memoryLimit)}</td>
+            </tr>
+          </tbody>
+        </HTMLTable>
+      )}
       <div className="programming-problem-statement__text">
         <RichStatementText key={alias}>{text}</RichStatementText>
       </div>

--- a/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemStatementCard/ProblemStatementCard.scss
+++ b/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemStatementCard/ProblemStatementCard.scss
@@ -7,7 +7,7 @@
   margin-top: 15px;
   margin-left: auto;
   margin-right: auto;
-  margin-bottom: 35px;
+  margin-bottom: 60px;
 
   td,
   th {
@@ -18,8 +18,6 @@
 }
 
 .programming-problem-statement__text {
-  margin-top: 25px;
-
   embed {
     width: 100%;
     min-height: 800px;

--- a/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemWorksheetCard.jsx
+++ b/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemWorksheetCard.jsx
@@ -6,12 +6,22 @@ import './ProblemWorksheetCard.scss';
 export function ProblemWorksheetCard({
   alias,
   worksheet: { statement, limits, submissionConfig, reasonNotAllowedToSubmit },
+  showTitle,
+  showLimits,
   submissionWarning,
   gradingLanguage,
   onSubmit,
 }) {
   const renderStatement = () => {
-    return <ProblemStatementCard alias={alias} statement={statement} limits={limits} />;
+    return (
+      <ProblemStatementCard
+        alias={alias}
+        statement={statement}
+        limits={limits}
+        showTitle={showTitle}
+        showLimits={showLimits}
+      />
+    );
   };
 
   const renderSubmission = () => {

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/ChapterProblemPage/ChapterProblemPage.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/ChapterProblemPage/ChapterProblemPage.jsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from '@blueprintjs/icons';
+import { ChevronRight, Home } from '@blueprintjs/icons';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
@@ -79,23 +79,25 @@ export class ChapterProblemPage extends Component {
 
   renderHeader = () => {
     const { course, chapter, match } = this.props;
+    const { response } = this.state;
+    const problemTitle = response && response.worksheet.statement.title;
 
     return (
       <div className="chapter-problem-page__title">
         <h3>
           <Link className="chapter-problem-page__title--link" to={`/courses/${course.slug}`}>
-            {course.name}
+            <Home />
           </Link>
           &nbsp;
           <ChevronRight className="chapter-problem-page__title--chevron" size={20} />
           &nbsp;
           <Link className="chapter-problem-page__title--link" to={`/courses/${course.slug}/chapters/${chapter.alias}`}>
-            {chapter.alias}. {chapter.name}
+            {chapter.alias}
           </Link>
           &nbsp;
           <ChevronRight className="chapter-problem-page__title--chevron" size={20} />
           &nbsp;
-          {match.params.problemAlias}
+          {match.params.problemAlias}. {problemTitle}
         </h3>
 
         {this.renderProgress()}

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/ChapterProblemPage/ChapterProblemPage.scss
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/ChapterProblemPage/ChapterProblemPage.scss
@@ -13,6 +13,7 @@
 }
 
 .chapter-problem-page__title h3 {
+  font-size: 22px !important;
   line-height: 24px !important;
   margin-bottom: 0;
 }
@@ -24,9 +25,14 @@
     text-decoration: none;
     color: $primary-color !important;
   }
+
+  & .bp5-icon {
+    height: 22px;
+  }
 }
 
 .chapter-problem-page__title--chevron {
+  height: 24px;
   color: $dark-secondary-background-color !important;
 }
 

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemPage.test.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemPage.test.jsx
@@ -71,6 +71,6 @@ describe('ChapterProblemProgrammingPage', () => {
   });
 
   test('page', () => {
-    expect(wrapper.text()).toContain('A. Problem');
+    expect(wrapper.text()).toContain('This is problem description');
   });
 });

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemStatementPage/ChapterProblemStatementPage.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemStatementPage/ChapterProblemStatementPage.jsx
@@ -60,7 +60,16 @@ function ChapterProblemStatementPage({ worksheet, renderNavigation }) {
       );
     }
 
-    return <ProblemWorksheetCard alias={problem.alias} worksheet={worksheet.worksheet} />;
+    const isIntroductoryProblem = !worksheet.worksheet.submissionConfig.gradingEngine.endsWith('Subtasks');
+
+    return (
+      <ProblemWorksheetCard
+        alias={problem.alias}
+        worksheet={worksheet.worksheet}
+        showTitle={!isIntroductoryProblem}
+        showLimits={!isIntroductoryProblem}
+      />
+    );
   };
 
   return (

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/resources/ChapterResourcesPage/ChapterResourcesPage.scss
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/resources/ChapterResourcesPage/ChapterResourcesPage.scss
@@ -7,7 +7,8 @@
 
 .chapter-resources-page__title {
   margin-bottom: 20px;
-  line-height: 20px !important;
+  font-size: 22px !important;
+  line-height: 24px !important;
 }
 
 .chapter-resources-page__title--link {
@@ -17,8 +18,13 @@
     text-decoration: none;
     color: $primary-color !important;
   }
+
+  & .bp5-icon {
+    height: 22px;
+  }
 }
 
 .chapter-resources-page__title--chevron {
+  height: 24px;
   color: $dark-secondary-background-color !important;
 }


### PR DESCRIPTION
We emphasize the problem name:

|Before|After|
|-|-|
|<img width="692" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/d15508a7-239d-4b29-bb58-0cba6e461643">|<img width="540" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/25232f84-f49e-4b85-ab26-dc54e6af35f1">|

For "introductory" problems, we also remove the time limits as new students don't necessarily have to know about them:

|Before|After|
|-|-|
|<img width="880" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/9cb73c5e-59c3-4893-8e0c-d93dd5867a84">|<img width="883" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/0b1fcc92-6925-402b-981c-06ef592b0dd3">|