### PR TITLE
feat(client,server,grader): allow revealing evaluation result for chapter submissions

### DIFF
--- a/judgels-backends/judgels-grader-api/src/main/java/judgels/gabriel/api/GradingOptions.java
+++ b/judgels-backends/judgels-grader-api/src/main/java/judgels/gabriel/api/GradingOptions.java
@@ -1,0 +1,25 @@
+package judgels.gabriel.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableGradingOptions.class)
+public interface GradingOptions {
+    /**
+     * Whether the input and solution output should be stored as part of the grading details, revealed to the contestant.
+     * This is experimental. Currently, for this option to be honored, all the following must be satisfied:
+     * - Grading engine is Batch.
+     * - No sample test data.
+     * - Official test data consists of at most 3 test cases.
+     */
+    @Value.Default
+    @JsonInclude(Include.NON_DEFAULT)
+    default boolean getShouldRevealEvaluation() {
+        return false;
+    }
+
+    class Builder extends ImmutableGradingOptions.Builder {}
+}

--- a/judgels-backends/judgels-grader-api/src/main/java/judgels/gabriel/api/GradingRequest.java
+++ b/judgels-backends/judgels-grader-api/src/main/java/judgels/gabriel/api/GradingRequest.java
@@ -10,8 +10,9 @@ public interface GradingRequest {
     String getGradingJid();
     String getProblemJid();
     String getGradingLanguage();
-    Instant getGradingLastUpdateTime();
     SubmissionSource getSubmissionSource();
+    Instant getGradingLastUpdateTime();
+    GradingOptions getGradingOptions();
 
     class Builder extends ImmutableGradingRequest.Builder {}
 }

--- a/judgels-backends/judgels-grader-api/src/main/java/judgels/gabriel/api/TestCaseResult.java
+++ b/judgels-backends/judgels-grader-api/src/main/java/judgels/gabriel/api/TestCaseResult.java
@@ -1,5 +1,7 @@
 package judgels.gabriel.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +14,12 @@ public interface TestCaseResult {
     String getScore();
     Optional<SandboxExecutionResult> getExecutionResult();
     List<Integer> getSubtaskIds();
+
+    @JsonInclude(Include.NON_ABSENT)
+    Optional<String> getRevealedInput();
+
+    @JsonInclude(Include.NON_ABSENT)
+    Optional<String> getRevealedSolutionOutput();
 
     class Builder extends ImmutableTestCaseResult.Builder {}
 }

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/gabriel/grading/GradingWorker.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/gabriel/grading/GradingWorker.java
@@ -19,6 +19,7 @@ import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingEngine;
 import judgels.gabriel.api.GradingException;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.GradingRequest;
 import judgels.gabriel.api.GradingResponse;
 import judgels.gabriel.api.GradingResult;
