### PR TITLE
Hide tabs and block routes for pelatnas users

### DIFF
--- a/judgels-client/src/routes/App.jsx
+++ b/judgels-client/src/routes/App.jsx
@@ -26,7 +26,7 @@ export default function App() {
     setGAUser(userJid);
   }, []);
 
-  const visibleAppRoutes = getVisibleAppRoutes(role);
+  const visibleAppRoutes = getVisibleAppRoutes(role, user);
   const homeRoute = getHomeRoute();
 
   return (

--- a/judgels-client/src/routes/AppRoutes.jsx
+++ b/judgels-client/src/routes/AppRoutes.jsx
@@ -5,6 +5,7 @@ import { JerahmeelRole } from '../modules/api/jerahmeel/role';
 import { JophielRole } from '../modules/api/jophiel/role';
 import { SandalphonRole } from '../modules/api/sandalphon/role';
 import { UrielRole } from '../modules/api/uriel/role';
+import { isUserBlocked } from './blockedUsernames';
 
 const appRoutes = [
   {
@@ -36,7 +37,7 @@ const appRoutes = [
     route: {
       path: '/courses',
     },
-    visible: () => isTLX(),
+    visible: (role, user) => isTLX() && !isUserBlocked(user),
   },
   {
     id: 'problems',
@@ -45,7 +46,7 @@ const appRoutes = [
     route: {
       path: '/problems',
     },
-    visible: () => isTLX(),
+    visible: (role, user) => isTLX() && !isUserBlocked(user),
   },
   {
     id: 'submissions',
@@ -54,7 +55,7 @@ const appRoutes = [
     route: {
       path: '/submissions',
     },
-    visible: () => isTLX(),
+    visible: (role, user) => isTLX() && !isUserBlocked(user),
   },
   {
     id: 'ranking',
@@ -63,7 +64,7 @@ const appRoutes = [
     route: {
       path: '/ranking',
     },
-    visible: () => isTLX(),
+    visible: (role, user) => isTLX() && !isUserBlocked(user),
   },
 ];
 
@@ -74,8 +75,8 @@ const homeRoute = {
   route: {},
 };
 
-export function getVisibleAppRoutes(role) {
-  return appRoutes.filter(route => route.visible(role));
+export function getVisibleAppRoutes(role, user) {
+  return appRoutes.filter(route => route.visible(role, user));
 }
 
 export function getHomeRoute() {

--- a/judgels-client/src/routes/AppRoutes.test.js
+++ b/judgels-client/src/routes/AppRoutes.test.js
@@ -3,10 +3,11 @@ import { JophielRole } from '../modules/api/jophiel/role';
 import { SandalphonRole } from '../modules/api/sandalphon/role';
 import { UrielRole } from '../modules/api/uriel/role';
 import { getVisibleAppRoutes } from './AppRoutes';
+import { BLOCKED_USERNAMES } from './blockedUsernames';
 
 describe('AppRoutes', () => {
-  const testAppRoutes = (role, expectedIds) => {
-    const appRoutes = getVisibleAppRoutes(role);
+  const testAppRoutes = (role, expectedIds, user = undefined) => {
+    const appRoutes = getVisibleAppRoutes(role, user);
     const ids = appRoutes.map(route => route.id);
     expect(ids).toEqual(expectedIds);
   };
@@ -50,5 +51,10 @@ describe('AppRoutes', () => {
 
   test('user', () => {
     testAppRoutes({}, ['contests', 'courses', 'problems', 'submissions', 'ranking']);
+  });
+
+  test('blocked user', () => {
+    const blockedUser = { username: BLOCKED_USERNAMES[0] };
+    testAppRoutes({}, ['contests'], blockedUser);
   });
 });

--- a/judgels-client/src/routes/blockedUsernames.js
+++ b/judgels-client/src/routes/blockedUsernames.js
@@ -1,0 +1,23 @@
+// Temporary list of usernames blocked from accessing submissions, courses, and problems
+// during selection tests. Remove this file when the restriction is no longer needed.
+export const BLOCKED_USERNAMES = [
+  'warren030310',
+  'mitchell.jh',
+  'thesen',
+  'Retr0Foxx',
+  'LC24',
+  'Andra_MHT_16',
+  'kalifpermadi',
+  'hitsuuj',
+  'marchell_hii',
+  'sakka',
+  'RKHTM',
+  'evanrusly',
+  'Jesslyn_nathania19',
+  'Bananade',
+  'yusuf12360',
+];
+
+export function isUserBlocked(user) {
+  return BLOCKED_USERNAMES.includes(user?.username);
+}

--- a/judgels-client/src/routes/courses/routes.jsx
+++ b/judgels-client/src/routes/courses/routes.jsx
@@ -1,4 +1,4 @@
-import { Outlet, createRoute, lazyRouteComponent } from '@tanstack/react-router';
+import { Outlet, createRoute, lazyRouteComponent, redirect } from '@tanstack/react-router';
 
 import { retryImport } from '../../lazy';
 import { ProblemType } from '../../modules/api/sandalphon/problem';
@@ -17,6 +17,7 @@ import { queryClient } from '../../modules/queryClient';
 import { getUser } from '../../modules/session';
 import { getWebPrefs } from '../../modules/webPrefs';
 import { createDocumentTitle } from '../../utils/title';
+import { isUserBlocked } from '../blockedUsernames';
 
 export const createCoursesRoutes = appRoute => {
   const coursesRoute = createRoute({
@@ -24,6 +25,11 @@ export const createCoursesRoutes = appRoute => {
     path: 'courses',
     component: Outlet,
     head: () => ({ meta: [{ title: createDocumentTitle('Courses') }] }),
+    beforeLoad: () => {
+      if (isUserBlocked(getUser())) {
+        throw redirect({ to: '/' });
+      }
+    },
   });
 
   const coursesIndexRoute = createRoute({

--- a/judgels-client/src/routes/problems/routes.jsx
+++ b/judgels-client/src/routes/problems/routes.jsx
@@ -1,4 +1,4 @@
-import { Outlet, createRoute, lazyRouteComponent } from '@tanstack/react-router';
+import { Outlet, createRoute, lazyRouteComponent, redirect } from '@tanstack/react-router';
 
 import { retryImport } from '../../lazy';
 import { ProblemType } from '../../modules/api/sandalphon/problem';
@@ -23,6 +23,7 @@ import { queryClient } from '../../modules/queryClient';
 import { getUser } from '../../modules/session';
 import { getWebPrefs } from '../../modules/webPrefs';
 import { createDocumentTitle } from '../../utils/title';
+import { isUserBlocked } from '../blockedUsernames';
 
 export const createProblemsRoutes = appRoute => {
   const problemsRoute = createRoute({
@@ -30,6 +31,11 @@ export const createProblemsRoutes = appRoute => {
     path: 'problems',
     component: Outlet,
     head: () => ({ meta: [{ title: createDocumentTitle('Problems') }] }),
+    beforeLoad: () => {
+      if (isUserBlocked(getUser())) {
+        throw redirect({ to: '/' });
+      }
+    },
   });
 
   const problemsIndexRoute = createRoute({

--- a/judgels-client/src/routes/ranking/routes.jsx
+++ b/judgels-client/src/routes/ranking/routes.jsx
@@ -1,9 +1,11 @@
-import { createRoute, lazyRouteComponent } from '@tanstack/react-router';
+import { createRoute, lazyRouteComponent, redirect } from '@tanstack/react-router';
 
 import { retryImport } from '../../lazy';
 import { topRatedProfilesQueryOptions } from '../../modules/queries/profile';
 import { queryClient } from '../../modules/queryClient';
+import { getUser } from '../../modules/session';
 import { createDocumentTitle } from '../../utils/title';
+import { isUserBlocked } from '../blockedUsernames';
 
 export const createRankingRoutes = appRoute => {
   const rankingRoute = createRoute({
@@ -11,6 +13,11 @@ export const createRankingRoutes = appRoute => {
     path: 'ranking',
     component: lazyRouteComponent(retryImport(() => import('./RankingLayout'))),
     head: () => ({ meta: [{ title: createDocumentTitle('Ranking') }] }),
+    beforeLoad: () => {
+      if (isUserBlocked(getUser())) {
+        throw redirect({ to: '/' });
+      }
+    },
   });
 
   const rankingIndexRoute = createRoute({

--- a/judgels-client/src/routes/submissions/routes.jsx
+++ b/judgels-client/src/routes/submissions/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoute, lazyRouteComponent } from '@tanstack/react-router';
+import { createRoute, lazyRouteComponent, redirect } from '@tanstack/react-router';
 
 import { retryImport } from '../../lazy';
 import { submissionWithSourceQueryOptions, submissionsQueryOptions } from '../../modules/queries/submissionProgramming';
@@ -6,6 +6,7 @@ import { queryClient } from '../../modules/queryClient';
 import { getUser } from '../../modules/session';
 import { getWebPrefs } from '../../modules/webPrefs';
 import { createDocumentTitle } from '../../utils/title';
+import { isUserBlocked } from '../blockedUsernames';
 
 export const createSubmissionsRoutes = appRoute => {
   const submissionsRoute = createRoute({
@@ -13,6 +14,11 @@ export const createSubmissionsRoutes = appRoute => {
     path: 'submissions',
     component: lazyRouteComponent(retryImport(() => import('./SubmissionsLayout'))),
     head: () => ({ meta: [{ title: createDocumentTitle('Submissions') }] }),
+    beforeLoad: () => {
+      if (isUserBlocked(getUser())) {
+        throw redirect({ to: '/' });
+      }
+    },
   });
 
   const submissionsIndexRoute = createRoute({


### PR DESCRIPTION

- Hide Courses, Problems, Submissions, and Ranking tabs for specific usernames during selection tests
- Block direct URL access to these routes (redirects to home page)
- Blocked usernames are configured in `blockedUsernames.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)