### PR TITLE
Admin: gate Jerahmeel admin access on isTLX()

### DIFF
--- a/judgels-client/src/routes/AppRoutes.jsx
+++ b/judgels-client/src/routes/AppRoutes.jsx
@@ -18,7 +18,7 @@ const appRoutes = [
       role.jophiel === JophielRole.Superadmin ||
       role.jophiel === JophielRole.Admin ||
       role.uriel === UrielRole.Admin ||
-      role.jerahmeel === JerahmeelRole.Admin,
+      (isTLX() && role.jerahmeel === JerahmeelRole.Admin),
   },
   {
     id: 'contests',

--- a/judgels-client/src/routes/admin/AdminIndexPage.jsx
+++ b/judgels-client/src/routes/admin/AdminIndexPage.jsx
@@ -1,6 +1,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Navigate } from '@tanstack/react-router';
 
+import { isTLX } from '../../conf';
 import { JerahmeelRole } from '../../modules/api/jerahmeel/role';
 import { JophielRole } from '../../modules/api/jophiel/role';
 import { UrielRole } from '../../modules/api/uriel/role';
@@ -17,7 +18,7 @@ export default function AdminIndexPage() {
   if (role.uriel === UrielRole.Admin) {
     return <Navigate to="/admin/contests" />;
   }
-  if (role.jerahmeel === JerahmeelRole.Admin) {
+  if (isTLX() && role.jerahmeel === JerahmeelRole.Admin) {
     return <Navigate to="/admin/courses" />;
   }
   return <Navigate to="/" />;

--- a/judgels-client/src/routes/admin/AdminLayout.jsx
+++ b/judgels-client/src/routes/admin/AdminLayout.jsx
@@ -13,6 +13,7 @@ import { Outlet } from '@tanstack/react-router';
 
 import ContentWithSidebar from '../../components/ContentWithSidebar/ContentWithSidebar';
 import { FullWidthPageLayout } from '../../components/FullWidthPageLayout/FullWidthPageLayout';
+import { isTLX } from '../../conf';
 import { JerahmeelRole } from '../../modules/api/jerahmeel/role';
 import { JophielRole } from '../../modules/api/jophiel/role';
 import { UrielRole } from '../../modules/api/uriel/role';
@@ -25,7 +26,7 @@ export default function AdminLayout() {
 
   const isJophielAdmin = role.jophiel === JophielRole.Admin || role.jophiel === JophielRole.Superadmin;
   const isUrielAdmin = role.uriel === UrielRole.Admin;
-  const isJerahmeelAdmin = role.jerahmeel === JerahmeelRole.Admin;
+  const isJerahmeelAdmin = isTLX() && role.jerahmeel === JerahmeelRole.Admin;
 
   const sidebarItems = [
     {


### PR DESCRIPTION
- The Admin tab now only considers Jerahmeel admin when running in TLX mode, matching how other Jerahmeel-backed tabs (Courses, Problems, Submissions, Ranking) are gated
- `AdminLayout` hides the Courses/Chapters/Archives/Problemsets sidebar items for Jerahmeel admins outside TLX mode
- `AdminIndexPage` no longer redirects to `/admin/courses` when Jerahmeel admin is the only role and the app is not TLX

🤖 Generated with [Claude Code](https://claude.com/claude-code)