@@ -56,6 +57,7 @@ public class GradingWorker {
 
     private GradingEngine engine;
     private GradingConfig config;
+    private GradingOptions options;
     private GradingLanguage language;
     private SubmissionSource source;
 
@@ -117,6 +119,7 @@ public class GradingWorker {
     private void initializeWorker() {
         LOGGER.info("Worker initialization started.");
 
+        options = request.getGradingOptions();
         source = request.getSubmissionSource();
 
         try {
@@ -146,7 +149,7 @@ public class GradingWorker {
                 .testDataFiles(testDataFiles)
                 .helperFiles(helperFiles)
                 .build();
-        result = engine.grade(engineDir.toFile(), config, language, source, sandboxFactory);
+        result = engine.grade(engineDir.toFile(), config, options, language, source, sandboxFactory);
 
         LOGGER.info("Grading finished. Result: {} {}", result.getVerdict().getCode(), result.getScore());
     }

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/BlackboxGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/BlackboxGradingEngineIntegrationTests.java
@@ -20,6 +20,7 @@ import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingEngine;
 import judgels.gabriel.api.GradingException;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.GradingResult;
 import judgels.gabriel.api.GradingResultDetails;
 import judgels.gabriel.api.GradingSource;
@@ -40,6 +41,7 @@ public class BlackboxGradingEngineIntegrationTests {
     protected static final ObjectMapper MAPPER = JudgelsObjectMappers.OBJECT_MAPPER;
 
     private GradingEngine engine;
+    private GradingOptions options;
     private GradingLanguage language;
 
     private File workerDir;
@@ -99,13 +101,17 @@ public class BlackboxGradingEngineIntegrationTests {
     }
 
     protected GradingResult runEngine(GradingConfig config) throws GradingException {
+        return runEngine(config, new GradingOptions.Builder().build());
+    }
+
+    protected GradingResult runEngine(GradingConfig config, GradingOptions options) throws GradingException {
         SandboxFactory sandboxFactory = new FakeSandboxFactory(sandboxDir);
         GradingSource source = new GradingSource.Builder()
                 .sourceFiles(sourceFiles)
                 .testDataFiles(testDataFiles)
                 .helperFiles(helperFiles)
                 .build();
-        return engine.grade(gradingDir, config, language, source, sandboxFactory);
+        return engine.grade(gradingDir, config, options, language, source, sandboxFactory);
     }
 
     protected GradingResultDetails getDetails(GradingResult result) {

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/api/EvaluationResult.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/api/EvaluationResult.java
@@ -7,6 +7,8 @@ import org.immutables.value.Value;
 public interface EvaluationResult {
     TestCaseVerdict getVerdict();
     Optional<SandboxExecutionResult> getExecutionResult();
+    Optional<String> getRevealedInput();
+    Optional<String> getRevealedSolutionOutput();
 
     static EvaluationResult skippedResult() {
         TestCaseVerdict verdict = new TestCaseVerdict.Builder().verdict(Verdict.SKIPPED).build();

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/api/GenerationResult.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/api/GenerationResult.java
@@ -7,6 +7,7 @@ import org.immutables.value.Value;
 public interface GenerationResult {
     Optional<TestCaseVerdict> getVerdict();
     SandboxExecutionResult getExecutionResult();
+    Optional<String> getRevealedSolutionOutput();
 
     class Builder extends ImmutableGenerationResult.Builder {}
 }

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/api/GradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/api/GradingEngine.java
@@ -11,6 +11,7 @@ public interface GradingEngine {
     GradingResult grade(
             File gradingDir,
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             GradingSource source,
             SandboxFactory sandboxFactory) throws GradingException;

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/BlackboxGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/BlackboxGradingEngine.java
@@ -23,6 +23,7 @@ import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingEngine;
 import judgels.gabriel.api.GradingException;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.GradingResult;
 import judgels.gabriel.api.GradingResultDetails;
 import judgels.gabriel.api.GradingSource;
@@ -51,6 +52,7 @@ public abstract class BlackboxGradingEngine implements GradingEngine {
     private File evaluationDir;
 
     private GradingConfig config;
+    private GradingOptions options;
     private GradingLanguage language;
     private GradingSource source;
     private SandboxFactory sandboxFactory;
@@ -74,12 +76,14 @@ public abstract class BlackboxGradingEngine implements GradingEngine {
     public GradingResult grade(
             File gradingDir,
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             GradingSource source,
             SandboxFactory sandboxFactory) throws GradingException {
 
         this.gradingDir = gradingDir;
         this.config = config;
+        this.options = options;
         this.language = language;
         this.source = source;
         this.sandboxFactory = sandboxFactory;
@@ -98,6 +102,7 @@ public abstract class BlackboxGradingEngine implements GradingEngine {
     protected abstract Aggregator getAggregator();
     protected abstract void prepare(
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             Map<String, File> sourceFiles,
             Map<String, File> helperFiles,
@@ -148,6 +153,7 @@ public abstract class BlackboxGradingEngine implements GradingEngine {
     private void prepareEngine() throws PreparationException {
         prepare(
                 config,
+                options,
                 language,
                 source.getSourceFiles(),
                 source.getHelperFiles(),
@@ -297,11 +303,15 @@ public abstract class BlackboxGradingEngine implements GradingEngine {
                     testCaseScore += testCaseScore.isEmpty() ? "" : " ";
                     testCaseScore += "[" + testCaseVerdict.getFeedback().get() + "]";
                 }
+
+                EvaluationResult evaluationResult = testGroupEvaluationResults.get(i).get(j);
                 testCaseResults.add(new TestCaseResult.Builder()
                         .verdict(testCaseVerdict.getVerdict())
                         .score(testCaseScore)
-                        .executionResult(testGroupEvaluationResults.get(i).get(j).getExecutionResult())
+                        .executionResult(evaluationResult.getExecutionResult())
                         .subtaskIds(testCase.getSubtaskIds())
+                        .revealedInput(evaluationResult.getRevealedInput())
+                        .revealedSolutionOutput(evaluationResult.getRevealedSolutionOutput())
                         .build());
             }
             testGroupResults.add(new TestGroupResult.Builder()

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/FilePeeker.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/FilePeeker.java
@@ -1,0 +1,37 @@
+package judgels.gabriel.engines;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class FilePeeker {
+    private FilePeeker() {}
+
+    public static String peekInputOutput(File file) throws IOException {
+        try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(file))) {
+            byte[] buffer = new byte[1024];
+            int bytesRead = bis.read(buffer, 0, 1024);
+            if (bytesRead <= 0) {
+                return "";
+            }
+
+            String str = new String(buffer, 0, bytesRead);
+            String[] lines = str.split("\n");
+
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < lines.length && i < 3; i++) {
+                String line = lines[i];
+                if (line.length() > 256) {
+                    line = line.substring(0, 256) + "... (truncated)";
+                }
+                sb.append(line).append('\n');
+            }
+
+            if (lines.length > 3) {
+                sb.append("... (truncated)\n");
+            }
+            return sb.toString();
+        }
+    }
+}

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/batch/BatchGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/batch/BatchGradingEngine.java
@@ -11,6 +11,7 @@ import judgels.gabriel.api.Compiler;
 import judgels.gabriel.api.Evaluator;
 import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.PreparationException;
 import judgels.gabriel.api.Sandbox;
 import judgels.gabriel.api.SandboxFactory;
@@ -74,6 +75,7 @@ public class BatchGradingEngine extends BlackboxGradingEngine {
     @Override
     public void prepare(
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             Map<String, File> sourceFiles,
             Map<String, File> helperFiles,
@@ -95,14 +97,22 @@ public class BatchGradingEngine extends BlackboxGradingEngine {
         Scorer scorer = ScorerRegistry.getAndPrepare(cfg.getCustomScorer(), helperFiles, scorerSandbox, evaluationDir);
 
         evaluatorSandbox = sandboxFactory.newSandbox();
+
+        boolean shouldRevealEvaluation = options.getShouldRevealEvaluation()
+                && config.getTestData().size() == 2
+                && config.getTestData().get(0).getTestCases().isEmpty() // no sample test data
+                && config.getTestData().get(1).getTestCases().size() <= 3; // official test data consists of at most 3 test cases
+
         evaluator.prepare(
                 evaluatorSandbox,
-                scorer, compilationDir,
+                scorer,
+                compilationDir,
                 evaluationDir,
                 language,
                 sourceFile,
                 cfg.getTimeLimit(),
-                cfg.getMemoryLimit());
+                cfg.getMemoryLimit(),
+                shouldRevealEvaluation);
     }
 
     @Override

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/batch/BatchWithSubtasksGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/batch/BatchWithSubtasksGradingEngine.java
@@ -11,6 +11,7 @@ import judgels.gabriel.api.Compiler;
 import judgels.gabriel.api.Evaluator;
 import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.PreparationException;
 import judgels.gabriel.api.Sandbox;
 import judgels.gabriel.api.SandboxFactory;
@@ -73,6 +74,7 @@ public class BatchWithSubtasksGradingEngine extends BlackboxGradingEngine {
     @Override
     public void prepare(
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             Map<String, File> sourceFiles,
             Map<String, File> helperFiles,
@@ -101,7 +103,8 @@ public class BatchWithSubtasksGradingEngine extends BlackboxGradingEngine {
                 language,
                 sourceFile,
                 cfg.getTimeLimit(),
-                cfg.getMemoryLimit());
+                cfg.getMemoryLimit(),
+                false);
     }
 
     @Override

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/functional/FunctionalGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/functional/FunctionalGradingEngine.java
@@ -11,6 +11,7 @@ import judgels.gabriel.api.Compiler;
 import judgels.gabriel.api.Evaluator;
 import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.PreparationException;
 import judgels.gabriel.api.Sandbox;
 import judgels.gabriel.api.SandboxFactory;
@@ -75,6 +76,7 @@ public class FunctionalGradingEngine extends BlackboxGradingEngine {
     @Override
     public void prepare(
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             Map<String, File> sourceFiles,
             Map<String, File> helperFiles,

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/functional/FunctionalWithSubtasksGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/functional/FunctionalWithSubtasksGradingEngine.java
@@ -11,6 +11,7 @@ import judgels.gabriel.api.Compiler;
 import judgels.gabriel.api.Evaluator;
 import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.PreparationException;
 import judgels.gabriel.api.Sandbox;
 import judgels.gabriel.api.SandboxFactory;
@@ -74,6 +75,7 @@ public class FunctionalWithSubtasksGradingEngine extends BlackboxGradingEngine {
     @Override
     public void prepare(
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             Map<String, File> sourceFiles,
             Map<String, File> helperFiles,

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/interactive/InteractiveGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/interactive/InteractiveGradingEngine.java
@@ -11,6 +11,7 @@ import judgels.gabriel.api.Compiler;
 import judgels.gabriel.api.Evaluator;
 import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.PreparationException;
 import judgels.gabriel.api.Sandbox;
 import judgels.gabriel.api.SandboxFactory;
@@ -73,6 +74,7 @@ public class InteractiveGradingEngine extends BlackboxGradingEngine {
     @Override
     public void prepare(
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             Map<String, File> sourceFiles,
             Map<String, File> helperFiles,

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/interactive/InteractiveWithSubtasksGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/interactive/InteractiveWithSubtasksGradingEngine.java
@@ -11,6 +11,7 @@ import judgels.gabriel.api.Compiler;
 import judgels.gabriel.api.Evaluator;
 import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.PreparationException;
 import judgels.gabriel.api.Sandbox;
 import judgels.gabriel.api.SandboxFactory;
@@ -72,6 +73,7 @@ public class InteractiveWithSubtasksGradingEngine extends BlackboxGradingEngine 
     @Override
     public void prepare(
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             Map<String, File> sourceFiles,
             Map<String, File> helperFiles,

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/outputonly/OutputOnlyGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/outputonly/OutputOnlyGradingEngine.java
@@ -11,6 +11,7 @@ import judgels.gabriel.api.Compiler;
 import judgels.gabriel.api.Evaluator;
 import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.PreparationException;
 import judgels.gabriel.api.Sandbox;
 import judgels.gabriel.api.SandboxFactory;
@@ -70,6 +71,7 @@ public class OutputOnlyGradingEngine extends BlackboxGradingEngine {
     @Override
     public void prepare(
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             Map<String, File> sourceFiles,
             Map<String, File> helperFiles,

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/outputonly/OutputOnlyWithSubtasksGradingEngine.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/engines/outputonly/OutputOnlyWithSubtasksGradingEngine.java
@@ -11,6 +11,7 @@ import judgels.gabriel.api.Compiler;
 import judgels.gabriel.api.Evaluator;
 import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.GradingLanguage;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.PreparationException;
 import judgels.gabriel.api.Sandbox;
 import judgels.gabriel.api.SandboxFactory;
@@ -69,6 +70,7 @@ public class OutputOnlyWithSubtasksGradingEngine extends BlackboxGradingEngine {
     @Override
     public void prepare(
             GradingConfig config,
+            GradingOptions options,
             GradingLanguage language,
             Map<String, File> sourceFiles,
             Map<String, File> helperFiles,

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/submission/programming/SubmissionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/submission/programming/SubmissionResource.java
@@ -27,6 +27,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.SubmissionSource;
 import judgels.jerahmeel.api.chapter.Chapter;
 import judgels.jerahmeel.api.chapter.problem.ChapterProblem;
@@ -261,7 +262,8 @@ public class SubmissionResource {
                 .build();
         SubmissionSource source = submissionSourceBuilder.fromNewSubmission(parts);
         ProblemSubmissionConfig config = sandalphonClient.getProgrammingProblemSubmissionConfig(data.getProblemJid());
-        Submission submission = submissionClient.submit(data, source, config);
+        GradingOptions options = new GradingOptions.Builder().shouldRevealEvaluation(true).build();
+        Submission submission = submissionClient.submit(data, source, config, options);
 
         submissionSourceBuilder.storeSubmissionSource(submission.getJid(), source);
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/sandalphon/submission/programming/SubmissionClient.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/sandalphon/submission/programming/SubmissionClient.java
@@ -5,6 +5,7 @@ import static judgels.sandalphon.submission.programming.SubmissionUtils.checkGra
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.GradingRequest;
 import judgels.gabriel.api.LanguageRestriction;
 import judgels.gabriel.api.SubmissionSource;
@@ -35,6 +36,10 @@ public class SubmissionClient {
     }
 
     public Submission submit(SubmissionData data, SubmissionSource source, ProblemSubmissionConfig config) {
+        return submit(data, source, config, new GradingOptions.Builder().build());
+    }
+
+    public Submission submit(SubmissionData data, SubmissionSource source, ProblemSubmissionConfig config, GradingOptions options) {
         LanguageRestriction restriction = config.getGradingLanguageRestriction();
         if (data.getAdditionalGradingLanguageRestriction().isPresent()) {
             restriction = LanguageRestriction.combine(
@@ -50,25 +55,30 @@ public class SubmissionClient {
 
         Submission submission = submissionStore.createSubmission(data, config);
         String gradingJid = submissionStore.createGrading(submission);
-        requestGrading(gradingJid, submission, source, config);
+        requestGrading(gradingJid, submission, source, config, options);
 
         return submission;
     }
 
     public void regrade(String gradingJid, Submission submission, SubmissionSource source, ProblemSubmissionConfig config) {
+        regrade(gradingJid, submission, source, config, new GradingOptions.Builder().build());
+    }
+
+    public void regrade(String gradingJid, Submission submission, SubmissionSource source, ProblemSubmissionConfig config, GradingOptions options) {
         if (config.getGradingLastUpdateTime().isAfter(submission.getTime())) {
             // TODO(fushar): update submission's grading engine
         }
-        requestGrading(gradingJid, submission, source, config);
+        requestGrading(gradingJid, submission, source, config, options);
     }
 
-    public void requestGrading(String gradingJid, Submission submission, SubmissionSource source, ProblemSubmissionConfig config) {
+    public void requestGrading(String gradingJid, Submission submission, SubmissionSource source, ProblemSubmissionConfig config, GradingOptions options) {
         GradingRequest gradingRequest = new GradingRequest.Builder()
                 .gradingJid(gradingJid)
                 .problemJid(submission.getProblemJid())
                 .gradingLanguage(submission.getGradingLanguage())
-                .gradingLastUpdateTime(config.getGradingLastUpdateTime())
                 .submissionSource(source)
+                .gradingLastUpdateTime(config.getGradingLastUpdateTime())
+                .gradingOptions(options)
                 .build();
 
         try {

--- a/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionSummary/ProblemSubmissionSummary.jsx
+++ b/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionSummary/ProblemSubmissionSummary.jsx
@@ -31,7 +31,7 @@ export function ProblemSubmissionSummary({ submissionJid, submission, submission
     return <Tag>{score}</Tag>;
   };
 
-  const renderDetails = () => {
+  const renderErrors = () => {
     const { latestGrading, gradingLanguage } = submission;
     const verdictCode = latestGrading.verdict.code;
 
@@ -45,7 +45,43 @@ export function ProblemSubmissionSummary({ submissionJid, submission, submission
         ));
       }
     }
+    return null;
+  };
 
+  const renderTestCaseResult = (result, idx) => {
+    const input = result.revealedInput && (
+      <div>
+        <h5>Input</h5>
+        <pre>{result.revealedInput}</pre>
+      </div>
+    );
+    const output = (
+      <div>
+        <h5>Your output</h5>
+        <pre>{result.revealedSolutionOutput}</pre>
+      </div>
+    );
+
+    return (
+      <div className="problem-submission-summary__evaluation-result" key={idx}>
+        {input}
+        {output}
+      </div>
+    );
+  };
+
+  const renderEvaluationResults = () => {
+    const { latestGrading } = submission;
+    const verdictCode = latestGrading.verdict.code;
+
+    if (verdictCode == VerdictCode.AC || verdictCode == VerdictCode.WA) {
+      const { details } = latestGrading;
+      for (const testGroupResult of details.testDataResults) {
+        if (testGroupResult.id === -1) {
+          return testGroupResult.testCaseResults.map(renderTestCaseResult);
+        }
+      }
+    }
     return null;
   };
 
@@ -67,15 +103,16 @@ export function ProblemSubmissionSummary({ submissionJid, submission, submission
 
     return (
       <>
-        <div className="problem-submission-summary__result">
-          <p>Verdict</p>
+        <div className="problem-submission-summary__evaluation">{renderEvaluationResults()}</div>
+        <div className="problem-submission-summary__verdict">
+          <h5>Verdict</h5>
           {renderScore(latestGrading)}
           <ButtonLink to={submissionUrl} className="details-button" small>
             Details
           </ButtonLink>
         </div>
         <VerdictTag square verdictCode={verdictCode} />
-        {renderDetails()}
+        {renderErrors()}
       </>
     );
   };

--- a/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionSummary/ProblemSubmissionSummary.scss
+++ b/judgels-client/src/components/ProblemWorksheetCard/Programming/ProblemSubmissionSummary/ProblemSubmissionSummary.scss
@@ -1,8 +1,16 @@
 .problem-submission-summary {
-  padding: 10px;
   width: 100%;
+  padding: 10px;
 
-  &__result {
+  &__evaluation-result {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    margin-bottom: 10px;
+  }
+
+  &__verdict {
     display: flex;
     gap: 10px;
 


### PR DESCRIPTION
This is experimental. Currently, for this option to be honored, all the following must be satisfied:

- Grading engine is Batch.
- No sample test data.
- Official test data consists of at most 3 test cases.

<img width="657" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/04c23558-154a-4623-9e9d-acd66f361756">
