### PR TITLE
feat: add button to copy source code from submission

### DIFF
--- a/judgels-client/src/components/SubmissionDetails/Programming/SubmissionDetails.jsx
+++ b/judgels-client/src/components/SubmissionDetails/Programming/SubmissionDetails.jsx
@@ -395,11 +395,11 @@ export function SubmissionDetails({
         <ContentCard key={key}>
           <div>
             {!hideSourceFilename && (
-              <h5 className="source-heading">
+              <h5 className="source-filename">
                 {key === DEFAULT_SOURCE_KEY ? '' : key + ': '} {submissionFiles[key].name}
               </h5>
             )}
-            <Button small className="source-download" icon={<Clipboard />} onClick={onCopy}>
+            <Button small className="source-copy" icon={<Clipboard />} onClick={onCopy}>
               Copy
             </Button>
             <div className="clearfix" />

--- a/judgels-client/src/components/SubmissionDetails/Programming/SubmissionDetails.jsx
+++ b/judgels-client/src/components/SubmissionDetails/Programming/SubmissionDetails.jsx
@@ -1,5 +1,5 @@
 import { Button, HTMLTable, ProgressBar } from '@blueprintjs/core';
-import { Download, Lock } from '@blueprintjs/icons';
+import { Clipboard, Download, Lock } from '@blueprintjs/icons';
 import { Link } from 'react-router-dom';
 
 import { isInteractive, isOutputOnly } from '../../../modules/api/gabriel/engine';
@@ -387,27 +387,36 @@ export function SubmissionDetails({
     const { details, verdict } = grading;
     const { submissionFiles } = source;
 
-    const sourceFiles = Object.keys(submissionFiles).map(key => (
-      <ContentCard key={key}>
-        {!hideSourceFilename && (
-          <h5>
-            {key === DEFAULT_SOURCE_KEY ? '' : key + ': '} {submissionFiles[key].name}
-          </h5>
-        )}
-        <SourceCode language={getGradingLanguageSyntaxHighlighterValue(gradingLanguage)}>
-          {decodeBase64(submissionFiles[key].content)}
-        </SourceCode>
-        {verdict.code === VerdictCode.CE &&
-          details &&
-          details.compilationOutputs &&
-          details.compilationOutputs[key] !== undefined && (
-            <div className="compilation-output">
-              <h5>Compilation Output</h5>
-              <pre>{details.compilationOutputs[key]}</pre>
-            </div>
-          )}
-      </ContentCard>
-    ));
+    const sourceFiles = Object.keys(submissionFiles).map(key => {
+      const sourceCode = decodeBase64(submissionFiles[key].content);
+      const onCopy = () => navigator.clipboard.writeText(sourceCode);
+
+      return (
+        <ContentCard key={key}>
+          <div>
+            {!hideSourceFilename && (
+              <h5 className="source-heading">
+                {key === DEFAULT_SOURCE_KEY ? '' : key + ': '} {submissionFiles[key].name}
+              </h5>
+            )}
+            <Button small className="source-download" icon={<Clipboard />} onClick={onCopy}>
+              Copy
+            </Button>
+            <div className="clearfix" />
+          </div>
+          <SourceCode language={getGradingLanguageSyntaxHighlighterValue(gradingLanguage)}>{sourceCode}</SourceCode>
+          {verdict.code === VerdictCode.CE &&
+            details &&
+            details.compilationOutputs &&
+            details.compilationOutputs[key] !== undefined && (
+              <div className="compilation-output">
+                <h5>Compilation Output</h5>
+                <pre>{details.compilationOutputs[key]}</pre>
+              </div>
+            )}
+        </ContentCard>
+      );
+    });
 
     const defaultCompilationOutputs =
       verdict.code === VerdictCode.CE &&

--- a/judgels-client/src/components/SubmissionDetails/Programming/SubmissionDetails.scss
+++ b/judgels-client/src/components/SubmissionDetails/Programming/SubmissionDetails.scss
@@ -49,11 +49,13 @@
     margin-top: 10px;
   }
 
-  .source-heading {
+  .source-heading,
+  .source-filename {
     float: left;
   }
 
-  .source-download {
+  .source-download,
+  .source-copy {
     margin-left: 10px;
     float: left;
   }

--- a/judgels-client/src/modules/clipboard/clipboard.js
+++ b/judgels-client/src/modules/clipboard/clipboard.js
@@ -1,0 +1,15 @@
+import { toastActions } from '../toast/toastActions';
+
+export const isClipboardWriteTextSupported = () => {
+  return !!(navigator.clipboard && navigator.clipboard.writeText);
+};
+
+export function copyTextToClipboard(text) {
+  if (!isClipboardWriteTextSupported()) {
+    return;
+  }
+  navigator.clipboard.writeText(text).then(
+    () => toastActions.showSuccessToast('Source code copied.'),
+    () => toastActions.showErrorToast({ message: 'Failed to copy.' })
+  );
+}


### PR DESCRIPTION
Screenshots:
<img width="1920" height="893" alt="Click button" src="https://github.com/user-attachments/assets/66dff9ce-96bc-4ebe-a929-24360379557e" />
<img width="1920" height="893" alt="Click button programmatically" src="https://github.com/user-attachments/assets/c97f718f-7c49-49a3-bc80-8b0fb61f6bc0" />

Minor issues:
- The toast is not visible when the page is scrolled down
- Source file name and copy button is slightly vertically-misaligned