### PR TITLE
feat(client): move chapter navigation from statement to code editor

### DIFF
--- a/judgels-client/src/components/ButtonLink/ButtonLink.jsx
+++ b/judgels-client/src/components/ButtonLink/ButtonLink.jsx
@@ -1,8 +1,11 @@
-import { Classes, Intent } from '@blueprintjs/core';
+import { Button, Classes, Intent } from '@blueprintjs/core';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
-export function ButtonLink({ className, active, intent, small, large, ...linkProps }) {
+export function ButtonLink({ className, disabled, active, intent, small, large, ...linkProps }) {
+  if (disabled) {
+    return <Button {...linkProps} small={small} disabled />;
+  }
   return (
     <Link
       {...linkProps}

--- a/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionEditor/ProblemSubmissionEditor.jsx
+++ b/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionEditor/ProblemSubmissionEditor.jsx
@@ -88,6 +88,7 @@ export class ProblemSubmissionEditor extends Component {
       config: { gradingEngine, gradingLanguageRestriction },
       reasonNotAllowedToSubmit,
       preferredGradingLanguage,
+      renderNavigation,
     } = this.props;
 
     if (reasonNotAllowedToSubmit) {
@@ -162,13 +163,17 @@ export class ProblemSubmissionEditor extends Component {
                 submission={this.state.submission}
                 submissionUrl={this.state.submissionUrl}
               />
-              <Button
-                type="submit"
-                text="Submit"
-                intent={Intent.PRIMARY}
-                loading={submitting}
-                disabled={!dirty || this.currentTimeout}
-              />
+              <div className="editor-buttons">
+                <Button
+                  type="submit"
+                  text="Submit"
+                  small
+                  intent={Intent.PRIMARY}
+                  loading={submitting}
+                  disabled={!dirty || this.currentTimeout}
+                />
+                <div className="editor-navigation">{renderNavigation({ hidePrev: true })}</div>
+              </div>
             </form>
           );
         }}

--- a/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionEditor/ProblemSubmissionEditor.scss
+++ b/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionEditor/ProblemSubmissionEditor.scss
@@ -42,6 +42,15 @@
         margin-left: auto;
       }
     }
