### PR TITLE
Admin: add Contests tab with listing page

### DIFF
--- a/judgels-client/src/routes/admin/AdminLayout.jsx
+++ b/judgels-client/src/routes/admin/AdminLayout.jsx
@@ -1,4 +1,13 @@
-import { Box, PanelStats, People, PredictiveAnalysis, Properties, Shield, TimelineLineChart } from '@blueprintjs/icons';
+import {
+  Box,
+  Console,
+  PanelStats,
+  People,
+  PredictiveAnalysis,
+  Properties,
+  Shield,
+  TimelineLineChart,
+} from '@blueprintjs/icons';
 import { Outlet } from '@tanstack/react-router';
 
 import ContentWithSidebar from '../../components/ContentWithSidebar/ContentWithSidebar';
@@ -20,6 +29,11 @@ export default function AdminLayout() {
       path: 'ratings',
       titleIcon: <TimelineLineChart />,
       title: 'Ratings',
+    },
+    {
+      path: 'contests',
+      titleIcon: <Console />,
+      title: 'Contests',
     },
     {
       path: 'courses',

--- a/judgels-client/src/routes/admin/contests/ContestsPage/ContestsPage.jsx
+++ b/judgels-client/src/routes/admin/contests/ContestsPage/ContestsPage.jsx
@@ -1,0 +1,80 @@
+import { HTMLTable } from '@blueprintjs/core';
+import { useQuery } from '@tanstack/react-query';
+import { Link, useLocation } from '@tanstack/react-router';
+
+import { ActionButtons } from '../../../../components/ActionButtons/ActionButtons';
+import { ContentCard } from '../../../../components/ContentCard/ContentCard';
+import { LoadingContentCard } from '../../../../components/LoadingContentCard/LoadingContentCard';
+import Pagination from '../../../../components/Pagination/Pagination';
+import { contestsQueryOptions } from '../../../../modules/queries/contest';
+import { ContestCreateDialog } from '../../../contests/contests/ContestCreateDialog/ContestCreateDialog';
+
+const PAGE_SIZE = 20;
+
+export default function ContestsPage() {
+  const location = useLocation();
+  const page = location.search.page;
+
+  const { data: response } = useQuery(contestsQueryOptions({ page }));
+
+  const renderContests = () => {
+    if (!response) {
+      return <LoadingContentCard />;
+    }
+
+    const contests = response.data.page;
+    if (contests.length === 0) {
+      return (
+        <p>
+          <small>No contests.</small>
+        </p>
+      );
+    }
+
+    const rows = contests.map(contest => (
+      <tr key={contest.jid}>
+        <td style={{ width: '60px' }}>{contest.id}</td>
+        <td style={{ width: '200px' }}>
+          <Link to={`/contests/${contest.slug}`}>{contest.slug}</Link>
+        </td>
+        <td>{contest.name}</td>
+      </tr>
+    ));
+
+    return (
+      <HTMLTable striped className="table-list-condensed">
+        <thead>
+          <tr>
+            <th style={{ width: '60px' }}>ID</th>
+            <th style={{ width: '200px' }}>Slug</th>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </HTMLTable>
+    );
+  };
+
+  const renderAction = () => {
+    return (
+      <ActionButtons>
+        <ContestCreateDialog />
+      </ActionButtons>
+    );
+  };
+
+  const renderPagination = () => {
+    if (!response) {
+      return null;
+    }
+    return <Pagination pageSize={PAGE_SIZE} totalCount={response.data.totalCount} />;
+  };
+
+  return (
+    <ContentCard title="Contests">
+      {renderAction()}
+      {renderContests()}
+      {renderPagination()}
+    </ContentCard>
+  );
+}

--- a/judgels-client/src/routes/admin/contests/ContestsPage/ContestsPage.test.jsx
+++ b/judgels-client/src/routes/admin/contests/ContestsPage/ContestsPage.test.jsx
@@ -1,0 +1,64 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockUriel } from '../../../../utils/nock';
+import ContestsPage from './ContestsPage';
+
+describe('ContestsPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async ({
+    contests = [
+      { jid: 'JIDCONTEST1', id: 1, slug: 'contest-1', name: 'Contest 1' },
+      { jid: 'JIDCONTEST2', id: 2, slug: 'contest-2', name: 'Contest 2' },
+    ],
+  } = {}) => {
+    nockUriel()
+      .get('/contests?')
+      .reply(200, {
+        data: { page: contests, totalCount: contests.length },
+        config: { canAdminister: true },
+        rolesMap: {},
+      });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter initialEntries={['/admin/contests']}>
+            <ContestsPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders placeholder when there are no contests', async () => {
+    await renderComponent({ contests: [] });
+    expect(await screen.findByText(/no contests/i)).toBeInTheDocument();
+  });
+
+  test('renders the contests table', async () => {
+    await renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('row').length).toBeGreaterThan(1);
+    });
+    const rows = screen.getAllByRole('row');
+    expect(
+      rows.map(row =>
+        within(row)
+          .queryAllByRole('cell')
+          .map(cell => cell.textContent)
+      )
+    ).toEqual([[], ['1', 'contest-1', 'Contest 1'], ['2', 'contest-2', 'Contest 2']]);
+  });
+
+  test('renders the create button', async () => {
+    await renderComponent();
+    expect(await screen.findByRole('button', { name: /new contest/i })).toBeInTheDocument();
+  });
+});

