### PR TITLE
fix(client): prevent course chapter compilation error to overflow

### DIFF
--- a/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemStatementRoutes.scss
+++ b/judgels-client/src/routes/courses/courses/single/chapters/single/problems/single/Programming/ChapterProblemStatementRoutes.scss
@@ -2,4 +2,5 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="1178" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/16e20d41-f363-488e-9eb9-9e4701599285">|<img width="1178" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/57db98c5-c8a3-4de3-8db3-cb98f90341a6">|