### PR TITLE
TLX: mark rating as TLX-only feature

### DIFF
--- a/judgels-backends/judgels-server-api/src/main/java/tlx/jophiel/api/user/rating/UserRatingUpdateData.java
+++ b/judgels-backends/judgels-server-api/src/main/java/tlx/jophiel/api/user/rating/UserRatingUpdateData.java
@@ -1,8 +1,9 @@
-package judgels.jophiel.api.user.rating;
+package tlx.jophiel.api.user.rating;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.Instant;
 import java.util.Map;
+import judgels.jophiel.api.user.rating.UserRating;
 import org.immutables.value.Value;
 
 @Value.Immutable

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/api/ProfileApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/jophiel/api/ProfileApiIntegrationTests.java
@@ -7,13 +7,13 @@ import java.util.List;
 import judgels.BaseJudgelsApiIntegrationTests;
 import judgels.jophiel.ProfileClient;
 import judgels.jophiel.UserClient;
-import judgels.jophiel.UserRatingClient;
 import judgels.jophiel.api.profile.BasicProfile;
 import judgels.jophiel.api.profile.Profile;
 import judgels.jophiel.api.user.User;
 import judgels.jophiel.api.user.rating.UserRating;
-import judgels.jophiel.api.user.rating.UserRatingUpdateData;
 import org.junit.jupiter.api.Test;
+import tlx.jophiel.UserRatingClient;
+import tlx.jophiel.api.user.rating.UserRatingUpdateData;
 
 public class ProfileApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
     private final ProfileClient profileClient = createClient(ProfileClient.class);

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/uriel/api/BaseUrielApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/uriel/api/BaseUrielApiIntegrationTests.java
@@ -14,10 +14,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import judgels.BaseJudgelsApiIntegrationTests;
-import judgels.jophiel.UserRatingClient;
 import judgels.jophiel.api.user.User;
 import judgels.jophiel.api.user.rating.UserRating;
-import judgels.jophiel.api.user.rating.UserRatingUpdateData;
 import judgels.sandalphon.api.problem.Problem;
 import judgels.uriel.ContestClient;
 import judgels.uriel.ContestContestantClient;
@@ -43,6 +41,8 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.H2Dialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import tlx.jophiel.UserRatingClient;
+import tlx.jophiel.api.user.rating.UserRatingUpdateData;
 
 public abstract class BaseUrielApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
     protected static final String ADMIN = "admin";

--- a/judgels-backends/judgels-server-app/src/integTest/java/tlx/jophiel/api/UserRatingApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/tlx/jophiel/api/UserRatingApiIntegrationTests.java
@@ -1,15 +1,15 @@
-package judgels.jophiel.api;
+package tlx.jophiel.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 import judgels.BaseJudgelsApiIntegrationTests;
-import judgels.jophiel.UserRatingClient;
 import judgels.jophiel.api.user.User;
 import judgels.jophiel.api.user.rating.UserRating;
 import judgels.jophiel.api.user.rating.UserRatingEvent;
-import judgels.jophiel.api.user.rating.UserRatingUpdateData;
 import org.junit.jupiter.api.Test;
+import tlx.jophiel.UserRatingClient;
+import tlx.jophiel.api.user.rating.UserRatingUpdateData;
 
 public class UserRatingApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
     private final UserRatingClient userRatingClient = createClient(UserRatingClient.class);

--- a/judgels-backends/judgels-server-app/src/integTest/java/tlx/jophiel/api/UserRatingApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/tlx/jophiel/api/UserRatingApiPermissionIntegrationTests.java
@@ -1,11 +1,11 @@
-package judgels.jophiel.api;
+package tlx.jophiel.api;
 
 import java.time.Instant;
 import judgels.BaseJudgelsApiIntegrationTests;
