### PR TITLE
katex: make it position: relative to fix broken layout

### DIFF
--- a/judgels-client/src/components/RichStatementText/RichStatementText.scss
+++ b/judgels-client/src/components/RichStatementText/RichStatementText.scss
@@ -2,6 +2,7 @@
 
 .rich-statement-text {
   .katex {
+    position: relative;
     font-size: 17px !important;
   }
 }


### PR DESCRIPTION
The Katex's MathML output has the following CSS:

```
.katex .katex-mathml {
    clip: rect(1px, 1px, 1px, 1px);
    border: 0;
    height: 1px;
    overflow: hidden;
    padding: 0;
    position: absolute;
    width: 1px;
}
```

The `position: absolute` rule breaks the layout when a problem is rendered within a course. This is because some course-related divs use something like `height: calc(100vh - xxx)` to maintain a sticky header. This is incompatible with MathML output above as it somehow sticks at the bottom of the page and causes unnecessary blank space.

With this, the MathML output does not break the layout as the parent div `.katex` now has `position: relative`.


|Before|After|
|-|-|
|<img width="938" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/57defadb-5e80-47ff-8e77-0a28a41675bf">|<img width="854" alt="image" src="https://github.com/ia-toki/judgels/assets/1525580/67ebc537-8b80-4876-93ef-88c04b304c73">|