### PR TITLE
Admin: add missing tests and fix inconsistent state setter naming

### DIFF
--- a/judgels-client/src/routes/admin/archives/ArchivesPage/ArchivesPage.test.jsx
+++ b/judgels-client/src/routes/admin/archives/ArchivesPage/ArchivesPage.test.jsx
@@ -1,0 +1,58 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockJerahmeel } from '../../../../utils/nock';
+import ArchivesPage from './ArchivesPage';
+
+describe('ArchivesPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async ({
+    archives = [
+      { jid: 'JIDARCHIVE1', id: 1, slug: 'archive-1', name: 'Archive 1', category: 'Category 1' },
+      { jid: 'JIDARCHIVE2', id: 2, slug: 'archive-2', name: 'Archive 2', category: 'Category 2' },
+    ],
+  } = {}) => {
+    nockJerahmeel().get('/archives').reply(200, { data: archives });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter initialEntries={['/admin/archives']}>
+            <ArchivesPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders placeholder when there are no archives', async () => {
+    await renderComponent({ archives: [] });
+    expect(await screen.findByText(/no archives/i)).toBeInTheDocument();
+  });
+
+  test('renders the archives table', async () => {
+    await renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('row').length).toBeGreaterThan(1);
+    });
+    const rows = screen.getAllByRole('row');
+    expect(
+      rows.map(row =>
+        within(row)
+          .queryAllByRole('cell')
+          .map(cell => cell.textContent)
+      )
+    ).toEqual([[], ['1', 'archive-1', 'Archive 1', 'Category 1'], ['2', 'archive-2', 'Archive 2', 'Category 2']]);
+  });
+
+  test('renders the create button', async () => {
+    await renderComponent();
+    expect(await screen.findByRole('button', { name: /new archive/i })).toBeInTheDocument();
+  });
+});

--- a/judgels-client/src/routes/admin/chapters/ChaptersPage/ChaptersPage.test.jsx
+++ b/judgels-client/src/routes/admin/chapters/ChaptersPage/ChaptersPage.test.jsx
@@ -1,0 +1,58 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockJerahmeel } from '../../../../utils/nock';
+import ChaptersPage from './ChaptersPage';
+
+describe('ChaptersPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async ({
+    chapters = [
+      { jid: 'JIDCHAPTER1', id: 1, name: 'Chapter 1' },
+      { jid: 'JIDCHAPTER2', id: 2, name: 'Chapter 2' },
+    ],
+  } = {}) => {
+    nockJerahmeel().get('/chapters').reply(200, { data: chapters });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter initialEntries={['/admin/chapters']}>
+            <ChaptersPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders placeholder when there are no chapters', async () => {
+    await renderComponent({ chapters: [] });
+    expect(await screen.findByText(/no chapters/i)).toBeInTheDocument();
+  });
+
+  test('renders the chapters table', async () => {
+    await renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('row').length).toBeGreaterThan(1);
+    });
+    const rows = screen.getAllByRole('row');
+    expect(
+      rows.map(row =>
+        within(row)
+          .queryAllByRole('cell')
+          .map(cell => cell.textContent)
+      )
+    ).toEqual([[], ['1', 'JIDCHAPTER1', 'Chapter 1'], ['2', 'JIDCHAPTER2', 'Chapter 2']]);
+  });
+
+  test('renders the create button', async () => {
+    await renderComponent();
+    expect(await screen.findByRole('button', { name: /new chapter/i })).toBeInTheDocument();
+  });
+});

