### PR TITLE
Fix horizontal overflow in problem statements

### DIFF
--- a/judgels-client/src/components/ContentCard/ContentCard.scss
+++ b/judgels-client/src/components/ContentCard/ContentCard.scss
@@ -1,6 +1,8 @@
 @use '../../styles/variables/colors' as *;
 
 .content-card {
+  overflow-x: auto;
+
   h3 {
     line-height: 9px;
   }


### PR DESCRIPTION
- Restore `overflow-x: auto` on `.content-card` so wide tables, `<pre>` blocks, and long inline math scroll inside the card instead of spilling past the 800px problem worksheet.
- The rule was inadvertently dropped in dfe69f9 (Simplify css: more `<Flex>` usage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)