### PR TITLE
grader: Beautify score output

### DIFF
--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/batch/BatchGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/batch/BatchGradingEngineIntegrationTests.java
@@ -55,11 +55,11 @@ class BatchGradingEngineIntegrationTests extends BlackboxGradingEngineIntegratio
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, ACCEPTED, 100)));
     }
@@ -79,11 +79,11 @@ class BatchGradingEngineIntegrationTests extends BlackboxGradingEngineIntegratio
                                 testCaseResult(WRONG_ANSWER, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, ACCEPTED, 100)));
     }
@@ -103,11 +103,11 @@ class BatchGradingEngineIntegrationTests extends BlackboxGradingEngineIntegratio
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, WRONG_ANSWER, 80)));
     }
@@ -127,11 +127,11 @@ class BatchGradingEngineIntegrationTests extends BlackboxGradingEngineIntegratio
                                 testCaseResult(WRONG_ANSWER, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1))),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, WRONG_ANSWER, 0)));
     }
@@ -151,11 +151,11 @@ class BatchGradingEngineIntegrationTests extends BlackboxGradingEngineIntegratio
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(OK, "10.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(OK, "10", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, OK, 90)));
     }

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/batch/BatchWithSubtasksGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/batch/BatchWithSubtasksGradingEngineIntegrationTests.java
@@ -52,18 +52,18 @@ class BatchWithSubtasksGradingEngineIntegrationTests extends BlackboxGradingEngi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2))),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, ACCEPTED, 70)));
@@ -79,18 +79,18 @@ class BatchWithSubtasksGradingEngineIntegrationTests extends BlackboxGradingEngi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(WRONG_ANSWER, "X", 2))),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(WRONG_ANSWER, "✕", 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, WRONG_ANSWER, 0)));
@@ -106,13 +106,13 @@ class BatchWithSubtasksGradingEngineIntegrationTests extends BlackboxGradingEngi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(WRONG_ANSWER, "X", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(WRONG_ANSWER, "✕", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2),
@@ -133,18 +133,18 @@ class BatchWithSubtasksGradingEngineIntegrationTests extends BlackboxGradingEngi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(TIME_LIMIT_EXCEEDED, "X", Optional.of(TIMED_OUT),  2))),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(TIME_LIMIT_EXCEEDED, "✕", Optional.of(TIMED_OUT),  2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, TIME_LIMIT_EXCEEDED, 0)));
@@ -160,12 +160,12 @@ class BatchWithSubtasksGradingEngineIntegrationTests extends BlackboxGradingEngi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(WRONG_ANSWER, "X", 1, 2),
+                                testCaseResult(WRONG_ANSWER, "✕", 1, 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 1, 2)),
                         testGroupResult(
                                 2,
@@ -187,18 +187,18 @@ class BatchWithSubtasksGradingEngineIntegrationTests extends BlackboxGradingEngi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2))),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, ACCEPTED, 70)));
@@ -215,18 +215,18 @@ class BatchWithSubtasksGradingEngineIntegrationTests extends BlackboxGradingEngi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(OK, "10.0", 2))),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(OK, "10", 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, OK, 10)));
@@ -242,18 +242,18 @@ class BatchWithSubtasksGradingEngineIntegrationTests extends BlackboxGradingEngi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(WRONG_ANSWER, "X", 2))),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(WRONG_ANSWER, "✕", 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, WRONG_ANSWER, 0)));

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/functional/FunctionalGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/functional/FunctionalGradingEngineIntegrationTests.java
@@ -53,11 +53,11 @@ class FunctionalGradingEngineIntegrationTests extends BlackboxGradingEngineInteg
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, ACCEPTED, 100)));
     }
@@ -78,11 +78,11 @@ class FunctionalGradingEngineIntegrationTests extends BlackboxGradingEngineInteg
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, WRONG_ANSWER, 80)));
     }
@@ -104,11 +104,11 @@ class FunctionalGradingEngineIntegrationTests extends BlackboxGradingEngineInteg
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(OK, "10.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(OK, "10", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, OK, 90)));
     }

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/functional/FunctionalGradingEngineJavaIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/functional/FunctionalGradingEngineJavaIntegrationTests.java
@@ -56,11 +56,11 @@ class FunctionalGradingEngineJavaIntegrationTests extends BlackboxGradingEngineI
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, ACCEPTED, 100)));
     }