--- a/judgels-client/src/routes/admin/courses/CourseChaptersSection/CourseChaptersSection.jsx
+++ b/judgels-client/src/routes/admin/courses/CourseChaptersSection/CourseChaptersSection.jsx
@@ -14,20 +14,20 @@ export function CourseChaptersSection({ course }) {
   const { data: chaptersResponse } = useSuspenseQuery(courseChaptersQueryOptions(course.jid));
   const setChaptersMutation = useMutation(setCourseChaptersMutationOptions(course.jid));
 
-  const [isEditing, setIsEditingChapters] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   const updateChapters = data => {
     const chapters = deserializeChapters(data.chapters);
     setChaptersMutation.mutate(chapters, {
       onSuccess: () => toastActions.showSuccessToast('Course chapters updated.'),
     });
-    setIsEditingChapters(false);
+    setIsEditing(false);
   };
 
   const renderEditButton = () => {
     return (
       !isEditing && (
-        <Button small intent={Intent.PRIMARY} icon={<Edit />} onClick={() => setIsEditingChapters(true)}>
+        <Button small intent={Intent.PRIMARY} icon={<Edit />} onClick={() => setIsEditing(true)}>
           Edit
         </Button>
       )
@@ -42,7 +42,7 @@ export function CourseChaptersSection({ course }) {
           initialValues={initialValues}
           validator={validateChapters}
           onSubmit={updateChapters}
-          onCancel={() => setIsEditingChapters(false)}
+          onCancel={() => setIsEditing(false)}
         />
       );
     }

--- a/judgels-client/src/routes/admin/courses/CourseGeneralSection/CourseGeneralSection.jsx
+++ b/judgels-client/src/routes/admin/courses/CourseGeneralSection/CourseGeneralSection.jsx
@@ -13,7 +13,7 @@ import * as toastActions from '../../../../modules/toast/toastActions';
 export function CourseGeneralSection({ course }) {
   const updateCourseMutation = useMutation(updateCourseMutationOptions(course.jid));
 
-  const [isEditing, setIsEditingGeneral] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   const keyStyles = { width: '250px' };
 
@@ -27,13 +27,13 @@ export function CourseGeneralSection({ course }) {
     await updateCourseMutation.mutateAsync(data, {
       onSuccess: () => toastActions.showSuccessToast('Course updated.'),
     });
-    setIsEditingGeneral(false);
+    setIsEditing(false);
   };
 
   const renderEditButton = () => {
     return (
       !isEditing && (
-        <Button small intent={Intent.PRIMARY} icon={<Edit />} onClick={() => setIsEditingGeneral(true)}>
+        <Button small intent={Intent.PRIMARY} icon={<Edit />} onClick={() => setIsEditing(true)}>
           Edit
         </Button>
       )
@@ -51,7 +51,7 @@ export function CourseGeneralSection({ course }) {
         <CourseGeneralEditForm
           initialValues={initialValues}
           onSubmit={updateCourse}
-          onCancel={() => setIsEditingGeneral(false)}
+          onCancel={() => setIsEditing(false)}
         />
       );
     }

--- a/judgels-client/src/routes/admin/courses/CourseGeneralSection/CourseGeneralSection.test.jsx
+++ b/judgels-client/src/routes/admin/courses/CourseGeneralSection/CourseGeneralSection.test.jsx
@@ -1,0 +1,82 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockJerahmeel } from '../../../../utils/nock';
+import { CourseGeneralSection } from './CourseGeneralSection';
+
+describe('CourseGeneralSection', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const course = {
+    id: 1,
+    jid: 'JIDCOURSE1',
+    slug: 'course-1',
+    name: 'Course 1',
+    description: 'Description 1',
+  };
+
+  const renderComponent = async () => {
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter>
+            <CourseGeneralSection course={course} />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders general details', async () => {
+    await renderComponent();
+
+    const table = screen.getByRole('table');
+    expect(
+      screen
+        .getAllByRole('row')
+        .map(row => screen.getAllByRole('cell', { container: row }).map(cell => cell.textContent))
+    );
+  });
+
+  test('form', async () => {
+    await renderComponent();
+
+    const user = userEvent.setup();
+
+    const button = await screen.findByRole('button', { name: /edit/i });
+    await user.click(button);
+
+    const slug = screen.getByRole('textbox', { name: /slug/i });
+    expect(slug).toHaveValue('course-1');
+    await user.clear(slug);
+    await user.type(slug, 'new-course');
+
+    const name = screen.getAllByRole('textbox', { name: /name/i });
+    expect(name[0]).toHaveValue('Course 1');
+    await user.clear(name[0]);
+    await user.type(name[0], 'New Course');
+
+    const description = document.querySelector('textarea[name="description"]');
+    expect(description).toHaveValue('Description 1');
+    await user.clear(description);
+    await user.type(description, 'New Description');
+
+    nockJerahmeel()
+      .post('/courses/JIDCOURSE1', {
+        slug: 'new-course',
+        name: 'New Course',
+        description: 'New Description',
+      })
+      .reply(200);
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(nock.isDone()).toBe(true));
+  });
+});

--- a/judgels-client/src/routes/admin/courses/CoursePage/CoursePage.test.jsx
+++ b/judgels-client/src/routes/admin/courses/CoursePage/CoursePage.test.jsx
@@ -1,0 +1,73 @@
+import { act, render, screen, within } from '@testing-library/react';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockJerahmeel } from '../../../../utils/nock';
+import CoursePage from './CoursePage';
+
+describe('CoursePage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async () => {
+    nockJerahmeel().get('/courses/slug/course-1').reply(200, {
+      id: 1,
+      jid: 'JIDCOURSE1',
+      slug: 'course-1',
+      name: 'Course 1',
+      description: 'Description 1',
+    });
+
+    nockJerahmeel()
+      .get('/courses/JIDCOURSE1/chapters')
+      .reply(200, {
+        data: [{ alias: 'A', chapterJid: 'JIDCHAPTER1' }],
+        chaptersMap: { JIDCHAPTER1: { name: 'Chapter 1' } },
+      });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter initialEntries={['/admin/courses/course-1']} path="/admin/courses/$courseSlug">
+            <CoursePage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders course details', async () => {
+    await renderComponent();
+
+    await screen.findByText(/Course 1/);
+
+    const tables = screen.getAllByRole('table');
+
+    expect(
+      within(tables[0])
+        .getAllByRole('row')
+        .map(row =>
+          within(row)
+            .getAllByRole('cell')
+            .map(cell => cell.textContent)
+        )
+    ).toEqual([
+      ['Slug', 'course-1'],
+      ['Name', 'Course 1'],
+      ['Description', 'Description 1'],
+    ]);
+
+    expect(
+      within(tables[1])
+        .getAllByRole('row')
+        .slice(1)
+        .map(row =>
+          within(row)
+            .getAllByRole('cell')
+            .map(cell => cell.textContent)
+        )
+    ).toEqual([['A', 'Chapter 1']]);
+  });
+});

