### PR TITLE
Fix highlight block margins and overflow in problem statements

### DIFF
--- a/judgels-client/src/components/HtmlText/HtmlText.scss
+++ b/judgels-client/src/components/HtmlText/HtmlText.scss
@@ -83,18 +83,19 @@
 
   .highlight {
     background-color: #ffe39f;
-    margin-left: -15px;
-    margin-right: -15px;
+    margin-left: -20px;
+    margin-right: -20px;
     margin-bottom: 20px;
     padding: 10px 20px;
     border-radius: 3px;
+    overflow-x: auto;
 
     .bp6-dark & {
       background-color: #0c5174;
     }
 
     &:first-child {
-      margin-top: -15px;
+      margin-top: -20px;
     }
 
     &:not(:first-child) {
@@ -102,7 +103,7 @@
     }
 
     &:last-child {
-      margin-bottom: -15px;
+      margin-bottom: -20px;
     }
 
     h3:first-child {


### PR DESCRIPTION

- Bump `.highlight` negative horizontal/first-last margins from `-15px` to `-20px` so the block bleeds cleanly to the content card edges. Blueprint Card's default padding is 20px, whereas the old `.content-card` used 15px — after dfe69f9 dropped that override, a 5px gap appeared around highlight blocks.
- Add `overflow-x: auto` on `.highlight` so wide tables or code blocks inside a highlight scroll within the block instead of spilling past the card.


🤖 Generated with [Claude Code](https://claude.com/claude-code)