### PR TITLE
Fix unreadable th color in HtmlText dark mode

### DIFF
--- a/judgels-client/src/components/HtmlText/HtmlText.scss
+++ b/judgels-client/src/components/HtmlText/HtmlText.scss
@@ -24,19 +24,19 @@
   table {
     width: inherit;
     margin-bottom: 10px;
-  }
 
-  td,
-  th {
-    border: solid 1px #cccccc;
-    text-align: left;
-    padding: 5px;
-  }
+    td,
+    th {
+      border: solid 1px #cccccc;
+      text-align: left;
+      padding: 5px;
+    }
 
-  th {
-    background-color: #eeeeee;
-    font-weight: bold;
-    color: $text-color;
+    th {
+      background-color: #eeeeee;
+      font-weight: bold;
+      color: $text-color;
+    }
   }
 
   pre {


### PR DESCRIPTION
- Nest `td`/`th` under `.html-text table` in `HtmlText.scss` so the selectors become `(0,0,1,2)` — high enough to beat the global `.bp6-dark th { color: $dark-text-color }` rule in `styles/index.scss` `(0,0,1,1)`, which had been winning the cascade and forcing light text on the light `#eeeeee` header background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)