+
+    .editor-buttons {
+      display: flex;
+      width: 100%;
+
+      .editor-navigation {
+        margin-left: auto;
+      }
+    }
   }
 
   .responsive-button {

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/ChapterProblemPage/ChapterProblemPage.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/ChapterProblemPage/ChapterProblemPage.jsx
@@ -152,7 +152,7 @@ export class ChapterProblemPage extends Component {
     return <ChapterProblemProgressTag verdict={progress.verdict} />;
   };
 
-  renderNavigation = () => {
+  renderNavigation = ({ hidePrev } = { hidePrev: false }) => {
     const { course, chapter, chapters } = this.props;
     const { response } = this.state;
     if (!response) {
@@ -164,9 +164,10 @@ export class ChapterProblemPage extends Component {
       <ChapterNavigation
         courseSlug={course.slug}
         chapterAlias={chapter.alias}
-        previousResourcePath={previousResourcePath}
+        previousResourcePath={hidePrev ? null : previousResourcePath}
         nextResourcePath={nextResourcePath}
         chapters={chapters}
+        disableNext={response.progress?.verdict.code !== VerdictCode.AC}
       />
     );
   };

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemPage.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemPage.jsx
@@ -6,8 +6,8 @@ import './ChapterProblemPage.scss';
 export default function ChapterProblemPage({ worksheet, renderNavigation }) {
   return (
     <div className="chapter-programming-problem-page">
-      <ChapterProblemStatementPage worksheet={worksheet} renderNavigation={renderNavigation} />
-      <ChapterProblemStatementRoutes worksheet={worksheet} />
+      <ChapterProblemStatementPage worksheet={worksheet} />
+      <ChapterProblemStatementRoutes worksheet={worksheet} renderNavigation={renderNavigation} />
     </div>
   );
 }

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemStatementPage/ChapterProblemStatementPage.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemStatementPage/ChapterProblemStatementPage.jsx
@@ -10,7 +10,7 @@ import { selectCourseChapter } from '../../../../../modules/courseChapterSelecto
 
 import './ChapterProblemStatementPage.scss';
 
-function ChapterProblemStatementPage({ worksheet, renderNavigation }) {
+function ChapterProblemStatementPage({ worksheet }) {
   const renderTimeLimit = timeLimit => {
     if (!timeLimit) {
       return '-';
@@ -93,10 +93,7 @@ function ChapterProblemStatementPage({ worksheet, renderNavigation }) {
     <ContentCard id="chapter-problem-statement" className="chapter-programming-problem-statement-page">
       {renderStatementHeader()}
       {renderStatement()}
-      <div className="chapter-programming-problem-statement-page__footer">
-        {renderEditorial()}
-        <div className="chapter-programming-problem-statement-page__navigation">{renderNavigation()}</div>
-      </div>
+      <div className="chapter-programming-problem-statement-page__footer">{renderEditorial()}</div>
     </ContentCard>
   );
 }

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemStatementRoutes.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemStatementRoutes.jsx
@@ -6,13 +6,15 @@ import ChapterProblemSubmissionRoutes from './submissions/ChapterProblemSubmissi
 
 import './ChapterProblemStatementRoutes.scss';
 
-export default function ChapterProblemStatementRoutes({ worksheet }) {
+export default function ChapterProblemStatementRoutes({ worksheet, renderNavigation }) {
   const topbarItems = [
     {
       id: '@',
       title: 'Submit',
       routeComponent: Route,
-      render: props => <ChapterProblemWorkspacePage {...props} worksheet={worksheet} />,
+      render: props => (
+        <ChapterProblemWorkspacePage {...props} worksheet={worksheet} renderNavigation={renderNavigation} />
+      ),
     },
     {
       id: 'submissions',

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemWorkspacePage/ChapterProblemWorkspacePage.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemWorkspacePage/ChapterProblemWorkspacePage.jsx
@@ -55,7 +55,7 @@ class ChapterProblemWorkspacePage extends Component {
   };
 
   render() {
-    const { gradingLanguage, worksheet, onGetSubmissionWithSource, onReloadProblem } = this.props;
+    const { gradingLanguage, worksheet, onGetSubmissionWithSource, onReloadProblem, renderNavigation } = this.props;
     const { skeletons, lastSubmission, lastSubmissionSource } = worksheet;
     const { submissionConfig, reasonNotAllowedToSubmit } = worksheet.worksheet;
     const { shouldResetEditor } = this.state;
@@ -88,6 +88,7 @@ class ChapterProblemWorkspacePage extends Component {
         onReset={this.resetEditor}
         onGetSubmissionWithSource={onGetSubmissionWithSource}
         onReloadProblem={onReloadProblem}
+        renderNavigation={renderNavigation}
       />
     );
   }

--- a/judgels-client/src/routes/courses/courses/single/chapters/single/resources/ChapterNavigation/ChapterNavigation.jsx
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/resources/ChapterNavigation/ChapterNavigation.jsx
@@ -3,7 +3,14 @@ import { ChevronLeft, ChevronRight } from '@blueprintjs/icons';
 
 import { ButtonLink } from '../../../../../../../../components/ButtonLink/ButtonLink';
 
-export function ChapterNavigation({ courseSlug, chapterAlias, previousResourcePath, nextResourcePath, chapters }) {
+export function ChapterNavigation({
+  courseSlug,
+  chapterAlias,
+  previousResourcePath,
+  nextResourcePath,
+  chapters,
+  disableNext,
+}) {
   const scrollToTop = () => {
     window.scrollTo(0, 0);
   };
@@ -32,6 +39,7 @@ export function ChapterNavigation({ courseSlug, chapterAlias, previousResourcePa
     return (
       <ButtonLink
         small
+        disabled={disableNext}
         intent={Intent.WARNING}
         to={`/courses/${courseSlug}/chapters/${chapterAlias}${nextResourcePath}`}
         onClick={scrollToTop}


### PR DESCRIPTION
Also, disable Next button if the current problem is not solved yet.

Before

<img width="1376" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/6fd17c6d-43c1-4ae5-80e1-3b2261e4dd61">


After

<img width="1369" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/8df7321a-f689-44b2-91ce-33429318613b">