--- a/judgels-client/src/routes/admin/routes.jsx
+++ b/judgels-client/src/routes/admin/routes.jsx
@@ -60,6 +60,12 @@ export const createAdminRoutes = appRoute => {
     component: lazyRouteComponent(retryImport(() => import('./ratings/RatingsPage/RatingsPage'))),
   });
 
+  const adminContestsRoute = createRoute({
+    getParentRoute: () => adminRoute,
+    path: 'contests',
+    component: lazyRouteComponent(retryImport(() => import('./contests/ContestsPage/ContestsPage'))),
+  });
+
   const adminCoursesRoute = createRoute({
     getParentRoute: () => adminRoute,
     path: 'courses',
@@ -135,6 +141,7 @@ export const createAdminRoutes = appRoute => {
     adminUserRoute,
     adminRolesRoute,
     adminRatingsRoute,
+    adminContestsRoute,
     adminCoursesRoute,
     adminCourseRoute,
     adminChaptersRoute,

--- a/judgels-client/src/routes/contests/contests/ContestsPage/ContestsPage.jsx
+++ b/judgels-client/src/routes/contests/contests/ContestsPage/ContestsPage.jsx
@@ -1,4 +1,3 @@
-import { Flex } from '@blueprintjs/labs';
 import { useQuery } from '@tanstack/react-query';
 import { useLocation } from '@tanstack/react-router';
 
@@ -8,7 +7,6 @@ import Pagination from '../../../../components/Pagination/Pagination';
 import SearchBox from '../../../../components/SearchBox/SearchBox';
 import { contestsQueryOptions } from '../../../../modules/queries/contest';
 import { ContestCard } from '../ContestCard/ContestCard';
-import { ContestCreateDialog } from '../ContestCreateDialog/ContestCreateDialog';
 
 const PAGE_SIZE = 20;
 
@@ -23,10 +21,7 @@ export default function ContestsPage() {
   const renderHeader = () => {
     return (
       <>
-        <Flex justifyContent="space-between" alignItems="center">
-          {renderCreateDialog()}
-          {renderFilter()}
-        </Flex>
+        {renderFilter()}
         {renderFilterResultsBanner()}
       </>
     );
@@ -49,17 +44,6 @@ export default function ContestsPage() {
     return (
       <SearchBox onRouteChange={searchBoxUpdateQueries} initialValue={name || ''} isLoading={isLoading && !!name} />
     );
-  };
-
-  const renderCreateDialog = () => {
-    if (!response) {
-      return null;
-    }
-    const config = response.config;
-    if (!config.canAdminister) {
-      return null;
-    }
-    return <ContestCreateDialog />;
   };
 
   const renderContests = () => {


### PR DESCRIPTION
- Add a new "Contests" tab in the admin sidebar
- Lists contests with id, slug, name columns and pagination
- Move the "New contest" button from the public contests page to Admin > Contests
- Clicking a contest slug links to `/contests/:slug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)