--- a/judgels-client/src/routes/admin/courses/CoursesPage/CoursesPage.test.jsx
+++ b/judgels-client/src/routes/admin/courses/CoursesPage/CoursesPage.test.jsx
@@ -1,0 +1,58 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockJerahmeel } from '../../../../utils/nock';
+import CoursesPage from './CoursesPage';
+
+describe('CoursesPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async ({
+    courses = [
+      { jid: 'JIDCOURSE1', id: 1, slug: 'course-1', name: 'Course 1' },
+      { jid: 'JIDCOURSE2', id: 2, slug: 'course-2', name: 'Course 2' },
+    ],
+  } = {}) => {
+    nockJerahmeel().get('/courses').reply(200, { data: courses });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter initialEntries={['/admin/courses']}>
+            <CoursesPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders placeholder when there are no courses', async () => {
+    await renderComponent({ courses: [] });
+    expect(await screen.findByText(/no courses/i)).toBeInTheDocument();
+  });
+
+  test('renders the courses table', async () => {
+    await renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('row').length).toBeGreaterThan(1);
+    });
+    const rows = screen.getAllByRole('row');
+    expect(
+      rows.map(row =>
+        within(row)
+          .queryAllByRole('cell')
+          .map(cell => cell.textContent)
+      )
+    ).toEqual([[], ['1', 'course-1', 'Course 1'], ['2', 'course-2', 'Course 2']]);
+  });
+
+  test('renders the create button', async () => {
+    await renderComponent();
+    expect(await screen.findByRole('button', { name: /new course/i })).toBeInTheDocument();
+  });
+});

--- a/judgels-client/src/routes/admin/problemsets/ProblemSetsPage/ProblemSetsPage.test.jsx
+++ b/judgels-client/src/routes/admin/problemsets/ProblemSetsPage/ProblemSetsPage.test.jsx
@@ -1,0 +1,70 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockJerahmeel } from '../../../../utils/nock';
+import ProblemSetsPage from './ProblemSetsPage';
+
+describe('ProblemSetsPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async ({
+    problemSets = [
+      { jid: 'JIDPROBLEMSET1', id: 1, slug: 'problemset-1', name: 'Problemset 1', archiveJid: 'JIDARCHIVE1' },
+      { jid: 'JIDPROBLEMSET2', id: 2, slug: 'problemset-2', name: 'Problemset 2', archiveJid: 'JIDARCHIVE1' },
+    ],
+    archiveSlugsMap = { JIDARCHIVE1: 'archive-1' },
+    totalCount = 2,
+  } = {}) => {
+    nockJerahmeel()
+      .get('/problemsets')
+      .query(true)
+      .reply(200, {
+        data: { page: problemSets, totalCount },
+        archiveSlugsMap,
+      });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter initialEntries={['/admin/problemsets']}>
+            <ProblemSetsPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders placeholder when there are no problem sets', async () => {
+    await renderComponent({ problemSets: [], archiveSlugsMap: {}, totalCount: 0 });
+    expect(await screen.findByText(/no problem sets/i)).toBeInTheDocument();
+  });
+
+  test('renders the problem sets table', async () => {
+    await renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('row').length).toBeGreaterThan(1);
+    });
+    const rows = screen.getAllByRole('row');
+    expect(
+      rows.map(row =>
+        within(row)
+          .queryAllByRole('cell')
+          .map(cell => cell.textContent)
+      )
+    ).toEqual([
+      [],
+      ['1', 'problemset-1', 'Problemset 1', 'archive-1'],
+      ['2', 'problemset-2', 'Problemset 2', 'archive-1'],
+    ]);
+  });
+
+  test('renders the create button', async () => {
+    await renderComponent();
+    expect(await screen.findByRole('button', { name: /new problemset/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Add missing test coverage for admin pages: `CoursePage`, `CourseGeneralSection`, `CoursesPage`, `ArchivesPage`, `ChaptersPage`, and `ProblemSetsPage`
- Fix inconsistent state setter naming in `CourseGeneralSection` (`setIsEditingGeneral` → `setIsEditing`) and `CourseChaptersSection` (`setIsEditingChapters` → `setIsEditing`) to match all other section components

🤖 Generated with [Claude Code](https://claude.com/claude-code)