@@ -83,11 +83,11 @@ class FunctionalGradingEngineJavaIntegrationTests extends BlackboxGradingEngineI
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, WRONG_ANSWER, 80)));
     }
@@ -111,11 +111,11 @@ class FunctionalGradingEngineJavaIntegrationTests extends BlackboxGradingEngineI
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(OK, "10.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(OK, "10", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, OK, 90)));
     }

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/functional/FunctionalWithSubtasksGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/functional/FunctionalWithSubtasksGradingEngineIntegrationTests.java
@@ -47,18 +47,18 @@ class FunctionalWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2))),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, ACCEPTED, 70)));
@@ -75,16 +75,16 @@ class FunctionalWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(WRONG_ANSWER, "X", 2),
+                                testCaseResult(WRONG_ANSWER, "✕", 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2))),
                 ImmutableList.of(
@@ -104,16 +104,16 @@ class FunctionalWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(WRONG_ANSWER, "X", 2),
+                                testCaseResult(WRONG_ANSWER, "✕", 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2))),
                 ImmutableList.of(

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/functional/FunctionalWithSubtasksGradingEngineJavaIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/functional/FunctionalWithSubtasksGradingEngineJavaIntegrationTests.java
@@ -50,18 +50,18 @@ class FunctionalWithSubtasksGradingEngineJavaIntegrationTests extends BlackboxGr
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2),
-                                testCaseResult(ACCEPTED, "*", 2))),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2),
+                                testCaseResult(ACCEPTED, "✓", 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, ACCEPTED, 70)));
@@ -80,16 +80,16 @@ class FunctionalWithSubtasksGradingEngineJavaIntegrationTests extends BlackboxGr
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(WRONG_ANSWER, "X", 2),
+                                testCaseResult(WRONG_ANSWER, "✕", 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2))),
                 ImmutableList.of(
@@ -111,16 +111,16 @@ class FunctionalWithSubtasksGradingEngineJavaIntegrationTests extends BlackboxGr
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", 1, 2),
-                                testCaseResult(ACCEPTED, "*", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", 1, 2),
+                                testCaseResult(ACCEPTED, "✓", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(WRONG_ANSWER, "X", 2),
+                                testCaseResult(WRONG_ANSWER, "✕", 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2))),
                 ImmutableList.of(

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/interactive/InteractiveGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/interactive/InteractiveGradingEngineIntegrationTests.java
@@ -59,11 +59,11 @@ class InteractiveGradingEngineIntegrationTests extends BlackboxGradingEngineInte
                                 testCaseResult(ACCEPTED, "[10]", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0 [9]", -1),
-                                testCaseResult(ACCEPTED, "20.0 [10]", -1),
-                                testCaseResult(ACCEPTED, "20.0 [10]", -1),
-                                testCaseResult(ACCEPTED, "20.0 [9]", -1),
-                                testCaseResult(ACCEPTED, "20.0 [1]", -1))),
+                                testCaseResult(ACCEPTED, "20 [9]", -1),
+                                testCaseResult(ACCEPTED, "20 [10]", -1),
+                                testCaseResult(ACCEPTED, "20 [10]", -1),
+                                testCaseResult(ACCEPTED, "20 [9]", -1),
+                                testCaseResult(ACCEPTED, "20 [1]", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, ACCEPTED, 100)));
     }
@@ -83,11 +83,11 @@ class InteractiveGradingEngineIntegrationTests extends BlackboxGradingEngineInte
                                 testCaseResult(WRONG_ANSWER, "[11]", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0 [1]", -1),
-                                testCaseResult(ACCEPTED, "20.0 [8]", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0 [11]", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0 [11]", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0 [11]", -1))),
+                                testCaseResult(ACCEPTED, "20 [1]", -1),
+                                testCaseResult(ACCEPTED, "20 [8]", -1),
+                                testCaseResult(WRONG_ANSWER, "0 [11]", -1),
+                                testCaseResult(WRONG_ANSWER, "0 [11]", -1),
+                                testCaseResult(WRONG_ANSWER, "0 [11]", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, WRONG_ANSWER, 40)));
     }
@@ -108,11 +108,11 @@ class InteractiveGradingEngineIntegrationTests extends BlackboxGradingEngineInte
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(OK, "10.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(OK, "10", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 ImmutableList.of(
                         subtaskResult(-1, OK, 90)));
     }
