### PR TITLE
problem: allow auto-populating by filename in ICPC-style problems with 1 subtask

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/michael/problem/programming/grading/config/BaseGradingConfigAdapter.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/michael/problem/programming/grading/config/BaseGradingConfigAdapter.java
@@ -340,6 +340,41 @@ public abstract class BaseGradingConfigAdapter implements GradingConfigAdapter {
             }
         }
 
+        if (maxTgNo == 0) {
+            // At this point, the provided test cases don't actually follow TCFrame format.
+            // We fall back to treating this problem to have a single subtask.
+
+            List<TestGroup> testGroupsPopulatedByFilename = autoPopulateTestDataByFilename(hasOutput, testDataFiles);
+
+            List<TestGroup> testGroupsWithSubtask1 = new ArrayList<>();
+            for (TestGroup testGroup : testGroupsPopulatedByFilename) {
+                int testGroupId = testGroup.getId() == 0 ? 0 : 1;
+
+                List<TestCase> testCasesForSubtask1 = new ArrayList<>();
+                for (TestCase testCase : testGroup.getTestCases()) {
+                    if (testGroupId == 0) {
+                        testCasesForSubtask1.add(new TestCase.Builder()
+                                .from(testCase)
+                                .subtaskIds(Set.of(0, 1))
+                                .build());
+                    } else {
+                        testCasesForSubtask1.add(new TestCase.Builder()
+                                .from(testCase)
+                                .subtaskIds(Set.of(1))
+                                .build());
+                    }
+                }
+
+                testGroupsWithSubtask1.add(new TestGroup.Builder()
+                        .id(testGroupId)
+                        .testCases(testCasesForSubtask1)
+                        .build());
+            }
+
+            List<Integer> subtask1Points = List.of(100);
+            return new Object[]{testGroupsWithSubtask1, subtask1Points};
+        }
+
         return new Object[]{testData, subtaskPoints};
     }
 

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/michael/problem/programming/grading/config/BatchWithSubtasksGradingConfigAdapterTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/michael/problem/programming/grading/config/BatchWithSubtasksGradingConfigAdapterTests.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import judgels.fs.FileInfo;
 import judgels.gabriel.api.TestCase;
 import judgels.gabriel.api.TestGroup;
@@ -112,6 +113,36 @@ public class BatchWithSubtasksGradingConfigAdapterTests extends BaseGradingConfi
                                 TestCase.of("hello_1_2.in", "hello_1_2.out", ImmutableSet.of(1, 2)))),
                         TestGroup.of(2, ImmutableList.of(
                                 TestCase.of("hello_2_1.in", "hello_2_1.out", ImmutableSet.of(2))))))
+                .build());
+    }
+
+    @Test
+    void test_auto_population_single_subtask() {
+        BatchWithSubtasksGradingConfig config = new BatchWithSubtasksGradingConfig.Builder()
+                .timeLimit(2000)
+                .memoryLimit(65536)
+                .subtaskPoints(List.of(30, 70))
+                .build();
+
+        List<FileInfo> testDataFiles = List.of(
+                createFile("hello_sample.in"),
+                createFile("hello_sample.out"),
+                createFile("hello_1.in"),
+                createFile("hello_1.out"),
+                createFile("hello_2.in"),
+                createFile("hello_2.out"),
+                createFile("hello_bogus.txt"));
+
+        BatchWithSubtasksGradingConfig populatedConfig = (BatchWithSubtasksGradingConfig) adapter.autoPopulateTestData(config, testDataFiles);
+        assertThat(populatedConfig).isEqualTo(new BatchWithSubtasksGradingConfig.Builder()
+                .from(config)
+                .testData(List.of(
+                        TestGroup.of(0, List.of(
+                                TestCase.of("hello_sample.in", "hello_sample.out", Set.of(0, 1)))),
+                        TestGroup.of(1, List.of(
+                                TestCase.of("hello_1.in", "hello_1.out", Set.of(1)),
+                                TestCase.of("hello_2.in", "hello_2.out", Set.of(1))))))
+                .subtaskPoints(List.of(100))
                 .build());
     }
 }

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/michael/problem/programming/grading/config/FunctionalWithSubtasksGradingConfigAdapterTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/michael/problem/programming/grading/config/FunctionalWithSubtasksGradingConfigAdapterTests.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import judgels.fs.FileInfo;
 import judgels.gabriel.api.TestCase;
 import judgels.gabriel.api.TestGroup;
@@ -117,6 +118,37 @@ public class FunctionalWithSubtasksGradingConfigAdapterTests extends BaseGrading
                                 TestCase.of("hello_1_2.in", "hello_1_2.out", ImmutableSet.of(1, 2)))),
                         TestGroup.of(2, ImmutableList.of(
                                 TestCase.of("hello_2_1.in", "hello_2_1.out", ImmutableSet.of(2))))))
