### PR TITLE
grader: Allow OK feedback to be on separate, third line

### DIFF
--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/helpers/TestCaseVerdictParser.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/helpers/TestCaseVerdictParser.java
@@ -56,6 +56,9 @@ public class TestCaseVerdictParser {
                     }
                 }
 
+                if (lines.length > 2) {
+                    feedback = Optional.of(lines[2]);
+                }
                 if (tokens.length > 1) {
                     feedback = Optional.of(tokens[1]);
                 }

--- a/judgels-backends/judgels-grader-engines/src/test/java/judgels/gabriel/scorers/TestCaseVerdictParserTests.java
+++ b/judgels-backends/judgels-grader-engines/src/test/java/judgels/gabriel/scorers/TestCaseVerdictParserTests.java
@@ -63,6 +63,12 @@ class TestCaseVerdictParserTests {
 
         @Test
         void ok_points_with_feedback() throws ScoringException {
+            assertThat(parser.parseOutput("OK\n70\na feedback\n")).isEqualTo(
+                    new TestCaseVerdict.Builder().verdict(Verdict.OK).points(70.0).feedback("a feedback").build());
+        }
+
+        @Test
+        void ok_points_with_feedback_on_same_line() throws ScoringException {
             assertThat(parser.parseOutput("OK\n70 a feedback\n")).isEqualTo(
                     new TestCaseVerdict.Builder().verdict(Verdict.OK).points(70.0).feedback("a feedback").build());
         }
@@ -75,6 +81,12 @@ class TestCaseVerdictParserTests {
 
         @Test
         void ok_percentage_with_feedback() throws ScoringException {
+            assertThat(parser.parseOutput("OK\n25%\na feedback\n")).isEqualTo(
+                    new TestCaseVerdict.Builder().verdict(Verdict.OK).percentage(25).feedback("a feedback").build());
+        }
+
+        @Test
+        void ok_percentage_with_feedback_on_same_line() throws ScoringException {
             assertThat(parser.parseOutput("OK\n25% a feedback\n")).isEqualTo(
                     new TestCaseVerdict.Builder().verdict(Verdict.OK).percentage(25).feedback("a feedback").build());
         }


### PR DESCRIPTION
Previously, to give a feedback from a scorer with a custom points, one would need to follow this format:

```
OK
50 a feedback
```

where `50` is the point and `a feedback` is the feedback.

This format is a bit weird and is not consistent with `AC` / `WA` verdicts, so with this PR, we allow this alternative format:

```
OK
50
a feedback
```

The old format is still supported for backward compatibility.