@@ -133,11 +133,11 @@ class InteractiveGradingEngineIntegrationTests extends BlackboxGradingEngineInte
                                 testCaseResult(TIME_LIMIT_EXCEEDED, "", Optional.of(SandboxExecutionStatus.TIMED_OUT), 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(TIME_LIMIT_EXCEEDED, "0.0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1),
-                                testCaseResult(TIME_LIMIT_EXCEEDED, "0.0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1),
-                                testCaseResult(TIME_LIMIT_EXCEEDED, "0.0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1),
-                                testCaseResult(TIME_LIMIT_EXCEEDED, "0.0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1),
-                                testCaseResult(TIME_LIMIT_EXCEEDED, "0.0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1))),
+                                testCaseResult(TIME_LIMIT_EXCEEDED, "0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1),
+                                testCaseResult(TIME_LIMIT_EXCEEDED, "0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1),
+                                testCaseResult(TIME_LIMIT_EXCEEDED, "0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1),
+                                testCaseResult(TIME_LIMIT_EXCEEDED, "0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1),
+                                testCaseResult(TIME_LIMIT_EXCEEDED, "0", Optional.of(SandboxExecutionStatus.TIMED_OUT), -1))),
                 List.of(
                         subtaskResult(-1, TIME_LIMIT_EXCEEDED, 0)));
     }
@@ -201,11 +201,11 @@ class InteractiveGradingEngineIntegrationTests extends BlackboxGradingEngineInte
                                 testCaseResult(WRONG_ANSWER, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1),
-                                testCaseResult(WRONG_ANSWER, "0.0", -1))),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1),
+                                testCaseResult(WRONG_ANSWER, "0", -1))),
                 List.of(
                         subtaskResult(-1, WRONG_ANSWER, 0)));
     }
@@ -227,11 +227,11 @@ class InteractiveGradingEngineIntegrationTests extends BlackboxGradingEngineInte
                                 testCaseResult(ACCEPTED, "", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1),
-                                testCaseResult(ACCEPTED, "20.0", -1))),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1),
+                                testCaseResult(ACCEPTED, "20", -1))),
                 List.of(
                         subtaskResult(-1, ACCEPTED, 100)));
     }
@@ -252,11 +252,11 @@ class InteractiveGradingEngineIntegrationTests extends BlackboxGradingEngineInte
                                 testCaseResult(ACCEPTED, "[10]", 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0 [9]", -1),
-                                testCaseResult(ACCEPTED, "20.0 [10]", -1),
-                                testCaseResult(ACCEPTED, "20.0 [10]", -1),
-                                testCaseResult(ACCEPTED, "20.0 [9]", -1),
-                                testCaseResult(ACCEPTED, "20.0 [1]", -1))),
+                                testCaseResult(ACCEPTED, "20 [9]", -1),
+                                testCaseResult(ACCEPTED, "20 [10]", -1),
+                                testCaseResult(ACCEPTED, "20 [10]", -1),
+                                testCaseResult(ACCEPTED, "20 [9]", -1),
+                                testCaseResult(ACCEPTED, "20 [1]", -1))),
                 List.of(
                         subtaskResult(-1, ACCEPTED, 100)));
     }

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/interactive/InteractiveWithSubtasksGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/interactive/InteractiveWithSubtasksGradingEngineIntegrationTests.java
@@ -50,18 +50,18 @@ class InteractiveWithSubtasksGradingEngineIntegrationTests extends BlackboxGradi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "* [8]", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "* [9]", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "* [10]", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓ [8]", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓ [9]", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓ [10]", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "* [9]", 1, 2),
-                                testCaseResult(ACCEPTED, "* [10]", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓ [9]", 1, 2),
+                                testCaseResult(ACCEPTED, "✓ [10]", 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "* [10]", 2),
-                                testCaseResult(ACCEPTED, "* [9]", 2),
-                                testCaseResult(ACCEPTED, "* [1]", 2))),
+                                testCaseResult(ACCEPTED, "✓ [10]", 2),
+                                testCaseResult(ACCEPTED, "✓ [9]", 2),
+                                testCaseResult(ACCEPTED, "✓ [1]", 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, ACCEPTED, 70)));
@@ -78,13 +78,13 @@ class InteractiveWithSubtasksGradingEngineIntegrationTests extends BlackboxGradi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "* [3]", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "* [5]", 0, 1, 2),
-                                testCaseResult(WRONG_ANSWER, "X [11]", 0, 2)),
+                                testCaseResult(ACCEPTED, "✓ [3]", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓ [5]", 0, 1, 2),
+                                testCaseResult(WRONG_ANSWER, "✕ [11]", 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "* [1]", 1, 2),
-                                testCaseResult(ACCEPTED, "* [8]", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓ [1]", 1, 2),
+                                testCaseResult(ACCEPTED, "✓ [8]", 1, 2)),
                         testGroupResult(
                                 2,
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2),
@@ -106,13 +106,13 @@ class InteractiveWithSubtasksGradingEngineIntegrationTests extends BlackboxGradi
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "* [3]", 0, 1, 2),
-                                testCaseResult(ACCEPTED, "* [5]", 0, 1, 2),
-                                testCaseResult(RUNTIME_ERROR, "X", Optional.of(NONZERO_EXIT_CODE), 0, 2)),
+                                testCaseResult(ACCEPTED, "✓ [3]", 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓ [5]", 0, 1, 2),
+                                testCaseResult(RUNTIME_ERROR, "✕", Optional.of(NONZERO_EXIT_CODE), 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "* [1]", 1, 2),
-                                testCaseResult(ACCEPTED, "* [8]", 1, 2)),
+                                testCaseResult(ACCEPTED, "✓ [1]", 1, 2),
+                                testCaseResult(ACCEPTED, "✓ [8]", 1, 2)),
                         testGroupResult(
                                 2,
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2),

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/outputonly/OutputOnlyGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/outputonly/OutputOnlyGradingEngineIntegrationTests.java
@@ -50,11 +50,11 @@ class OutputOnlyGradingEngineIntegrationTests extends BlackboxGradingEngineInteg
                                 testCaseResult(ACCEPTED, "", Optional.empty(), 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1))),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1))),
                 ImmutableList.of(
                         subtaskResult(-1, ACCEPTED, 100)));
     }
