### PR TITLE
fix(server): mkdirs before cloning problems

### DIFF
--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/FileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/FileSystem.java
@@ -8,6 +8,7 @@ import java.util.List;
 public interface FileSystem {
     void createDirectory(Path dirPath);
     boolean directoryExists(Path dirPath);
+    void copyDirectory(Path srcPath, Path destPath);
     void createFile(Path filePath);
     void removeFile(Path filePath);
     File getFile(Path filePath);
@@ -28,7 +29,4 @@ public interface FileSystem {
     default String readFromFile(Path filePath) {
         return new String(readByteArrayFromFile(filePath));
     }
-
-    void copyDirectory(Path src, Path dest);
-    void copy(Path src, Path dest);
 }

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/aws/AwsFileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/aws/AwsFileSystem.java
@@ -74,6 +74,11 @@ public final class AwsFileSystem implements FileSystem {
     }
 
     @Override
+    public void copyDirectory(Path srcPath, Path destPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void createFile(Path filePath) {
         throw new UnsupportedOperationException();
     }
@@ -212,15 +217,5 @@ public final class AwsFileSystem implements FileSystem {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    @Override
-    public void copyDirectory(Path src, Path dest) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void copy(Path src, Path dest) {
-        throw new UnsupportedOperationException();
     }
 }

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/duplex/DuplexFileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/duplex/DuplexFileSystem.java
@@ -29,6 +29,11 @@ public final class DuplexFileSystem implements FileSystem {
     }
 
     @Override
+    public void copyDirectory(Path srcPath, Path destPath) {
+        local.copyDirectory(srcPath, destPath);
+    }
+
+    @Override
     public void createFile(Path filePath) {
         local.createFile(filePath);
     }
@@ -101,15 +106,5 @@ public final class DuplexFileSystem implements FileSystem {
         } catch (RuntimeException e) {
             return aws.readByteArrayFromFile(filePath);
         }
-    }
-
-    @Override
-    public void copyDirectory(Path src, Path dest) {
-        local.copyDirectory(src, dest);
-    }
-
-    @Override
-    public void copy(Path src, Path dest) {
-        local.copy(src, dest);
     }
 }

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/local/LocalFileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/local/LocalFileSystem.java
@@ -66,6 +66,15 @@ public final class LocalFileSystem implements FileSystem {
     }
 
     @Override
+    public void copyDirectory(Path srcPath, Path destPath) {
+        try (Stream<Path> stream = Files.walk(baseDir.resolve(srcPath))) {
+            stream.forEach(src -> copy(src, baseDir.resolve(destPath).resolve(baseDir.resolve(srcPath).relativize(src))));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     public void createFile(Path filePath) {
         writeByteArrayToFile(filePath, new byte[0]);
     }
@@ -218,20 +227,10 @@ public final class LocalFileSystem implements FileSystem {
         }
     }
 
-    @Override
-    public void copyDirectory(Path src, Path dest) {
-        try (Stream<Path> stream = Files.walk(src)) {
-            stream.forEach(source -> copy(source, dest.resolve(src.relativize(source))));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    public void copy(Path src, Path dest) {
+    private static void copy(Path src, Path dest) {
         try {
             Files.copy(src, dest, REPLACE_EXISTING, COPY_ATTRIBUTES);
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
     }

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/user/avatar/UserAvatarIntegrationTestModule.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/user/avatar/UserAvatarIntegrationTestModule.java
@@ -32,6 +32,9 @@ public class UserAvatarIntegrationTestModule {
         }
 
         @Override
+        public void copyDirectory(Path srcPath, Path destPath) {}
+
+        @Override
         public void createFile(Path filePath) {}
 
         @Override
@@ -78,11 +81,5 @@ public class UserAvatarIntegrationTestModule {
         public byte[] readByteArrayFromFile(Path filePath) {
             return new byte[0];
         }
-
-        @Override
-        public void copyDirectory(Path src, Path dest) {}
-
-        @Override
-        public void copy(Path src, Path dest) {}
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/sandalphon/LocalGit.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/sandalphon/LocalGit.java
@@ -45,13 +45,11 @@ public final class LocalGit implements Git {
 
     @Override
     public void clone(Path originDirPath, Path rootDirPath) {
-        String srcDirAbsolutePath = fs.getFile(originDirPath).getAbsolutePath();
-        String destDirAbsolutePath = fs.getFile(rootDirPath).getAbsolutePath();
-
-        fs.copyDirectory(Path.of(srcDirAbsolutePath), Path.of(destDirAbsolutePath));
+        fs.createDirectory(rootDirPath);
+        fs.copyDirectory(originDirPath, rootDirPath);
 
         File destDir = fs.getFile(rootDirPath);
-        String destURI = "file://" + srcDirAbsolutePath;
+        String destURI = "file://" + fs.getFile(originDirPath).getAbsolutePath();
 
         try {
             org.eclipse.jgit.api.Git.open(destDir).remoteAdd().setName("origin").setUri(new URIish(destURI)).call();

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/fs/InMemoryFileSystem.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/fs/InMemoryFileSystem.java
@@ -29,6 +29,9 @@ public class InMemoryFileSystem implements FileSystem {
     }
 
     @Override
+    public void copyDirectory(Path srcPath, Path destPath) {}
+
+    @Override
     public void createFile(Path filePath) {
         throw new UnsupportedOperationException();
     }
@@ -135,10 +138,4 @@ public class InMemoryFileSystem implements FileSystem {
     public byte[] readByteArrayFromFile(Path filePath) {
         return fs.get(filePath);
     }
-
-    @Override
-    public void copyDirectory(Path src, Path dest) {}
-
-    @Override
-    public void copy(Path src, Path dest) {}
 }


### PR DESCRIPTION
Currently, when cloning a problem authored by different user, it will result in error. This is a regression from https://github.com/ia-toki/judgels/pull/553.

This PR fixes that by making sure the user-clone directory exists before cloning.