### PR TITLE
Allow guests for exporting users which will exclude email

### DIFF
--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/api/UserApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/api/UserApiIntegrationTests.java
@@ -54,9 +54,14 @@ class UserApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
         assertThat(response.getLastSessionTimesMap()).doesNotContainKeys(nani.getJid());
 
         String exportedCsv = userClient.exportUsers(adminToken, List.of("nani", "nano", "bogus"));
-        assertThat(exportedCsv).isEqualTo(String.format("jid,username,email\n"
-                + "%s,nani,nani@domain.com\n"
-                + "%s,nano,nano@domain.com\n", nani.getJid(), nano.getJid()));
+        assertThat(exportedCsv).isEqualTo(String.format("username,jid,email\n"
+                + "nani,%s,nani@domain.com\n"
+                + "nano,%s,nano@domain.com\n", nani.getJid(), nano.getJid()));
+
+        exportedCsv = userClient.exportUsers(List.of("nani", "nano", "bogus"));
+        assertThat(exportedCsv).isEqualTo(String.format("username,jid\n"
+                + "nani,%s\n"
+                + "nano,%s\n", nani.getJid(), nano.getJid()));
     }
 
     @Test

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/api/UserApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/api/UserApiPermissionIntegrationTests.java
@@ -35,8 +35,7 @@ class UserApiPermissionIntegrationTests extends BaseJudgelsApiIntegrationTests {
 
     @Test
     void export_users() {
-        assertPermitted(exportUsers(adminToken));
-        assertForbidden(exportUsers(userToken));
+        assertPermitted(exportUsers());
     }
 
     @Test
@@ -61,8 +60,8 @@ class UserApiPermissionIntegrationTests extends BaseJudgelsApiIntegrationTests {
         return () -> userClient.getUsers(token);
     }
 
-    private ThrowingCallable exportUsers(String token) {
-        return () -> userClient.exportUsers(token, List.of());
+    private ThrowingCallable exportUsers() {
+        return () -> userClient.exportUsers(List.of());
     }
 
     private ThrowingCallable upsertUsers(String token) {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/hibernate/StatsUserProblemHibernateDao.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/hibernate/StatsUserProblemHibernateDao.java
@@ -163,6 +163,11 @@ public class StatsUserProblemHibernateDao extends HibernateDao<StatsUserProblemM
     }
 
     @Override
+    public long selectTotalScoreByUserJid(String userJid) {
+        return 0;
+    }
+
+    @Override
     public Map<String, Long> selectCountsVerdictByUserJid(String userJid) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<Tuple> cq = cb.createTupleQuery();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/persistence/StatsUserProblemDao.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/persistence/StatsUserProblemDao.java
@@ -17,5 +17,6 @@ public interface StatsUserProblemDao extends Dao<StatsUserProblemModel> {
     Map<String, Long> selectCountsAcceptedByProblemJids(Collection<String> problemJids);
     Map<String, Long> selectCountsTriedByProblemJids(Collection<String> problemJids);
     long selectCountTriedByUserJid(String userJid);
+    long selectTotalScoreByUserJid(String userJid);
     Map<String, Long> selectCountsVerdictByUserJid(String userJid);
 }

--- a/judgels-backends/judgels-server-feign/src/main/java/judgels/jophiel/UserClient.java
+++ b/judgels-backends/judgels-server-feign/src/main/java/judgels/jophiel/UserClient.java
@@ -31,6 +31,10 @@ public interface UserClient {
     User getMyself(@Param("token") String token);
 
     @RequestLine("POST /api/v2/users/batch-get")
+    @Headers("Content-Type: application/json")
+    String exportUsers(List<String> usernames);
+
+    @RequestLine("POST /api/v2/users/batch-get")
     @Headers({"Authorization: Bearer {token}", "Content-Type: application/json"})
     String exportUsers(@Param("token") String token, List<String> usernames);
 }


### PR DESCRIPTION
For a local contest use case, we want organizers to be able to export username -> jid mapping of existing users.