@@ -74,11 +74,11 @@ class OutputOnlyGradingEngineIntegrationTests extends BlackboxGradingEngineInteg
                                 testCaseResult(WRONG_ANSWER, "", Optional.empty(), 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1))),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1))),
                 ImmutableList.of(
                         subtaskResult(-1, ACCEPTED, 100)));
     }
@@ -98,11 +98,11 @@ class OutputOnlyGradingEngineIntegrationTests extends BlackboxGradingEngineInteg
                                 testCaseResult(ACCEPTED, "", Optional.empty(), 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(WRONG_ANSWER, "0.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1))),
+                                testCaseResult(WRONG_ANSWER, "0", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1))),
                 ImmutableList.of(
                         subtaskResult(-1, WRONG_ANSWER, 80)));
     }
@@ -122,11 +122,11 @@ class OutputOnlyGradingEngineIntegrationTests extends BlackboxGradingEngineInteg
                                 testCaseResult(ACCEPTED, "", Optional.empty(), 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(SKIPPED, "0.0", Optional.empty(), -1))),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(SKIPPED, "0", Optional.empty(), -1))),
                 ImmutableList.of(
                         subtaskResult(-1, OK, 80)));
     }
@@ -147,11 +147,11 @@ class OutputOnlyGradingEngineIntegrationTests extends BlackboxGradingEngineInteg
                                 testCaseResult(ACCEPTED, "", Optional.empty(), 0)),
                         testGroupResult(
                                 -1,
-                                testCaseResult(OK, "10.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1),
-                                testCaseResult(ACCEPTED, "20.0", Optional.empty(), -1))),
+                                testCaseResult(OK, "10", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1),
+                                testCaseResult(ACCEPTED, "20", Optional.empty(), -1))),
                 ImmutableList.of(
                         subtaskResult(-1, OK, 90)));
     }

