### PR TITLE
Fix stretched image in submission details

### DIFF
--- a/judgels-client/src/components/SubmissionDetails/Programming/SubmissionDetails.scss
+++ b/judgels-client/src/components/SubmissionDetails/Programming/SubmissionDetails.scss
@@ -58,7 +58,7 @@
   }
 
   .submission-details-image {
-    overflow: auto;
+    align-self: start;
   }
 
   details summary {


### PR DESCRIPTION
- Fix submission images stretching to fill the full ContentCard width
- The issue was caused by ContentCard wrapping children in a flex column container, which stretches items by default
- Use `align-self: start` to keep images at their natural size

🤖 Generated with [Claude Code](https://claude.com/claude-code)