### PR TITLE
TLX: mark AWS as TLX-only feature

### DIFF
--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/FileSystems.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/FileSystems.java
@@ -2,13 +2,13 @@ package judgels.fs;
 
 import java.nio.file.Path;
 import java.util.Optional;
-import judgels.fs.aws.AwsConfiguration;
-import judgels.fs.aws.AwsFileSystem;
-import judgels.fs.aws.AwsFsConfiguration;
-import judgels.fs.duplex.DuplexFileSystem;
-import judgels.fs.duplex.DuplexFsConfiguration;
 import judgels.fs.local.LocalFileSystem;
 import judgels.fs.local.LocalFsConfiguration;
+import tlx.fs.aws.AwsConfiguration;
+import tlx.fs.aws.AwsFileSystem;
+import tlx.fs.aws.AwsFsConfiguration;
+import tlx.fs.duplex.DuplexFileSystem;
+import tlx.fs.duplex.DuplexFsConfiguration;
 
 public class FileSystems {
     private FileSystems() {}

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/FsConfiguration.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/judgels/fs/FsConfiguration.java
@@ -2,9 +2,9 @@ package judgels.fs;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import judgels.fs.aws.AwsFsConfiguration;
-import judgels.fs.duplex.DuplexFsConfiguration;
 import judgels.fs.local.LocalFsConfiguration;
+import tlx.fs.aws.AwsFsConfiguration;
+import tlx.fs.duplex.DuplexFsConfiguration;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/aws/AwsConfiguration.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/aws/AwsConfiguration.java
@@ -1,4 +1,4 @@
-package judgels.fs.aws;
+package tlx.fs.aws;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Optional;

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/aws/AwsFileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/aws/AwsFileSystem.java
@@ -1,4 +1,4 @@
-package judgels.fs.aws;
+package tlx.fs.aws;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/aws/AwsFsConfiguration.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/aws/AwsFsConfiguration.java
@@ -1,4 +1,4 @@
-package judgels.fs.aws;
+package tlx.fs.aws;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/aws/AwsModule.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/aws/AwsModule.java
@@ -1,4 +1,4 @@
-package judgels.fs.aws;
+package tlx.fs.aws;
 
 import dagger.Module;
 import dagger.Provides;

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/duplex/DuplexFileSystem.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/duplex/DuplexFileSystem.java
@@ -1,4 +1,4 @@
-package judgels.fs.duplex;
+package tlx.fs.duplex;
 
 import java.io.File;
 import java.io.InputStream;
@@ -6,8 +6,8 @@ import java.nio.file.Path;
 import java.util.List;
 import judgels.fs.FileInfo;
 import judgels.fs.FileSystem;
-import judgels.fs.aws.AwsFileSystem;
 import judgels.fs.local.LocalFileSystem;
+import tlx.fs.aws.AwsFileSystem;
 
 public final class DuplexFileSystem implements FileSystem {
     private final LocalFileSystem local;

--- a/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/duplex/DuplexFsConfiguration.java
+++ b/judgels-backends/judgels-commons/judgels-fs/src/main/java/tlx/fs/duplex/DuplexFsConfiguration.java
@@ -1,10 +1,10 @@
-package judgels.fs.duplex;
+package tlx.fs.duplex;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import judgels.fs.FsConfiguration;
-import judgels.fs.aws.AwsFsConfiguration;
 import org.immutables.value.Value;
+import tlx.fs.aws.AwsFsConfiguration;
 
 @JsonTypeName("duplex")
 @Value.Style(passAnnotations = JsonTypeName.class)

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
@@ -7,7 +7,6 @@ import io.dropwizard.core.setup.Environment;
 import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.hibernate.HibernateBundle;
 import java.time.Duration;
-import judgels.fs.aws.AwsModule;
 import judgels.jerahmeel.DaggerJerahmeelComponent;
 import judgels.jerahmeel.JerahmeelComponent;
 import judgels.jerahmeel.JerahmeelConfiguration;
@@ -40,6 +39,7 @@ import judgels.uriel.UrielComponent;
 import judgels.uriel.UrielConfiguration;
 import judgels.uriel.file.FileModule;
 import org.eclipse.jetty.server.session.SessionHandler;
+import tlx.fs.aws.AwsModule;
 
 public class JudgelsServerApplication extends Application<JudgelsServerApplicationConfiguration> {
     private final HibernateBundle<JudgelsServerApplicationConfiguration> hibernateBundle = new JudgelsServerHibernateBundle();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/JerahmeelComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/JerahmeelComponent.java
@@ -3,7 +3,6 @@ package judgels.jerahmeel;
 import dagger.Component;
 import jakarta.inject.Singleton;
 import judgels.JudgelsServerModule;
-import judgels.fs.aws.AwsModule;
 import judgels.jerahmeel.archive.ArchiveResource;
 import judgels.jerahmeel.chapter.ChapterResource;
 import judgels.jerahmeel.chapter.lesson.ChapterLessonResource;
@@ -40,6 +39,7 @@ import judgels.service.gabriel.GabrielClientModule;
 import judgels.service.hibernate.JudgelsHibernateModule;
 import judgels.service.persistence.JudgelsPersistenceModule;
 import judgels.uriel.hibernate.UrielHibernateDaoModule;
+import tlx.fs.aws.AwsModule;
 
 @Component(modules = {
         // Judgels service

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/JerahmeelConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/JerahmeelConfiguration.java
@@ -3,11 +3,11 @@ package judgels.jerahmeel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Optional;
-import judgels.fs.aws.AwsConfiguration;
 import judgels.gabriel.api.GabrielClientConfiguration;
 import judgels.jerahmeel.stats.StatsConfiguration;
 import judgels.jerahmeel.submission.programming.SubmissionConfiguration;
 import org.immutables.value.Value;
+import tlx.fs.aws.AwsConfiguration;
 
 @Value.Immutable
 @JsonDeserialize(as = ImmutableJerahmeelConfiguration.class)

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/submission/programming/SubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/submission/programming/SubmissionModule.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import judgels.fs.FileSystem;
 import judgels.fs.FileSystems;
-import judgels.fs.aws.AwsConfiguration;
 import judgels.jerahmeel.persistence.ProgrammingGradingDao;
 import judgels.jerahmeel.persistence.ProgrammingSubmissionDao;
 import judgels.jerahmeel.stats.StatsConfiguration;
@@ -32,6 +31,7 @@ import judgels.service.JudgelsScheduler;
 import judgels.uriel.persistence.ContestProgrammingGradingDao;
 import judgels.uriel.persistence.ContestProgrammingSubmissionDao;
 import judgels.uriel.submission.UrielSubmissionStore;
+import tlx.fs.aws.AwsConfiguration;
 
 @Module
 public class SubmissionModule {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/tasks/UploadDuplexSubmissionsToAwsTask.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jerahmeel/tasks/UploadDuplexSubmissionsToAwsTask.java
@@ -10,13 +10,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import judgels.fs.FileSystem;
-import judgels.fs.duplex.DuplexFileSystem;
 import judgels.jerahmeel.submission.JerahmeelSubmissionStore;
 import judgels.jerahmeel.submission.programming.SubmissionFs;
 import judgels.persistence.api.Page;
 import judgels.sandalphon.api.submission.programming.Submission;
 import judgels.sandalphon.submission.programming.SubmissionSourceBuilder;
 import judgels.sandalphon.submission.programming.SubmissionStore;
+import tlx.fs.duplex.DuplexFileSystem;
 
 /**
  * Uploads submission files from local to AWS S3.

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/JophielComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/JophielComponent.java
@@ -3,7 +3,6 @@ package judgels.jophiel;
 import dagger.Component;
 import jakarta.inject.Singleton;
 import judgels.JudgelsServerModule;
-import judgels.fs.aws.AwsModule;
 import judgels.jophiel.auth.AuthModule;
 import judgels.jophiel.hibernate.JophielHibernateDaoModule;
 import judgels.jophiel.mailer.MailerModule;
@@ -32,6 +31,7 @@ import judgels.service.JudgelsScheduler;
 import judgels.service.JudgelsSchedulerModule;
 import judgels.service.hibernate.JudgelsHibernateModule;
 import judgels.service.persistence.JudgelsPersistenceModule;
+import tlx.fs.aws.AwsModule;
 
 @Component(modules = {
         // Judgels service

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/JophielConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/JophielConfiguration.java
@@ -3,8 +3,6 @@ package judgels.jophiel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Optional;
-import judgels.fs.aws.AwsConfiguration;
-import judgels.fs.aws.AwsFsConfiguration;
 import judgels.jophiel.auth.AuthConfiguration;
 import judgels.jophiel.mailer.MailerConfiguration;
 import judgels.jophiel.session.SessionConfiguration;
@@ -15,6 +13,8 @@ import judgels.jophiel.user.superadmin.SuperadminCreatorConfiguration;
 import judgels.jophiel.user.web.WebConfiguration;
 import judgels.recaptcha.RecaptchaConfiguration;
 import org.immutables.value.Value;
+import tlx.fs.aws.AwsConfiguration;
+import tlx.fs.aws.AwsFsConfiguration;
 
 @Value.Immutable
 @JsonDeserialize(as = ImmutableJophielConfiguration.class)

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/avatar/UserAvatarModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/user/avatar/UserAvatarModule.java
@@ -7,8 +7,8 @@ import java.nio.file.Path;
 import java.util.Optional;
 import judgels.fs.FileSystem;
 import judgels.fs.FileSystems;
-import judgels.fs.aws.AwsConfiguration;
 import judgels.service.JudgelsBaseDataDir;
+import tlx.fs.aws.AwsConfiguration;
 
 @Module
 public class UserAvatarModule {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/UrielComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/UrielComponent.java
@@ -3,7 +3,6 @@ package judgels.uriel;
 import dagger.Component;
 import jakarta.inject.Singleton;
 import judgels.JudgelsServerModule;
-import judgels.fs.aws.AwsModule;
 import judgels.jophiel.hibernate.JophielHibernateDaoModule;
 import judgels.messaging.rabbitmq.RabbitMQModule;
 import judgels.sandalphon.SandalphonClientModule;
@@ -43,6 +42,7 @@ import judgels.uriel.submission.programming.SubmissionModule;
 import judgels.uriel.tasks.DumpContestTask;
 import judgels.uriel.tasks.ReplaceProblemTask;
 import judgels.uriel.tasks.UrielTaskModule;
+import tlx.fs.aws.AwsModule;
 
 @Component(modules = {
         // Judgels service

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/UrielConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/UrielConfiguration.java
@@ -3,12 +3,12 @@ package judgels.uriel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Optional;
-import judgels.fs.aws.AwsConfiguration;
-import judgels.fs.aws.AwsFsConfiguration;
 import judgels.gabriel.api.GabrielClientConfiguration;
 import judgels.uriel.file.FileConfiguration;
 import judgels.uriel.submission.programming.SubmissionConfiguration;
 import org.immutables.value.Value;
+import tlx.fs.aws.AwsConfiguration;
+import tlx.fs.aws.AwsFsConfiguration;
 
 @Value.Immutable
 @JsonDeserialize(as = ImmutableUrielConfiguration.class)

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/file/FileModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/file/FileModule.java
@@ -7,8 +7,8 @@ import java.nio.file.Path;
 import java.util.Optional;
 import judgels.fs.FileSystem;
 import judgels.fs.FileSystems;
-import judgels.fs.aws.AwsConfiguration;
 import judgels.service.JudgelsBaseDataDir;
+import tlx.fs.aws.AwsConfiguration;
 
 @Module
 public class FileModule {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/submission/programming/SubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/submission/programming/SubmissionModule.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import judgels.fs.FileSystem;
 import judgels.fs.FileSystems;
-import judgels.fs.aws.AwsConfiguration;
 import judgels.messaging.MessageClient;
 import judgels.sandalphon.submission.bundle.BaseItemSubmissionStore;
 import judgels.sandalphon.submission.bundle.ItemSubmissionStore;
@@ -30,6 +29,7 @@ import judgels.service.JudgelsScheduler;
 import judgels.uriel.persistence.ContestBundleItemSubmissionDao;
 import judgels.uriel.persistence.ContestProgrammingGradingDao;
 import judgels.uriel.persistence.ContestProgrammingSubmissionDao;
+import tlx.fs.aws.AwsConfiguration;
 
 @Module
 public class SubmissionModule {


### PR DESCRIPTION
Mark the following as TLX-only features:

#### In `judgels-server.yml`

- `jerahmeel.aws`
- `duplex` and `aws` options in:
    - `uriel.file.fs.type`
    - `uriel.submission.fs.type`
    - `jerahmeel.submission.fs.type`