--- a/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/outputonly/OutputOnlyWithSubtasksGradingEngineIntegrationTests.java
+++ b/judgels-backends/judgels-grader-engines/src/integTest/java/judgels/gabriel/engines/outputonly/OutputOnlyWithSubtasksGradingEngineIntegrationTests.java
@@ -47,18 +47,18 @@ class OutputOnlyWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2))),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, ACCEPTED, 70)));
@@ -74,18 +74,18 @@ class OutputOnlyWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
-                                testCaseResult(WRONG_ANSWER, "X", Optional.empty(), 2))),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
+                                testCaseResult(WRONG_ANSWER, "✕", Optional.empty(), 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, WRONG_ANSWER, 0)));
@@ -101,13 +101,13 @@ class OutputOnlyWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(WRONG_ANSWER, "X", Optional.empty(), 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(WRONG_ANSWER, "✕", Optional.empty(), 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2)),
                         testGroupResult(
                                 2,
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2),
@@ -128,17 +128,17 @@ class OutputOnlyWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
@@ -155,12 +155,12 @@ class OutputOnlyWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(WRONG_ANSWER, "X", Optional.empty(), 1, 2),
+                                testCaseResult(WRONG_ANSWER, "✕", Optional.empty(), 1, 2),
                                 testCaseResult(SKIPPED, "?", Optional.empty(), 1, 2)),
                         testGroupResult(
                                 2,
@@ -183,18 +183,18 @@ class OutputOnlyWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2))),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, ACCEPTED, 70)));
@@ -211,18 +211,18 @@ class OutputOnlyWithSubtasksGradingEngineIntegrationTests extends BlackboxGradin
                 ImmutableList.of(
                         testGroupResult(
                                 0,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 0, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 0, 2)),
                         testGroupResult(
                                 1,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 1, 2)),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 1, 2)),
                         testGroupResult(
                                 2,
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
-                                testCaseResult(ACCEPTED, "*", Optional.empty(), 2),
-                                testCaseResult(WRONG_ANSWER, "X", Optional.empty(), 2))),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
+                                testCaseResult(ACCEPTED, "✓", Optional.empty(), 2),
+                                testCaseResult(WRONG_ANSWER, "✕", Optional.empty(), 2))),
                 ImmutableList.of(
                         subtaskResult(1, ACCEPTED, 30),
                         subtaskResult(2, WRONG_ANSWER, 0)));

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/aggregators/MinAggregator.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/aggregators/MinAggregator.java
@@ -26,20 +26,20 @@ public final class MinAggregator implements Aggregator {
                 double okPoints = 0.0;
                 if (testCaseVerdict.getPercentage().isPresent()) {
                     okPoints = testCaseVerdict.getPercentage().get() * subtaskPoints / 100.0;
-                    points = testCaseVerdict.getPercentage().get() + "%";
+                    points = PointUtils.formatPoints(testCaseVerdict.getPercentage().get()) + "%";
                 } else if (testCaseVerdict.getPoints().isPresent()) {
                     okPoints = testCaseVerdict.getPoints().get();
-                    points = "" + okPoints;
+                    points = PointUtils.formatPoints(okPoints);
                 }
                 aggregatedPoints = Math.min(aggregatedPoints, okPoints);
             } else if (verdict == Verdict.ACCEPTED) {
-                points = "*";
+                points = "✓";
             } else if (verdict == Verdict.SKIPPED) {
                 aggregatedPoints = 0.0;
                 points = "?";
             } else {
                 aggregatedPoints = 0.0;
-                points = "X";
+                points = "✕";
             }
 
             testCasePoints.add(points);

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/aggregators/PointUtils.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/aggregators/PointUtils.java
@@ -1,0 +1,18 @@
+package judgels.gabriel.aggregators;
+
+public class PointUtils {
+    private PointUtils() {}
+
+    public static String formatPoints(double pts) {
+        String result = "" + pts;
+        if (result.contains(".")) {
+            while (result.charAt(result.length() - 1) == '0') {
+                result = result.substring(0, result.length() - 1);
+            }
+            if (result.charAt(result.length() - 1) == '.') {
+                result = result.substring(0, result.length() - 1);
+            }
+        }
+        return result;
+    }
+}

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/aggregators/SumAggregator.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/gabriel/aggregators/SumAggregator.java
@@ -37,7 +37,7 @@ public final class SumAggregator implements Aggregator {
             }
             aggregatedPoints += points;
 
-            testCasePoints.add("" + points);
+            testCasePoints.add(PointUtils.formatPoints(points));
         }
         if (aggregatedVerdict == Verdict.SKIPPED) {
             aggregatedVerdict = Verdict.OK;

--- a/judgels-backends/judgels-grader-engines/src/test/java/judgels/gabriel/aggregators/MinAggregatorTests.java
+++ b/judgels-backends/judgels-grader-engines/src/test/java/judgels/gabriel/aggregators/MinAggregatorTests.java
@@ -27,7 +27,7 @@ class MinAggregatorTests {
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 70.0);
         assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.ACCEPTED, 70.0));
