### PR TITLE
Dropwizard: ensure ThreadLocal is clean before running contest scoreboard updater

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/scoreboard/ContestScoreboardUpdaterModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/uriel/contest/scoreboard/ContestScoreboardUpdaterModule.java
@@ -16,6 +16,7 @@ import judgels.uriel.contest.ContestTimer;
 import judgels.uriel.contest.contestant.ContestContestantStore;
 import judgels.uriel.contest.module.ContestModuleStore;
 import judgels.uriel.contest.problem.ContestProblemStore;
+import org.hibernate.SessionFactory;
 
 @Module
 public class ContestScoreboardUpdaterModule {
@@ -26,6 +27,7 @@ public class ContestScoreboardUpdaterModule {
     static ContestScoreboardPoller contestScoreboardPoller(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             JudgelsScheduler scheduler,
+            SessionFactory sessionFactory,
             ContestStore contestStore,
             ContestScoreboardUpdater contestScoreboardUpdater) {
 
@@ -34,10 +36,12 @@ public class ContestScoreboardUpdaterModule {
         return unitOfWorkAwareProxyFactory.create(
                 ContestScoreboardPoller.class,
                 new Class<?>[] {
+                        SessionFactory.class,
                         ContestStore.class,
                         ExecutorService.class,
                         ContestScoreboardUpdater.class},
                 new Object[] {
+                        sessionFactory,
                         contestStore,
                         executorService,
                         contestScoreboardUpdater});


### PR DESCRIPTION
Fixing this error

```
ERROR [2025-08-30 12:22:43,356] judgels.uriel.contest.scoreboard.ContestScoreboardPoller: Failed to process scoreboard of contest JIDCONTN4yyVcTQxC3rsmbWQKwk
! java.lang.IllegalArgumentException: Cannot create binding for parameter reference [org.hibernate.query.sqm.tree.expression.ValueBindJpaCriteriaParameter@7e01e4a7] - reference is not a parameter of this query
! at org.hibernate.query.internal.QueryParameterBindingsImpl.makeBinding(QueryParameterBindingsImpl.java:82)
! at org.hibernate.query.internal.QueryParameterBindingsImpl.getBinding(QueryParameterBindingsImpl.java:111)
! at org.hibernate.query.sqm.internal.QuerySqmImpl.<init>(QuerySqmImpl.java:254)
! at org.hibernate.internal.AbstractSharedSessionContract.createCriteriaQuery(AbstractSharedSessionContract.java:1337)
! at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:1298)
! at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:126)
! at judgels.persistence.hibernate.HibernateQueryBuilder.list(HibernateQueryBuilder.java:102)
! at judgels.persistence.hibernate.HibernateQueryBuilder.all(HibernateQueryBuilder.java:78)
! at judgels.jophiel.hibernate.UserInfoHibernateDao.selectAllByUserJids(UserInfoHibernateDao.java:26)
! at judgels.jophiel.user.info.UserInfoStore.getInfos(UserInfoStore.java:27)
! at judgels.jophiel.profile.ProfileStore.getProfiles(ProfileStore.java:46)
! at judgels.jophiel.JophielClient.getProfiles(JophielClient.java:51)
! at judgels.uriel.contest.scoreboard.ContestScoreboardUpdater.update(ContestScoreboardUpdater.java:126)
! at judgels.uriel.contest.scoreboard.ContestScoreboardUpdater$ByteBuddy$WMgTwzeT.update$accessor$Qgk8lQZ5(Unknown Source)
! at judgels.uriel.contest.scoreboard.ContestScoreboardUpdater$ByteBuddy$WMgTwzeT$auxiliary$6wCc2j8c.call(Unknown Source)
! at io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory$MethodInterceptor.invoke(UnitOfWorkAwareProxyFactory.java:167)
! at judgels.uriel.contest.scoreboard.ContestScoreboardUpdater$ByteBuddy$WMgTwzeT.update(Unknown Source)
! at judgels.uriel.contest.scoreboard.ContestScoreboardPoller.lambda$updateContestAsync$0(ContestScoreboardPoller.java:50)
! ... 5 common frames omitted
! Causing: java.util.concurrent.CompletionException: java.lang.IllegalArgumentException: Cannot create binding for parameter reference [org.hibernate.query.sqm.tree.expression.ValueBindJpaCriteriaParameter@7e01e4a7] - reference is not a parameter of this query
! at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source)
! at java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source)
! at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source)
! at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
! at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
! at com.codahale.metrics.InstrumentedThreadFactory$InstrumentedRunnable.run(InstrumentedThreadFactory.java:66)
! at java.base/java.lang.Thread.run(Unknown Source)
```