### PR TITLE
Admin: improve dialog test coverage

### DIFF
--- a/judgels-client/src/routes/admin/roles/RoleEditDialog/RoleEditDialog.test.jsx
+++ b/judgels-client/src/routes/admin/roles/RoleEditDialog/RoleEditDialog.test.jsx
@@ -36,12 +36,7 @@ describe('RoleEditDialog', () => {
     );
   };
 
-  test('renders the edit button', async () => {
-    await renderComponent();
-    expect(screen.getByRole('button', { name: /edit roles/i })).toBeInTheDocument();
-  });
-
-  test('pre-fills the textarea with current roles', async () => {
+  test('form', async () => {
     await renderComponent();
     const user = userEvent.setup();
 
@@ -49,18 +44,14 @@ describe('RoleEditDialog', () => {
 
     const textarea = screen.getByRole('textbox');
     expect(textarea.value).toBe('andi,ADMIN,ADMIN,ADMIN,ADMIN\nbudi,,ADMIN,,');
-  });
 
-  test('submits roles', async () => {
-    await renderComponent();
-    const user = userEvent.setup();
-
-    await user.click(screen.getByRole('button', { name: /edit roles/i }));
+    await user.clear(textarea);
+    await user.type(textarea, 'andi,ADMIN,ADMIN,,\ncaca,,ADMIN,,');
 
     nockJophiel()
       .put('/user-roles', {
-        andi: { jophiel: 'ADMIN', sandalphon: 'ADMIN', uriel: 'ADMIN', jerahmeel: 'ADMIN' },
-        budi: { sandalphon: 'ADMIN' },
+        andi: { jophiel: 'ADMIN', sandalphon: 'ADMIN' },
+        caca: { sandalphon: 'ADMIN' },
       })
       .reply(200);
 

--- a/judgels-client/src/routes/admin/users/UserUpsertDialog/UserUpsertDialog.test.jsx
+++ b/judgels-client/src/routes/admin/users/UserUpsertDialog/UserUpsertDialog.test.jsx
@@ -25,12 +25,7 @@ describe('UserUpsertDialog', () => {
     );
   };
 
-  test('renders the upsert button', async () => {
-    await renderComponent();
-    expect(screen.getByRole('button', { name: /upsert users/i })).toBeInTheDocument();
-  });
-
-  test('submits CSV and renders results', async () => {
+  test('form', async () => {
     await renderComponent();
     const user = userEvent.setup();
 


### PR DESCRIPTION

- Consolidate RoleEditDialog tests into a single form test that asserts pre-filled state, edits CSV, and submits
- Consolidate UserUpsertDialog tests similarly


🤖 Generated with [Claude Code](https://claude.com/claude-code)