### PR TITLE
CI: Update actions to use Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         ports:
           - 5672:5672
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
 
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set up JDK
         if: steps.changed-files.outputs.gradle == '1'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: "11"
@@ -94,7 +94,7 @@ jobs:
       CONTAINER_REGISTRY_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
       CONTAINER_REGISTRY_TOKEN: ${{ secrets.CONTAINER_REGISTRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
 
@@ -109,7 +109,7 @@ jobs:
 
       - name: Set up JDK
         if: steps.changed-files.outputs.gradle == '1'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: "11"
@@ -156,7 +156,7 @@ jobs:
       WEB_KNOWN_HOSTS: ${{ secrets.WEB_KNOWN_HOSTS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 50
 
@@ -193,12 +193,12 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.repository_owner == 'ia-toki'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
 
       - name: Check out deployment repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ secrets.TLX_STAGING_DEPLOYMENT_REPOSITORY }}
           token: ${{ secrets.TLX_STAGING_DEPLOYMENT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       CONTAINER_REGISTRY_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
       CONTAINER_REGISTRY_TOKEN: ${{ secrets.CONTAINER_REGISTRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50
 


### PR DESCRIPTION
See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/