-        assertThat(result.getTestCasePoints()).containsExactly("*", "*");
+        assertThat(result.getTestCasePoints()).containsExactly("✓", "✓");
     }
 
     @Test
@@ -39,7 +39,7 @@ class MinAggregatorTests {
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 70.0);
         assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.RUNTIME_ERROR, 0.0));
-        assertThat(result.getTestCasePoints()).containsExactly("*", "X", "X");
+        assertThat(result.getTestCasePoints()).containsExactly("✓", "✕", "✕");
     }
 
     @Test
@@ -51,7 +51,7 @@ class MinAggregatorTests {
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 70.0);
         assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.RUNTIME_ERROR, 0.0));
-        assertThat(result.getTestCasePoints()).containsExactly("*", "X", "?");
+        assertThat(result.getTestCasePoints()).containsExactly("✓", "✕", "?");
     }
 
     @Test
@@ -63,19 +63,19 @@ class MinAggregatorTests {
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 70.0);
         assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.OK, 0.0));
-        assertThat(result.getTestCasePoints()).containsExactly("*", "*", "?");
+        assertThat(result.getTestCasePoints()).containsExactly("✓", "✓", "?");
     }
 
     @Test
     void aggregate_min_ok_points() {
         List<TestCaseVerdict> testCaseVerdicts = ImmutableList.of(
                 new TestCaseVerdict.Builder().verdict(Verdict.ACCEPTED).build(),
-                new TestCaseVerdict.Builder().verdict(Verdict.OK).points(20.0).build(),
+                new TestCaseVerdict.Builder().verdict(Verdict.OK).points(20.5).build(),
                 new TestCaseVerdict.Builder().verdict(Verdict.OK).points(30.0).build());
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 70.0);
-        assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.OK, 20.0));
-        assertThat(result.getTestCasePoints()).containsExactly("*", "20.0", "30.0");
+        assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.OK, 20.5));
+        assertThat(result.getTestCasePoints()).containsExactly("✓", "20.5", "30");
     }
 
     @Test
@@ -87,7 +87,7 @@ class MinAggregatorTests {
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 70.0);
         assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.OK, 8.75));
-        assertThat(result.getTestCasePoints()).containsExactly("*", "12.5%", "50.0%");
+        assertThat(result.getTestCasePoints()).containsExactly("✓", "12.5%", "50%");
     }
 
     @Test

--- a/judgels-backends/judgels-grader-engines/src/test/java/judgels/gabriel/aggregators/SumAggregatorTests.java
+++ b/judgels-backends/judgels-grader-engines/src/test/java/judgels/gabriel/aggregators/SumAggregatorTests.java
@@ -27,7 +27,7 @@ class SumAggregatorTests {
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 100.0);
         assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.ACCEPTED, 100.0));
-        assertThat(result.getTestCasePoints()).containsExactly("50.0", "50.0");
+        assertThat(result.getTestCasePoints()).containsExactly("50", "50");
     }
 
     @Test
@@ -40,7 +40,7 @@ class SumAggregatorTests {
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 100.0);
         assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.TIME_LIMIT_EXCEEDED, 55.0));
-        assertThat(result.getTestCasePoints()).containsExactly("25.0", "0.0", "30.0", "0.0");
+        assertThat(result.getTestCasePoints()).containsExactly("25", "0", "30", "0");
     }
 
     @Test
@@ -53,7 +53,7 @@ class SumAggregatorTests {
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 100.0);
         assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.TIME_LIMIT_EXCEEDED, 50.0));
-        assertThat(result.getTestCasePoints()).containsExactly("25.0", "25.0", "0.0", "0.0");
+        assertThat(result.getTestCasePoints()).containsExactly("25", "25", "0", "0");
     }
 
     @Test
@@ -66,7 +66,7 @@ class SumAggregatorTests {
 
         AggregationResult result = aggregator.aggregate(testCaseVerdicts, 100.0);
         assertThat(result.getSubtaskVerdict()).isEqualTo(SubtaskVerdict.of(Verdict.OK, 50.0));
-        assertThat(result.getTestCasePoints()).containsExactly("25.0", "25.0", "0.0", "0.0");
+        assertThat(result.getTestCasePoints()).containsExactly("25", "25", "0", "0");
     }
 
     @Test


### PR DESCRIPTION
- `*` => `✓`
- `X` => `✕`
- Simplify floating-point score by removing zero suffixes