### PR TITLE
Standardize judgels-client test patterns

### DIFF
--- a/judgels-client/src/components/forms/FormTableCheckbox/FormTableCheckbox.jsx
+++ b/judgels-client/src/components/forms/FormTableCheckbox/FormTableCheckbox.jsx
@@ -16,6 +16,7 @@ export function FormTableCheckbox(props) {
       <Checkbox
         defaultChecked={!!value}
         onChange={newOnChange}
+        aria-label={props.label}
         {...inputProps}
         className={classNames(getIntentClassName(meta))}
       />

--- a/judgels-client/src/components/forms/FormTableDateInput/FormTableDateInput.jsx
+++ b/judgels-client/src/components/forms/FormTableDateInput/FormTableDateInput.jsx
@@ -26,7 +26,7 @@ export function FormTableDateInput(props) {
         maxDate={new Date(4102444800000)}
         timePickerProps={{ showArrowButtons: true }}
         onChange={onChange}
-        inputProps={{ name: inputProps.name }}
+        inputProps={{ name: inputProps.name, 'aria-label': props.label }}
         {...inputProps}
       />
       <FormInputValidation meta={meta} />

--- a/judgels-client/src/components/forms/FormTableSelect/FormTableSelect.jsx
+++ b/judgels-client/src/components/forms/FormTableSelect/FormTableSelect.jsx
@@ -10,7 +10,7 @@ export function FormTableSelect(props) {
   const { input, meta, children } = props;
   return (
     <FormTableInput {...props}>
-      <HTMLSelect {...input} className={classNames(getIntentClassName(meta))}>
+      <HTMLSelect {...input} aria-label={props.label} className={classNames(getIntentClassName(meta))}>
         {children}
       </HTMLSelect>
     </FormTableInput>

--- a/judgels-client/src/components/forms/FormTableTextInput/FormTableTextInput.jsx
+++ b/judgels-client/src/components/forms/FormTableTextInput/FormTableTextInput.jsx
@@ -12,6 +12,7 @@ export function FormTableTextInput(props) {
         {...input}
         type={type || 'text'}
         disabled={disabled}
+        aria-label={props.label}
         className={classNames(Classes.INPUT, getIntentClassName(meta))}
       />
     </FormTableInput>

--- a/judgels-client/src/routes/admin/archives/ArchiveCreateDialog/ArchiveCreateDialog.test.jsx
+++ b/judgels-client/src/routes/admin/archives/ArchiveCreateDialog/ArchiveCreateDialog.test.jsx
@@ -29,16 +29,16 @@ describe('ArchiveCreateDialog', () => {
     const button = screen.getByRole('button');
     await user.click(button);
 
-    const slug = document.querySelector('input[name="slug"]');
+    const slug = screen.getByRole('textbox', { name: /slug/i });
     await user.type(slug, 'new-archive');
 
-    const name = document.querySelector('input[name="name"]');
+    const name = screen.getByRole('textbox', { name: /^name$/i });
     await user.type(name, 'New archive');
 
-    const category = document.querySelector('input[name="category"]');
+    const category = screen.getByRole('textbox', { name: /category/i });
     await user.type(category, 'New category');
 
-    const description = document.querySelector('textarea[name="description"]');
+    const description = screen.getByRole('textbox', { name: /description/i });
     await user.type(description, 'New description');
 
     nockJerahmeel()

--- a/judgels-client/src/routes/admin/users/UserViewPage/UserViewPage.test.jsx
+++ b/judgels-client/src/routes/admin/users/UserViewPage/UserViewPage.test.jsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 
@@ -40,18 +40,34 @@ describe('UserViewPage', () => {
   test('renders user details', async () => {
     await renderComponent();
 
-    expect(await screen.findAllByText(/andi/));
-    expect(screen.getByText('JIDUSER123')).toBeInTheDocument();
-    expect(screen.getByText('andi@example.com')).toBeInTheDocument();
-  });
+    await screen.findAllByText(/andi/);
+    const tables = screen.getAllByRole('table');
+    expect(
+      within(tables[0])
+        .getAllByRole('row')
+        .map(row =>
+          within(row)
+            .getAllByRole('cell')
+            .map(cell => cell.textContent)
+        )
+    ).toEqual([
+      ['JID', 'JIDUSER123'],
+      ['Email', 'andi@example.com'],
+    ]);
 
-  test('renders user info', async () => {
-    await renderComponent();
-
-    expect(await screen.findByText(/Andi Smith/)).toBeInTheDocument();
-    expect(screen.getByText('Andi Smith')).toBeInTheDocument();
-    expect(screen.getByText('MALE')).toBeInTheDocument();
-    expect(screen.getByText('ID')).toBeInTheDocument();
+    expect(
+      within(tables[1])
+        .getAllByRole('row')
+        .map(row =>
+          within(row)
+            .getAllByRole('cell')
+            .map(cell => cell.textContent)
+        )
+    ).toEqual([
+      ['Name', 'Andi Smith'],
+      ['Gender', 'MALE'],
+      ['Country', 'ID'],
+    ]);
   });
 
   test('user info form', async () => {
@@ -62,16 +78,16 @@ describe('UserViewPage', () => {
     const button = await screen.findByRole('button', { name: /edit/i });
     await user.click(button);
 
-    const name = document.querySelector('input[name="name"]');
+    const name = screen.getByRole('textbox', { name: /name/i });
     expect(name).toHaveValue('Andi Smith');
     await user.clear(name);
     await user.type(name, 'Caca');
 
-    const gender = document.querySelector('select[name="gender"]');
+    const gender = screen.getByRole('combobox', { name: /gender/i });
     expect(gender).toHaveValue('MALE');
     await user.selectOptions(gender, 'FEMALE');
 
-    const country = document.querySelector('select[name="country"]');
+    const country = screen.getByRole('combobox', { name: /country/i });
     expect(country).toHaveValue('ID');
     await user.selectOptions(country, 'US');
 

--- a/judgels-client/src/routes/contests/contests/single/announcements/ContestAnnouncementCard/ContestAnnouncementCard.jsx
+++ b/judgels-client/src/routes/contests/contests/single/announcements/ContestAnnouncementCard/ContestAnnouncementCard.jsx
@@ -41,7 +41,7 @@ export function ContestAnnouncementCard({
   };
 
   return (
-    <Callout className="contest-announcement-card" intent={intent} icon={null}>
+    <Callout role="article" className="contest-announcement-card" intent={intent} icon={null}>
       <Flex justifyContent="space-between">
         <h5>{announcement.title}</h5>
         <p>

--- a/judgels-client/src/routes/contests/contests/single/announcements/ContestAnnouncementsPage/ContestAnnouncementsPage.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/announcements/ContestAnnouncementsPage/ContestAnnouncementsPage.test.jsx
@@ -83,15 +83,15 @@ describe('ContestAnnouncementsPage', () => {
   test('renders placeholder when there are no announcements', async () => {
     await renderComponent({ announcements: [] });
     expect(await screen.findByText('No announcements.')).toBeInTheDocument();
-    expect(document.querySelectorAll('div.contest-announcement-card')).toHaveLength(0);
+    expect(screen.queryAllByRole('article')).toHaveLength(0);
   });
 
   test('renders announcements when not canSupervise', async () => {
     await renderComponent({ canSupervise: false });
     await waitFor(() => {
-      expect(document.querySelectorAll('div.contest-announcement-card').length).toBeGreaterThan(0);
+      expect(screen.getAllByRole('article').length).toBeGreaterThan(0);
     });
-    const announcements = document.querySelectorAll('div.contest-announcement-card');
+    const announcements = screen.getAllByRole('article');
     expect(announcements).toHaveLength(2);
 
     expect(within(announcements[0]).getByRole('heading')).toHaveTextContent('Title 1');
@@ -106,9 +106,9 @@ describe('ContestAnnouncementsPage', () => {
   test('renders announcements when canSupervise', async () => {
     await renderComponent({ canSupervise: true });
     await waitFor(() => {
-      expect(document.querySelectorAll('div.contest-announcement-card').length).toBeGreaterThan(0);
+      expect(screen.getAllByRole('article').length).toBeGreaterThan(0);
     });
-    const announcements = document.querySelectorAll('div.contest-announcement-card');
+    const announcements = screen.getAllByRole('article');
     expect(announcements).toHaveLength(2);
 
     expect(within(announcements[0]).getByRole('heading')).toHaveTextContent('Title 1');
@@ -123,9 +123,9 @@ describe('ContestAnnouncementsPage', () => {
   test('renders announcements when canManage', async () => {
     await renderComponent({ canSupervise: true, canManage: true });
     await waitFor(() => {
-      expect(document.querySelectorAll('div.contest-announcement-card').length).toBeGreaterThan(0);
+      expect(screen.getAllByRole('article').length).toBeGreaterThan(0);
     });
-    const announcements = document.querySelectorAll('div.contest-announcement-card');
+    const announcements = screen.getAllByRole('article');
     expect(announcements).toHaveLength(2);
 
     expect(within(announcements[0]).getByRole('heading')).toHaveTextContent('Title 1');

--- a/judgels-client/src/routes/contests/contests/single/clarifications/ContestClarificationCard/ContestClarificationCard.jsx
+++ b/judgels-client/src/routes/contests/contests/single/clarifications/ContestClarificationCard/ContestClarificationCard.jsx
@@ -79,7 +79,7 @@ export function ContestClarificationCard({
   };
 
   return (
-    <Callout className="contest-clarification-card" intent={questionIntent} icon={null}>
+    <Callout role="article" className="contest-clarification-card" intent={questionIntent} icon={null}>
       <Flex justifyContent="space-between">
         <h5>
           {clarification.title} &nbsp; <Tag>{topic}</Tag>
@@ -93,6 +93,7 @@ export function ContestClarificationCard({
       <hr />
       <div className="multiline-text">{clarification.question}</div>
       <Callout
+        role="article"
         className="contest-clarification-card contest-clarification-card__answer"
         intent={answerIntent}
         icon={null}

--- a/judgels-client/src/routes/contests/contests/single/clarifications/ContestClarificationsPage/ContestClarificationsPage.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/clarifications/ContestClarificationsPage/ContestClarificationsPage.test.jsx
@@ -96,15 +96,15 @@ describe('ContestClarificationsPage', () => {
   test('renders placeholder when there are no clarifications', async () => {
     await renderComponent({ clarifications: [] });
     expect(await screen.findByText('No clarifications.')).toBeInTheDocument();
-    expect(document.querySelectorAll('div.contest-clarification-card')).toHaveLength(0);
+    expect(screen.queryAllByRole('article')).toHaveLength(0);
   });
 
   test('renders clarifications when not canSupervise', async () => {
     await renderComponent({ canSupervise: false });
     await waitFor(() => {
-      expect(document.querySelectorAll('div.contest-clarification-card').length).toBeGreaterThan(0);
+      expect(screen.getAllByRole('article').length).toBeGreaterThan(0);
     });
-    const clarifications = document.querySelectorAll('div.contest-clarification-card');
+    const clarifications = screen.getAllByRole('article');
     expect(clarifications).toHaveLength(4);
 
     expect(within(clarifications[0]).getAllByRole('heading')[0]).toHaveTextContent('Title 1 General');
@@ -125,9 +125,9 @@ describe('ContestClarificationsPage', () => {
   test('renders clarifications when canSupervise', async () => {
     await renderComponent({ canSupervise: true });
     await waitFor(() => {
-      expect(document.querySelectorAll('div.contest-clarification-card').length).toBeGreaterThan(0);
+      expect(screen.getAllByRole('article').length).toBeGreaterThan(0);
     });
-    const clarifications = document.querySelectorAll('div.contest-clarification-card');
+    const clarifications = screen.getAllByRole('article');
     expect(clarifications).toHaveLength(4);
 
     expect(within(clarifications[0]).getAllByRole('heading')[0]).toHaveTextContent('Title 1 General');

--- a/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsTab/ContestEditConfigsTab.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsTab/ContestEditConfigsTab.test.jsx
@@ -1,5 +1,6 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 
 import { setSession } from '../../../../../../modules/session';
 import { QueryClientProviderWrapper } from '../../../../../../test/QueryClientProviderWrapper';
@@ -73,47 +74,45 @@ describe('ContestEditConfigsTab', () => {
     const button = await screen.findByRole('button', { name: /edit/i });
     await user.click(button);
 
-    const icpcWrongSubmissionPenalty = document.querySelector('input[name="icpcWrongSubmissionPenalty"]');
+    const icpcWrongSubmissionPenalty = screen.getByRole('textbox', { name: /wrong submission penalty/i });
     await user.clear(icpcWrongSubmissionPenalty);
     await user.type(icpcWrongSubmissionPenalty, '25');
 
-    const scoreboardIsIncognito = document.querySelector('input[name="scoreboardIsIncognito"]');
+    const scoreboardIsIncognito = screen.getByRole('checkbox', { name: /incognito scoreboard/i });
     await user.click(scoreboardIsIncognito);
 
-    const clarificationTimeLimitDuration = document.querySelector('input[name="clarificationTimeLimitDuration"]');
+    const clarificationTimeLimitDuration = screen.getByRole('textbox', { name: /clarification duration/i });
     await user.clear(clarificationTimeLimitDuration);
     await user.type(clarificationTimeLimitDuration, '2h 5m');
 
-    const divisionDivision = document.querySelector('input[name="divisionDivision"]');
+    const divisionDivision = screen.getByRole('textbox', { name: /division/i });
     await user.clear(divisionDivision);
     await user.type(divisionDivision, '2');
 
-    const frozenScoreboardFreezeTime = document.querySelector('input[name="frozenScoreboardFreezeTime"]');
+    const frozenScoreboardFreezeTime = screen.getByRole('textbox', { name: /freeze time/i });
     await user.clear(frozenScoreboardFreezeTime);
     await user.type(frozenScoreboardFreezeTime, '1h 5m');
 
-    const frozenScoreboardIsOfficialAllowed = document.querySelector('input[name="frozenScoreboardIsOfficialAllowed"]');
+    const frozenScoreboardIsOfficialAllowed = screen.getByRole('checkbox', { name: /is now unfrozen/i });
     await user.click(frozenScoreboardIsOfficialAllowed);
 
-    const mergedScoreboardPreviousContestJid = document.querySelector(
-      'input[name="mergedScoreboardPreviousContestJid"]'
-    );
+    const mergedScoreboardPreviousContestJid = screen.getByRole('textbox', { name: /previous contest jid/i });
     await user.clear(mergedScoreboardPreviousContestJid);
     await user.type(mergedScoreboardPreviousContestJid, 'JIDCONT12345');
 
-    const externalScoreboardReceiverUrl = document.querySelector('input[name="externalScoreboardReceiverUrl"]');
+    const externalScoreboardReceiverUrl = screen.getByRole('textbox', { name: /receiver url/i });
     await user.clear(externalScoreboardReceiverUrl);
     await user.type(externalScoreboardReceiverUrl, 'http://new.external.scoreboard');
 
-    const externalScoreboardReceiverSecret = document.querySelector('input[name="externalScoreboardReceiverSecret"]');
+    const externalScoreboardReceiverSecret = screen.getByRole('textbox', { name: /receiver secret/i });
     await user.clear(externalScoreboardReceiverSecret);
     await user.type(externalScoreboardReceiverSecret, 'the_new_secret');
 
-    const virtualDuration = document.querySelector('input[name="virtualDuration"]');
+    const virtualDuration = screen.getByRole('textbox', { name: /virtual contest duration/i });
     await user.clear(virtualDuration);
     await user.type(virtualDuration, '5h 5m');
 
-    const editorialPreface = document.querySelector('textarea[name="editorialPreface"]');
+    const editorialPreface = screen.getByRole('textbox', { name: /preface/i });
     await user.clear(editorialPreface);
     await user.type(editorialPreface, '<p>Thank you for your participation.</p>');
 
@@ -154,6 +153,8 @@ describe('ContestEditConfigsTab', () => {
 
     const submitButton = screen.getByRole('button', { name: /save/i });
     await user.click(submitButton);
+
+    await waitFor(() => expect(nock.isDone()).toBe(true));
   });
 
   test('submits empty restriction when we allow all languages', async () => {
@@ -172,7 +173,7 @@ describe('ContestEditConfigsTab', () => {
     const button = await screen.findByRole('button', { name: /edit/i });
     await user.click(button);
 
-    const icpcAllowAllLanguages = document.querySelector('input[name="icpcAllowAllLanguages"]');
+    const icpcAllowAllLanguages = screen.getByRole('checkbox', { name: /\(all\)/i });
     await user.click(icpcAllowAllLanguages);
 
     nockUriel()
@@ -187,6 +188,8 @@ describe('ContestEditConfigsTab', () => {
 
     const submitButton = screen.getByRole('button', { name: /save/i });
     await user.click(submitButton);
+
+    await waitFor(() => expect(nock.isDone()).toBe(true));
   });
 
   test('submits the restriction when we allow not all languages', async () => {
@@ -205,7 +208,7 @@ describe('ContestEditConfigsTab', () => {
     const button = await screen.findByRole('button', { name: /edit/i });
     await user.click(button);
 
-    const icpcAllowAllLanguages = document.querySelector('input[name="icpcAllowAllLanguages"]');
+    const icpcAllowAllLanguages = screen.getByRole('checkbox', { name: /\(all\)/i });
     await user.click(icpcAllowAllLanguages);
 
     const icpcAllowedLanguagesPascal = screen.getByRole('checkbox', { name: /pascal/i });
@@ -226,5 +229,7 @@ describe('ContestEditConfigsTab', () => {
 
     const submitButton = screen.getByRole('button', { name: /save/i });
     await user.click(submitButton);
+
+    await waitFor(() => expect(nock.isDone()).toBe(true));
   });
 });

--- a/judgels-client/src/routes/contests/contests/single/components/ContestEditDescriptionTab/ContestEditDescriptionTab.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/components/ContestEditDescriptionTab/ContestEditDescriptionTab.test.jsx
@@ -1,5 +1,6 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 
 import { setSession } from '../../../../../../modules/session';
 import { QueryClientProviderWrapper } from '../../../../../../test/QueryClientProviderWrapper';
@@ -50,5 +51,7 @@ describe('ContestEditDescriptionTab', () => {
 
     const submitButton = screen.getByRole('button', { name: /save/i });
     await user.click(submitButton);
+
+    await waitFor(() => expect(nock.isDone()).toBe(true));
   });
 });

--- a/judgels-client/src/routes/contests/contests/single/components/ContestEditGeneralTab/ContestEditGeneralTab.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/components/ContestEditGeneralTab/ContestEditGeneralTab.test.jsx
@@ -1,5 +1,6 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 
 import { setSession } from '../../../../../../modules/session';
 import { QueryClientProviderWrapper } from '../../../../../../test/QueryClientProviderWrapper';
@@ -24,7 +25,6 @@ describe('ContestEditGeneralTab', () => {
         style: 'ICPC',
         beginTime: parseDateTime('2018-09-10 13:00').getTime(),
       });
-    nockUriel().get('/contests/slug/contest-a/config').reply(200, {});
 
     await act(async () =>
       render(
@@ -45,12 +45,12 @@ describe('ContestEditGeneralTab', () => {
     const button = await screen.findByRole('button', { name: /edit/i });
     await user.click(button);
 
-    const slug = document.querySelector('input[name="slug"]');
+    const slug = screen.getByRole('textbox', { name: /slug/i });
     expect(slug).toHaveValue('contest-a');
     await user.clear(slug);
     await user.type(slug, 'contest-b');
 
-    const name = document.querySelector('input[name="name"]');
+    const name = screen.getByRole('textbox', { name: /^name$/i });
     expect(name).toHaveValue('Contest A');
     await user.clear(name);
     await user.type(name, 'Contest B');
@@ -59,7 +59,7 @@ describe('ContestEditGeneralTab', () => {
     await user.clear(beginTime);
     await user.type(beginTime, '2018-09-10 17:00');
 
-    const duration = document.querySelector('input[name="duration"]');
+    const duration = screen.getByRole('textbox', { name: /duration/i });
     await user.clear(duration);
     await user.type(duration, '6h');
 
@@ -84,5 +84,7 @@ describe('ContestEditGeneralTab', () => {
       });
 
     await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(nock.isDone()).toBe(true));
   });
 });

--- a/judgels-client/src/routes/contests/contests/single/files/ContestFilesPage/ContestFilesPage.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/files/ContestFilesPage/ContestFilesPage.test.jsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 
@@ -55,7 +55,18 @@ describe('ContestFilesPage', () => {
       expect(screen.getAllByRole('row').length).toBeGreaterThan(1);
     });
     const rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(1 + 1 + 2);
+    expect(
+      rows.map(row =>
+        within(row)
+          .queryAllByRole('cell')
+          .map(cell => cell.textContent)
+      )
+    ).toEqual([
+      ['', 'Upload new file...'],
+      [],
+      ['editorial.pdf', '100 B', expect.any(String), ''],
+      ['solutions.zip', '100 B', expect.any(String), ''],
+    ]);
   });
 
   test('upload form', async () => {

--- a/judgels-client/src/routes/contests/contests/single/problems/ContestProblemsPage/ContestProblemsPage.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/problems/ContestProblemsPage/ContestProblemsPage.test.jsx
@@ -76,8 +76,7 @@ describe('ContestProblemsPage', () => {
     await renderComponent({ problems: [] });
 
     expect(await screen.findByText(/no problems/i)).toBeInTheDocument();
-    const cards = document.querySelectorAll('div.contest-problem-card');
-    expect(cards).toHaveLength(0);
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
   });
 
   test('renders the problems when there are problems', async () => {
@@ -100,8 +99,8 @@ describe('ContestProblemsPage', () => {
     });
 
     await waitFor(() => {
-      const cards = document.querySelectorAll('div.contest-problem-card');
-      expect([...cards].map(card => card.textContent)).toEqual([
+      const cards = screen.getAllByRole('link');
+      expect(cards.map(card => card.textContent)).toEqual([
         'B. Problem B [100 points]8 submissions left',
         'A. Problem ACLOSED',
       ]);

--- a/judgels-client/src/routes/contests/contests/single/supervisors/ContestSupervisorAddDialog/ContestSupervisorAddDialog.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/supervisors/ContestSupervisorAddDialog/ContestSupervisorAddDialog.test.jsx
@@ -36,10 +36,10 @@ describe('ContestSupervisorAddDialog', () => {
     const usernames = screen.getByRole('textbox');
     await user.type(usernames, 'andi\n\nbudi\n caca  \n');
 
-    const announcementPermission = document.querySelector('input[name="managementPermissions.Announcements"]');
+    const announcementPermission = screen.getByRole('checkbox', { name: /announcements/i });
     await user.click(announcementPermission);
 
-    const clarificationPermission = document.querySelector('input[name="managementPermissions.Clarifications"]');
+    const clarificationPermission = screen.getByRole('checkbox', { name: /clarifications/i });
     await user.click(clarificationPermission);
 
     nockUriel()

--- a/judgels-client/src/routes/jophiel/login/LoginPage/LoginPage.test.jsx
+++ b/judgels-client/src/routes/jophiel/login/LoginPage/LoginPage.test.jsx
@@ -28,7 +28,7 @@ describe('LoginPage', () => {
     const usernameOrEmail = screen.getByRole('textbox', { name: /username or email/i });
     await user.type(usernameOrEmail, 'user');
 
-    const password = document.querySelector('input[name="password"]');
+    const password = screen.getByLabelText(/password/i);
     await user.type(password, 'pass');
 
     nockJophiel()

--- a/judgels-client/src/routes/jophiel/register/RegisterPage/RegisterPage.test.jsx
+++ b/judgels-client/src/routes/jophiel/register/RegisterPage/RegisterPage.test.jsx
@@ -36,10 +36,10 @@ describe('RegisterPage', () => {
     const email = screen.getByRole('textbox', { name: /email/i });
     await user.type(email, 'email@domain.com');
 
-    const password = document.querySelector('input[name="password"]');
+    const password = screen.getByLabelText(/^password$/i);
     await user.type(password, 'pass');
 
-    const confirmPassword = document.querySelector('input[name="confirmPassword"]');
+    const confirmPassword = screen.getByLabelText(/confirm password/i);
     await user.type(confirmPassword, 'pass');
 
     nockJophiel().get('/user-search/username-exists/user').reply(200, false);

--- a/judgels-client/src/routes/jophiel/resetPassword/ResetPasswordPage/ResetPasswordPage.test.jsx
+++ b/judgels-client/src/routes/jophiel/resetPassword/ResetPasswordPage/ResetPasswordPage.test.jsx
@@ -25,10 +25,10 @@ describe('ResetPasswordPage', () => {
 
     const user = userEvent.setup();
 
-    const password = document.querySelector('input[name="password"]');
+    const password = screen.getByLabelText(/^new password$/i);
     await user.type(password, 'pass');
 
-    const confirmPassword = document.querySelector('input[name="confirmPassword"]');
+    const confirmPassword = screen.getByLabelText(/^confirm new password$/i);
     await user.type(confirmPassword, 'pass');
 
     nockJophiel().post('/user-account/reset-password', { emailCode: 'code123', newPassword: 'pass' }).reply(200);


### PR DESCRIPTION
## Summary

- Replace `document.querySelector` with testing-library selectors (`getByRole`, `getByLabelText`) for form inputs, selects, and checkboxes across 12 test files
- Add `aria-label` to `FormTableTextInput`, `FormTableSelect`, `FormTableCheckbox`, and `FormTableDateInput` for accessibility and testability
- Add `role="article"` to announcement/clarification card components; use existing `role="link"` for problem cards — replacing `document.querySelectorAll` CSS class selectors with `getAllByRole`
- Improve table assertions to check cell content matrix (row × cell) instead of just `getByText` or row count
- Add missing `await waitFor(() => expect(nock.isDone()).toBe(true))` in `ContestEditGeneralTab`, `ContestEditConfigsTab`, and `ContestEditDescriptionTab` tests
