### PR TITLE
contest: don't use transactional db in scheduled scoreboard updater

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/scoreboard/ContestScoreboardPoller.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/scoreboard/ContestScoreboardPoller.java
@@ -30,7 +30,7 @@ public class ContestScoreboardPoller implements Runnable {
     }
 
     @Override
-    @UnitOfWork(readOnly = true)
+    @UnitOfWork(readOnly = true, transactional = false)
     public void run() {
         try {
             for (Contest contest : contestStore.getRunningContests()) {


### PR DESCRIPTION
Fixes https://github.com/ia-toki/judgels/issues/434