### PR TITLE
Enforce MySQL JDBC connection to use UTC timezone

### DIFF
--- a/judgels-backends/judgels-server-app/var/conf/judgels-server.yml.example
+++ b/judgels-backends/judgels-server-app/var/conf/judgels-server.yml.example
@@ -16,7 +16,7 @@ server:
 
 database:
   driverClass: com.mysql.cj.jdbc.Driver
-  url: jdbc:mysql://localhost/judgels?useSSL=false
+  url: jdbc:mysql://localhost/judgels?useSSL=false&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true
   user: judgels
   password: judgels
   properties:


### PR DESCRIPTION
This is to fix wrong results for the `getActiveContests()` endpoint which uses `UNIX_TIMESTAMP()` and `FROM_UNIXTIME()`.