+                .build());
+    }
+
+    @Test
+    void test_auto_population_single_subtask() {
+        FunctionalWithSubtasksGradingConfig config = new FunctionalWithSubtasksGradingConfig.Builder()
+                .timeLimit(2000)
+                .memoryLimit(65536)
+                .sourceFileFieldKeys(List.of("encoder", "decoder"))
+                .subtaskPoints(List.of(30, 70))
+                .build();
+
+        List<FileInfo> testDataFiles = List.of(
+                createFile("hello_sample_1.in"),
+                createFile("hello_sample_1.out"),
+                createFile("hello_1.in"),
+                createFile("hello_1.out"),
+                createFile("hello_2.in"),
+                createFile("hello_2.out"),
+                createFile("hello_bogus.txt"));
+
+        FunctionalWithSubtasksGradingConfig populatedConfig = (FunctionalWithSubtasksGradingConfig) adapter.autoPopulateTestData(config, testDataFiles);
+        assertThat(populatedConfig).isEqualTo(new FunctionalWithSubtasksGradingConfig.Builder()
+                .from(config)
+                .testData(List.of(
+                        TestGroup.of(0, List.of(
+                                TestCase.of("hello_sample_1.in", "hello_sample_1.out", Set.of(0, 1)))),
+                        TestGroup.of(1, List.of(
+                                TestCase.of("hello_1.in", "hello_1.out", Set.of(1)),
+                                TestCase.of("hello_2.in", "hello_2.out", Set.of(1))))))
+                .subtaskPoints(List.of(100))
                 .build());
     }
 }

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/michael/problem/programming/grading/config/InteractiveWithSubtasksGradingConfigAdapterTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/michael/problem/programming/grading/config/InteractiveWithSubtasksGradingConfigAdapterTests.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import judgels.fs.FileInfo;
 import judgels.gabriel.api.TestCase;
 import judgels.gabriel.api.TestGroup;
@@ -107,6 +108,32 @@ public class InteractiveWithSubtasksGradingConfigAdapterTests extends BaseGradin
                                 TestCase.of("hello_1_2.in", "", ImmutableSet.of(1, 2)))),
                         TestGroup.of(2, ImmutableList.of(
                                 TestCase.of("hello_2_1.in", "", ImmutableSet.of(2))))))
+                .build());
+    }
+
+    @Test
+    void test_auto_population_single_subtask() {
+        InteractiveWithSubtasksGradingConfig config = new InteractiveWithSubtasksGradingConfig.Builder()
+                .timeLimit(2000)
+                .memoryLimit(65536)
+                .subtaskPoints(List.of(30, 70))
+                .build();
+
+        List<FileInfo> testDataFiles = List.of(
+                createFile("hello_sample_1.in"),
+                createFile("hello_1.in"),
+                createFile("hello_2.in"));
+
+        InteractiveWithSubtasksGradingConfig populatedConfig = (InteractiveWithSubtasksGradingConfig) adapter.autoPopulateTestData(config, testDataFiles);
+        assertThat(populatedConfig).isEqualTo(new InteractiveWithSubtasksGradingConfig.Builder()
+                .from(config)
+                .testData(List.of(
+                        TestGroup.of(0, List.of(
+                                TestCase.of("hello_sample_1.in", "", Set.of(0, 1)))),
+                        TestGroup.of(1, List.of(
+                                TestCase.of("hello_1.in", "", Set.of(1)),
+                                TestCase.of("hello_2.in", "", Set.of(1))))))
+                .subtaskPoints(List.of(100))
                 .build());
     }
 }

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/michael/problem/programming/grading/config/OutputOnlyWithSubtasksGradingConfigAdapterTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/michael/problem/programming/grading/config/OutputOnlyWithSubtasksGradingConfigAdapterTests.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import judgels.fs.FileInfo;
 import judgels.gabriel.api.TestCase;
 import judgels.gabriel.api.TestGroup;
@@ -102,6 +103,34 @@ public class OutputOnlyWithSubtasksGradingConfigAdapterTests extends BaseGrading
                                 TestCase.of("hello_1_2.in", "hello_1_2.out", ImmutableSet.of(1, 2)))),
                         TestGroup.of(2, ImmutableList.of(
                                 TestCase.of("hello_2_1.in", "hello_2_1.out", ImmutableSet.of(2))))))
+                .build());
+    }
+
+    @Test
+    void test_auto_population_single_subtask() {
+        OutputOnlyWithSubtasksGradingConfig config = new OutputOnlyWithSubtasksGradingConfig.Builder()
+                .subtaskPoints(List.of(30, 70))
+                .build();
+
+        List<FileInfo> testDataFiles = List.of(
+                createFile("hello_sample_1.in"),
+                createFile("hello_sample_1.out"),
+                createFile("hello_1.in"),
+                createFile("hello_1.out"),
+                createFile("hello_2.in"),
+                createFile("hello_2.out"),
+                createFile("hello_bogus.txt"));
+
+        OutputOnlyWithSubtasksGradingConfig populatedConfig = (OutputOnlyWithSubtasksGradingConfig) adapter.autoPopulateTestData(config, testDataFiles);
+        assertThat(populatedConfig).isEqualTo(new OutputOnlyWithSubtasksGradingConfig.Builder()
+                .from(config)
+                .testData(List.of(
+                        TestGroup.of(0, List.of(
+                                TestCase.of("hello_sample_1.in", "hello_sample_1.out", Set.of(0, 1)))),
+                        TestGroup.of(1, List.of(
+                                TestCase.of("hello_1.in", "hello_1.out", Set.of(1)),
+                                TestCase.of("hello_2.in", "hello_2.out", Set.of(1))))))
+                .subtaskPoints(List.of(100))
                 .build());
     }
 }


### PR DESCRIPTION
When setting up ICPC-style problems, the conventional way is to use `*WithSubtasks` engine. However, when using "auto populate by tcframe format" button, sometimes it won't work because it expects the test cases to have `slug_x_y.in` format, where `x` is the test group number. When the original test cases only have `slug_no.in` format, population will fail.

This PR supports that case. In case of failed population, it will try to just populate by filename, then assign to Subtask 1.