### PR TITLE
fix(client): fix contest module weird behavior when first enabling a module

### DIFF
--- a/judgels-client/src/routes/contests/contests/single/components/ContestEditModulesTab/ContestEditModulesTab.jsx
+++ b/judgels-client/src/routes/contests/contests/single/components/ContestEditModulesTab/ContestEditModulesTab.jsx
@@ -41,9 +41,9 @@ class ContestEditModulesTab extends Component {
 
     return (
       <div className="contest-edit-dialog__content">
-        {this.renderEnabledModules(enabledModules)}
+        <>{this.renderEnabledModules(enabledModules)}</>
         <hr />
-        {this.renderDisabledModules(disabledModules)}
+        <>{this.renderDisabledModules(disabledModules)}</>
       </div>
     );
   };


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="597" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/569b8666-dd28-4c20-a239-b38412c0ceed">|<img width="601" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/ac7e485d-8508-43f5-a32e-f19bdf2a4101">|