-import judgels.jophiel.UserRatingClient;
-import judgels.jophiel.api.user.rating.UserRatingUpdateData;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
+import tlx.jophiel.UserRatingClient;
+import tlx.jophiel.api.user.rating.UserRatingUpdateData;
 
 public class UserRatingApiPermissionIntegrationTests extends BaseJudgelsApiIntegrationTests {
     private final UserRatingClient userRatingClient = createClient(UserRatingClient.class);

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/JophielComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/jophiel/JophielComponent.java
@@ -17,7 +17,6 @@ import judgels.jophiel.user.account.UserResetPasswordModule;
 import judgels.jophiel.user.avatar.UserAvatarModule;
 import judgels.jophiel.user.avatar.UserAvatarResource;
 import judgels.jophiel.user.info.UserInfoResource;
-import judgels.jophiel.user.rating.UserRatingResource;
 import judgels.jophiel.user.registration.web.UserRegistrationWebResource;
 import judgels.jophiel.user.role.UserRoleResource;
 import judgels.jophiel.user.search.UserSearchResource;
@@ -46,9 +45,9 @@ import tlx.fs.aws.AwsModule;
 
         // 3rd parties
         AuthModule.class,
-        AwsModule.class,
         MailerModule.class,
         RecaptchaModule.class,
+        AwsModule.class,
 
         // Features
         SuperadminModule.class,
@@ -67,10 +66,10 @@ public interface JophielComponent {
     UserAvatarResource userAvatarResource();
     UserInfoResource userProfileResource();
     UserRegistrationWebResource userRegistrationWebResource();
-    UserRatingResource userRatingResource();
     UserRoleResource userRoleResource();
     UserSearchResource userSearchResource();
     UserWebResource userWebResource();
+    tlx.jophiel.user.rating.UserRatingResource userRatingResource();
 
     JudgelsScheduler scheduler();
     SessionCleaner sessionCleaner();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/UrielComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/UrielComponent.java
@@ -27,7 +27,6 @@ import judgels.uriel.contest.log.ContestLogResource;
 import judgels.uriel.contest.manager.ContestManagerResource;
 import judgels.uriel.contest.module.ContestModuleResource;
 import judgels.uriel.contest.problem.ContestProblemResource;
-import judgels.uriel.contest.rating.ContestRatingResource;
 import judgels.uriel.contest.scoreboard.ContestScoreboardPoller;
 import judgels.uriel.contest.scoreboard.ContestScoreboardResource;
 import judgels.uriel.contest.scoreboard.ContestScoreboardUpdaterModule;
@@ -82,12 +81,12 @@ public interface UrielComponent {
     ContestManagerResource contestManagerResource();
     ContestModuleResource contestModuleResource();
     ContestProblemResource contestProblemResource();
-    ContestRatingResource contestRatingResource();
     ContestResource contestResource();
     ContestScoreboardResource contestScoreboardResource();
     ContestSubmissionResource contestProgrammingSubmissionResource();
     ContestSupervisorResource contestSupervisorResource();
     ContestWebResource contestWebResource();
+    tlx.uriel.contest.rating.ContestRatingResource contestRatingResource();
 
     JudgelsScheduler scheduler();
     ContestLogPoller contestLogPoller();

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/jophiel/user/rating/UserRatingResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/jophiel/user/rating/UserRatingResource.java
@@ -1,4 +1,4 @@
-package judgels.jophiel.user.rating;
+package tlx.jophiel.user.rating;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -15,10 +15,11 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import java.util.List;
 import judgels.jophiel.api.user.rating.UserRatingEvent;
-import judgels.jophiel.api.user.rating.UserRatingUpdateData;
 import judgels.jophiel.user.UserRoleChecker;
+import judgels.jophiel.user.rating.UserRatingStore;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
+import tlx.jophiel.api.user.rating.UserRatingUpdateData;
 
 @Path("/api/v2/user-rating")
 public class UserRatingResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/uriel/contest/rating/ContestRatingComputer.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/uriel/contest/rating/ContestRatingComputer.java
@@ -1,4 +1,4 @@
-package judgels.uriel.contest.rating;
+package tlx.uriel.contest.rating;
 
 import com.google.common.collect.ImmutableMap;
 import jakarta.inject.Inject;

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/uriel/contest/rating/ContestRatingResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/uriel/contest/rating/ContestRatingResource.java
@@ -1,4 +1,4 @@
-package judgels.uriel.contest.rating;
+package tlx.uriel.contest.rating;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;

--- a/judgels-backends/judgels-server-app/src/test/java/tlx/uriel/contest/rating/ContestRatingComputerTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/tlx/uriel/contest/rating/ContestRatingComputerTests.java
@@ -1,4 +1,4 @@
-package judgels.uriel.contest.rating;
+package tlx.uriel.contest.rating;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/judgels-backends/judgels-server-feign/src/main/java/tlx/jophiel/UserRatingClient.java
+++ b/judgels-backends/judgels-server-feign/src/main/java/tlx/jophiel/UserRatingClient.java
@@ -1,11 +1,11 @@
-package judgels.jophiel;
+package tlx.jophiel;
 
 import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
 import java.util.List;
 import judgels.jophiel.api.user.rating.UserRatingEvent;
-import judgels.jophiel.api.user.rating.UserRatingUpdateData;
+import tlx.jophiel.api.user.rating.UserRatingUpdateData;
 
 public interface UserRatingClient {
     @RequestLine("POST /api/v2/user-rating")


### PR DESCRIPTION
Mark the following as TLX-only feature:

- `tlx.jophiel.user.rating.UserRatingResource`
- `tlx.uriel.contest.rating.ContestRatingResource`