### PR TITLE
Admin: guard tab and sidebar items by per-service role

### DIFF
--- a/judgels-client/src/modules/api/sandalphon/role.js
+++ b/judgels-client/src/modules/api/sandalphon/role.js
@@ -1,0 +1,3 @@
+export const SandalphonRole = {
+  Admin: 'ADMIN',
+};

--- a/judgels-client/src/modules/api/uriel/role.js
+++ b/judgels-client/src/modules/api/uriel/role.js
@@ -1,0 +1,3 @@
+export const UrielRole = {
+  Admin: 'ADMIN',
+};

--- a/judgels-client/src/routes/AppRoutes.jsx
+++ b/judgels-client/src/routes/AppRoutes.jsx
@@ -1,7 +1,10 @@
 import { Console, Home, Key, Layers, Manual, PredictiveAnalysis, TimelineLineChart } from '@blueprintjs/icons';
 
 import { isTLX } from '../conf';
+import { JerahmeelRole } from '../modules/api/jerahmeel/role';
 import { JophielRole } from '../modules/api/jophiel/role';
+import { SandalphonRole } from '../modules/api/sandalphon/role';
+import { UrielRole } from '../modules/api/uriel/role';
 
 const appRoutes = [
   {
@@ -11,7 +14,11 @@ const appRoutes = [
     route: {
       path: '/admin',
     },
-    visible: role => isTLX() && (role.jophiel === JophielRole.Superadmin || role.jophiel === JophielRole.Admin),
+    visible: role =>
+      role.jophiel === JophielRole.Superadmin ||
+      role.jophiel === JophielRole.Admin ||
+      role.uriel === UrielRole.Admin ||
+      role.jerahmeel === JerahmeelRole.Admin,
   },
   {
     id: 'contests',

--- a/judgels-client/src/routes/AppRoutes.test.js
+++ b/judgels-client/src/routes/AppRoutes.test.js
@@ -1,4 +1,7 @@
+import { JerahmeelRole } from '../modules/api/jerahmeel/role';
 import { JophielRole } from '../modules/api/jophiel/role';
+import { SandalphonRole } from '../modules/api/sandalphon/role';
+import { UrielRole } from '../modules/api/uriel/role';
 import { getVisibleAppRoutes } from './AppRoutes';
 
 describe('AppRoutes', () => {
@@ -21,6 +24,21 @@ describe('AppRoutes', () => {
 
   test('Jophiel superadmin', () => {
     testAppRoutes({ jophiel: JophielRole.Superadmin }, [
+      'admin',
+      'contests',
+      'courses',
+      'problems',
+      'submissions',
+      'ranking',
+    ]);
+  });
+
+  test('Uriel admin', () => {
+    testAppRoutes({ uriel: UrielRole.Admin }, ['admin', 'contests', 'courses', 'problems', 'submissions', 'ranking']);
+  });
+
+  test('Jerahmeel admin', () => {
+    testAppRoutes({ jerahmeel: JerahmeelRole.Admin }, [
       'admin',
       'contests',
       'courses',

--- a/judgels-client/src/routes/admin/AdminIndexPage.jsx
+++ b/judgels-client/src/routes/admin/AdminIndexPage.jsx
@@ -1,0 +1,24 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Navigate } from '@tanstack/react-router';
+
+import { JerahmeelRole } from '../../modules/api/jerahmeel/role';
+import { JophielRole } from '../../modules/api/jophiel/role';
+import { UrielRole } from '../../modules/api/uriel/role';
+import { userWebConfigQueryOptions } from '../../modules/queries/userWeb';
+
+export default function AdminIndexPage() {
+  const {
+    data: { role },
+  } = useSuspenseQuery(userWebConfigQueryOptions());
+
+  if (role.jophiel === JophielRole.Admin || role.jophiel === JophielRole.Superadmin) {
+    return <Navigate to="/admin/users" />;
+  }
+  if (role.uriel === UrielRole.Admin) {
+    return <Navigate to="/admin/contests" />;
+  }
+  if (role.jerahmeel === JerahmeelRole.Admin) {
+    return <Navigate to="/admin/courses" />;
+  }
+  return <Navigate to="/" />;
+}

--- a/judgels-client/src/routes/admin/AdminLayout.jsx
+++ b/judgels-client/src/routes/admin/AdminLayout.jsx
@@ -8,54 +8,75 @@ import {
   Shield,
   TimelineLineChart,
 } from '@blueprintjs/icons';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
 
 import ContentWithSidebar from '../../components/ContentWithSidebar/ContentWithSidebar';
 import { FullWidthPageLayout } from '../../components/FullWidthPageLayout/FullWidthPageLayout';
+import { JerahmeelRole } from '../../modules/api/jerahmeel/role';
+import { JophielRole } from '../../modules/api/jophiel/role';
+import { UrielRole } from '../../modules/api/uriel/role';
+import { userWebConfigQueryOptions } from '../../modules/queries/userWeb';
 
 export default function AdminLayout() {
+  const {
+    data: { role },
+  } = useSuspenseQuery(userWebConfigQueryOptions());
+
+  const isJophielAdmin = role.jophiel === JophielRole.Admin || role.jophiel === JophielRole.Superadmin;
+  const isUrielAdmin = role.uriel === UrielRole.Admin;
+  const isJerahmeelAdmin = role.jerahmeel === JerahmeelRole.Admin;
+
   const sidebarItems = [
     {
       path: 'users',
       titleIcon: <People />,
       title: 'Users',
+      visible: isJophielAdmin,
     },
     {
       path: 'roles',
       titleIcon: <Shield />,
       title: 'Roles',
+      visible: isJophielAdmin,
     },
     {
       path: 'ratings',
       titleIcon: <TimelineLineChart />,
       title: 'Ratings',
+      visible: isJophielAdmin,
     },
     {
       path: 'contests',
       titleIcon: <Console />,
       title: 'Contests',
+      visible: isUrielAdmin,
     },
     {
       path: 'courses',
       titleIcon: <PredictiveAnalysis />,
       title: 'Courses',
+      visible: isJerahmeelAdmin,
     },
     {
       path: 'chapters',
       titleIcon: <Properties />,
       title: 'Chapters',
+      visible: isJerahmeelAdmin,
     },
     {
       path: 'archives',
       titleIcon: <Box />,
       title: 'Archives',
+      visible: isJerahmeelAdmin,
     },
     {
       path: 'problemsets',
       titleIcon: <PanelStats />,
       title: 'Problemsets',
+      visible: isJerahmeelAdmin,
     },
-  ];
+  ].filter(item => item.visible);
 
   const contentWithSidebarProps = {
     title: 'Admin',

--- a/judgels-client/src/routes/admin/routes.jsx
+++ b/judgels-client/src/routes/admin/routes.jsx
@@ -1,4 +1,4 @@
-import { Navigate, createRoute, lazyRouteComponent } from '@tanstack/react-router';
+import { createRoute, lazyRouteComponent } from '@tanstack/react-router';
 
 import { isTLX } from '../../conf';
 import { retryImport } from '../../lazy';
@@ -29,7 +29,7 @@ export const createAdminRoutes = appRoute => {
   const adminIndexRoute = createRoute({
     getParentRoute: () => adminRoute,
     path: '/',
-    component: () => <Navigate to="/admin/users" />,
+    component: lazyRouteComponent(retryImport(() => import('./AdminIndexPage'))),
   });
 
   const adminUsersRoute = createRoute({


### PR DESCRIPTION
## Summary
- Admin tab is now visible to any user with admin role in Jophiel, Uriel, or Jerahmeel (previously gated solely on Jophiel + isTLX)
- Admin sidebar items are filtered per-service: Users/Roles/Ratings require Jophiel admin, Contests requires Uriel admin, Courses/Chapters/Archives/Problemsets require Jerahmeel admin
- `/admin` index now redirects to the first section the user can access (instead of always `/admin/users`)
- Adds `UrielRole` and `SandalphonRole` constants for parity with existing `JophielRole` and `JerahmeelRole`

🤖 Generated with [Claude Code](https://claude.com/claude-code)