### PR TITLE
Dropwizard: serve versioned webjars using AssetsBundle

### DIFF
--- a/judgels-backends/gradle.properties
+++ b/judgels-backends/gradle.properties
@@ -7,7 +7,6 @@ awsJavaSdkS3Version = 1.11.258
 caffeineVersion  = 3.0.2
 daggerVersion = 2.19
 dropwizardVersion = 2.1.12
-dropwizardWebJarsBundleVersion = 1.0.5
 dropwizardWebSecurityVersion = 1.1.0
 feignVersion = 11.8
 feignFormVersion = 3.8.0

--- a/judgels-backends/judgels-server-app/build.gradle
+++ b/judgels-backends/judgels-server-app/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     implementation "io.dropwizard:dropwizard-migrations:$dropwizardVersion"
     implementation "io.dropwizard:dropwizard-views-freemarker:$dropwizardVersion"
 
-    implementation "io.dropwizard-bundles:dropwizard-webjars-bundle:$dropwizardWebJarsBundleVersion"
     implementation 'javax.inject:javax.inject:1'
     implementation 'org.webjars:bootstrap:3.3.4'
     implementation 'org.webjars:jquery:2.1.4'

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
@@ -3,7 +3,6 @@ package judgels;
 import com.palantir.websecurity.WebSecurityBundle;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
-import io.dropwizard.bundles.webjars.WebJarBundle;
 import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.setup.Bootstrap;
@@ -56,10 +55,10 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
 
         bootstrap.addBundle(hibernateBundle);
         bootstrap.addBundle(new AssetsBundle());
+        bootstrap.addBundle(new AssetsBundle("/META-INF/resources/webjars", "/webjars", null, "webjars"));
         bootstrap.addBundle(new MultiPartBundle());
         bootstrap.addBundle(new JudgelsServerMigrationsBundle());
         bootstrap.addBundle(new JudgelsServerViewBundle());
-        bootstrap.addBundle(new WebJarBundle("org.webjars.bower", "org.webjars.npm"));
         bootstrap.addBundle(new WebSecurityBundle());
     }
 

--- a/judgels-backends/judgels-server-app/src/main/resources/judgels/michael/resource/ckeditor.ftl
+++ b/judgels-backends/judgels-server-app/src/main/resources/judgels/michael/resource/ckeditor.ftl
@@ -1,2 +1,2 @@
-<script src="/webjars/ckeditor/full/ckeditor.js"></script>
+<script src="/webjars/ckeditor/4.19.0/full/ckeditor.js"></script>
 <script><#include "ckeditor-3.js"></script>

--- a/judgels-backends/judgels-server-app/src/main/resources/judgels/michael/resource/katex.ftl
+++ b/judgels-backends/judgels-server-app/src/main/resources/judgels/michael/resource/katex.ftl
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="/webjars/katex/dist/katex.min.css"/>
-<script src="/webjars/katex/dist/katex.min.js"></script>
-<script src="/webjars/katex/dist/contrib/auto-render.min.js"></script>
+<link rel="stylesheet" href="/webjars/katex/0.16.4/dist/katex.min.css"/>
+<script src="/webjars/katex/0.16.4/dist/katex.min.js"></script>
+<script src="/webjars/katex/0.16.4/dist/contrib/auto-render.min.js"></script>
 <script><#include "katex.js"></script>

--- a/judgels-backends/judgels-server-app/src/main/resources/judgels/michael/template/base/baseLayout.ftl
+++ b/judgels-backends/judgels-server-app/src/main/resources/judgels/michael/template/base/baseLayout.ftl
@@ -6,13 +6,13 @@
       <meta name="robots" content="noindex">
       <title>${title}</title>
       <link rel="stylesheet" href="/assets/css/reset.css">
-      <link rel="stylesheet" href="/webjars/open-sans/css/open-sans.min.css">
-      <link rel="stylesheet" href="/webjars/roboto-fontface/css/roboto/roboto-fontface.css">
-      <link rel="stylesheet" href="/webjars/bootstrap/css/bootstrap.min.css">
+      <link rel="stylesheet" href="/webjars/open-sans/1.1.0/css/open-sans.min.css">
+      <link rel="stylesheet" href="/webjars/roboto-fontface/0.7.0/css/roboto/roboto-fontface.css">
+      <link rel="stylesheet" href="/webjars/bootstrap/3.3.4/css/bootstrap.min.css">
       <link rel="stylesheet" href="/assets/css/main-6.css">
       <link rel="shortcut icon" type="image/ico" href="/assets/images/favicon.ico">
-      <script src="/webjars/jquery/jquery.min.js"></script>
-      <script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+      <script src="/webjars/jquery/2.1.4/jquery.min.js"></script>
+      <script src="/webjars/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     </head>
     <body>
       <#nested>


### PR DESCRIPTION
Use versioned webjars instead of adding another dependency just to be able to dynamically look up webjars.