### PR TITLE
Split SandalphonClient into ProblemService & LessonService

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/chapter/lesson/ChapterLessonResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/chapter/lesson/ChapterLessonResource.java
@@ -33,8 +33,8 @@ import judgels.api.lesson.LessonInfo;
 import judgels.api.lesson.LessonStatement;
 import judgels.chapter.ChapterStore;
 import judgels.chapter.resource.ChapterResourceStore;
+import judgels.lesson.LessonService;
 import judgels.role.TrainingAdminRoleChecker;
-import judgels.sandalphon.SandalphonClient;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 
@@ -45,7 +45,7 @@ public class ChapterLessonResource {
     @Inject protected ChapterStore chapterStore;
     @Inject protected ChapterResourceStore resourceStore;
     @Inject protected ChapterLessonStore lessonStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected LessonService lessonService;
 
     @Inject public ChapterLessonResource() {}
 
@@ -68,7 +68,7 @@ public class ChapterLessonResource {
         checkArgument(aliases.size() == data.size(), "Lesson aliases must be unique");
         checkArgument(slugs.size() == data.size(), "Lesson slugs must be unique");
 
-        Map<String, String> slugToJidMap = sandalphonClient.translateAllowedLessonSlugsToJids(actorJid, slugs);
+        Map<String, String> slugToJidMap = lessonService.translateAllowedLessonSlugsToJids(actorJid, slugs);
 
         List<ChapterLesson> setData = data.stream().filter(cp -> slugToJidMap.containsKey(cp.getSlug())).map(lesson ->
                 new ChapterLesson.Builder()
@@ -93,7 +93,7 @@ public class ChapterLessonResource {
         List<ChapterLesson> lessons = lessonStore.getLessons(chapterJid);
 
         var lessonJids = Lists.transform(lessons, ChapterLesson::getLessonJid);
-        Map<String, LessonInfo> lessonsMap = sandalphonClient.getLessons(lessonJids);
+        Map<String, LessonInfo> lessonsMap = lessonService.getLessons(lessonJids);
 
         return new ChapterLessonsResponse.Builder()
                 .data(lessons)
@@ -118,8 +118,8 @@ public class ChapterLessonResource {
 
         ChapterLesson lesson = checkFound(lessonStore.getLessonByAlias(chapterJid, lessonAlias));
         String lessonJid = lesson.getLessonJid();
-        LessonInfo lessonInfo = sandalphonClient.getLesson(lessonJid);
-        LessonStatement statement = sandalphonClient.getLessonStatement(req, uriInfo, lesson.getLessonJid(), language);
+        LessonInfo lessonInfo = lessonService.getLesson(lessonJid);
+        LessonStatement statement = lessonService.getLessonStatement(req, uriInfo, lesson.getLessonJid(), language);
 
         List<Optional<String>> previousAndNextResourcePaths =
                 resourceStore.getPreviousAndNextResourcePathsForLesson(chapterJid, lessonAlias);

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/chapter/problem/ChapterProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/chapter/problem/ChapterProblemResource.java
@@ -38,9 +38,9 @@ import judgels.chapter.ChapterStore;
 import judgels.chapter.resource.ChapterResourceStore;
 import judgels.gabriel.api.SubmissionSource;
 import judgels.gabriel.api.Verdict;
+import judgels.problem.ProblemService;
 import judgels.problemset.problem.ProblemSetProblemStore;
 import judgels.role.TrainingAdminRoleChecker;
-import judgels.sandalphon.SandalphonClient;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.stats.StatsStore;
@@ -59,7 +59,7 @@ public class ChapterProblemResource {
     @Inject protected StatsStore statsStore;
     @Inject @JerahmeelSubmissionStore protected SubmissionStore submissionStore;
     @Inject protected SubmissionSourceBuilder submissionSourceBuilder;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
 
     @Inject public ChapterProblemResource() {}
 
@@ -82,7 +82,7 @@ public class ChapterProblemResource {
         checkArgument(aliases.size() == data.size(), "Problem aliases must be unique");
         checkArgument(slugs.size() == data.size(), "Problem slugs must be unique");
 
-        Map<String, String> slugToJidMap = sandalphonClient.translateAllowedProblemSlugsToJids(actorJid, slugs);
+        Map<String, String> slugToJidMap = problemService.translateAllowedProblemSlugsToJids(actorJid, slugs);
 
         List<ChapterProblem> setData = data.stream().filter(cp -> slugToJidMap.containsKey(cp.getSlug())).map(problem ->
                 new ChapterProblem.Builder()
@@ -108,7 +108,7 @@ public class ChapterProblemResource {
         List<ChapterProblem> problems = chapterProblemStore.getProblems(chapterJid);
 
         var problemJids = Lists.transform(problems, ChapterProblem::getProblemJid);
-        Map<String, ProblemInfo> problemsMap = sandalphonClient.getProblems(problemJids);
+        Map<String, ProblemInfo> problemsMap = problemService.getProblems(problemJids);
         Map<String, List<List<String>>> problemSetProblemPathsMap = problemSetProblemStore.getProblemSetProblemPathsMap(problemJids);
         Map<String, ProblemProgress> problemProgressesMap = statsStore.getProblemProgressesMap(actorJid, problemJids);
 
@@ -137,7 +137,7 @@ public class ChapterProblemResource {
 
         ChapterProblem problem = checkFound(chapterProblemStore.getProblemByAlias(chapterJid, problemAlias));
         String problemJid = problem.getProblemJid();
-        ProblemInfo problemInfo = sandalphonClient.getProblem(problemJid);
+        ProblemInfo problemInfo = problemService.getProblem(problemJid);
 
         Optional<String> reasonNotAllowedToSubmit = authHeader.isPresent()
                 ? Optional.empty()
@@ -148,7 +148,7 @@ public class ChapterProblemResource {
         List<List<String>> problemSetProblemPaths = problemSetProblemStore.getProblemSetProblemPaths(problemJid);
         ProblemProgress progress = statsStore.getProblemProgressesMap(actorJid, Set.of(problemJid)).get(problemJid);
         Optional<ProblemEditorialInfo> editorial = progress.getVerdict().equals(Verdict.ACCEPTED.getCode())
-                ? sandalphonClient.getProblemEditorial(req, uriInfo, problemJid, language)
+                ? problemService.getProblemEditorial(req, uriInfo, problemJid, language)
                 : Optional.empty();
 
         if (problemInfo.getType() == ProblemType.PROGRAMMING) {
@@ -168,10 +168,10 @@ public class ChapterProblemResource {
                     .previousResourcePath(previousAndNextResourcePaths.get(0))
                     .nextResourcePath(previousAndNextResourcePaths.get(1))
                     .worksheet(new judgels.api.problem.programming.ProblemWorksheet.Builder()
-                            .from(sandalphonClient.getProgrammingProblemWorksheet(req, uriInfo, problemJid, language))
+                            .from(problemService.getProgrammingProblemWorksheet(req, uriInfo, problemJid, language))
                             .reasonNotAllowedToSubmit(reasonNotAllowedToSubmit)
                             .build())
-                    .skeletons(sandalphonClient.getProgrammingProblemSkeletons(problemJid))
+                    .skeletons(problemService.getProgrammingProblemSkeletons(problemJid))
                     .lastSubmission(lastSubmission)
                     .lastSubmissionSource(lastSubmissionSource)
                     .problemSetProblemPaths(problemSetProblemPaths)
@@ -186,7 +186,7 @@ public class ChapterProblemResource {
                     .previousResourcePath(previousAndNextResourcePaths.get(0))
                     .nextResourcePath(previousAndNextResourcePaths.get(1))
                     .worksheet(new judgels.api.problem.bundle.ProblemWorksheet.Builder()
-                            .from(sandalphonClient.getBundleProblemWorksheetWithoutAnswerKey(req, uriInfo, problemJid, language))
+                            .from(problemService.getBundleProblemWorksheetWithoutAnswerKey(req, uriInfo, problemJid, language))
                             .reasonNotAllowedToSubmit(reasonNotAllowedToSubmit)
                             .build())
                     .progress(progress)

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/clarification/ContestClarificationResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/clarification/ContestClarificationResource.java
@@ -36,8 +36,8 @@ import judgels.contest.ContestStore;
 import judgels.contest.log.ContestLogger;
 import judgels.contest.problem.ContestProblemStore;
 import judgels.persistence.api.Page;
+import judgels.problem.ProblemService;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonClient;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 
@@ -52,7 +52,7 @@ public class ContestClarificationResource {
     @Inject protected ContestClarificationStore clarificationStore;
     @Inject protected ContestProblemStore problemStore;
     @Inject protected ProfileStore profileStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
 
     @Inject public ContestClarificationResource() {}
 
@@ -136,7 +136,7 @@ public class ContestClarificationResource {
         Map<String, Profile> profilesMap = profileStore.getProfiles(userJids, contest.getBeginTime());
 
         Map<String, String> problemAliasesMap = problemStore.getProblemAliasesByJids(contestJid, problemJids);
-        Map<String, String> problemNamesMap = sandalphonClient.getProblemNames(problemJids, language);
+        Map<String, String> problemNamesMap = problemService.getProblemNames(problemJids, language);
 
         contestLogger.log(contestJid, "OPEN_CLARIFICATIONS");
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/editorial/ContestEditorialResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/editorial/ContestEditorialResource.java
@@ -33,8 +33,8 @@ import judgels.contest.ContestStore;
 import judgels.contest.log.ContestLogger;
 import judgels.contest.module.ContestModuleStore;
 import judgels.contest.problem.ContestProblemStore;
+import judgels.problem.ProblemService;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonClient;
 
 @Path("/api/v2/contests/{contestJid}/editorial")
 public class ContestEditorialResource {
@@ -44,7 +44,7 @@ public class ContestEditorialResource {
     @Inject protected ContestModuleStore contestModuleStore;
     @Inject protected ContestProblemStore problemStore;
     @Inject protected ProfileStore profileStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
 
     @Inject public ContestEditorialResource() {}
 
@@ -65,9 +65,9 @@ public class ContestEditorialResource {
         List<ContestProblem> problems = problemStore.getProblems(contestJid);
 
         var problemJids = Lists.transform(problems, ContestProblem::getProblemJid);
-        Map<String, ProblemInfo> problemsMap = sandalphonClient.getProblems(problemJids);
-        Map<String, ProblemMetadata> problemMetadatasMap = sandalphonClient.getProblemMetadatas(problemJids);
-        Map<String, ProblemEditorialInfo> problemEditorialsMap = sandalphonClient.getProblemEditorials(req, uriInfo, problemJids, language);
+        Map<String, ProblemInfo> problemsMap = problemService.getProblems(problemJids);
+        Map<String, ProblemMetadata> problemMetadatasMap = problemService.getProblemMetadatas(problemJids);
+        Map<String, ProblemEditorialInfo> problemEditorialsMap = problemService.getProblemEditorials(req, uriInfo, problemJids, language);
 
         Map<String, Profile> profilesMap = Maps.newHashMap();
         profilesMap.putAll(profileStore.parseProfiles(config.getPreface().orElse("")));

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/problem/ContestProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/problem/ContestProblemResource.java
@@ -39,7 +39,7 @@ import judgels.contest.ContestStore;
 import judgels.contest.log.ContestLogger;
 import judgels.contest.module.ContestModuleStore;
 import judgels.gabriel.api.LanguageRestriction;
-import judgels.sandalphon.SandalphonClient;
+import judgels.problem.ProblemService;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.submission.programming.SubmissionStore;
@@ -53,7 +53,7 @@ public class ContestProblemResource {
     @Inject protected ContestProblemStore problemStore;
     @Inject protected ContestModuleStore moduleStore;
     @Inject protected SubmissionStore submissionStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
 
     @Inject public ContestProblemResource() {}
 
@@ -76,7 +76,7 @@ public class ContestProblemResource {
         checkArgument(aliases.size() == data.size(), "Problem aliases must be unique");
         checkArgument(slugs.size() == data.size(), "Problem slugs must be unique");
 
-        Map<String, String> slugToJidMap = sandalphonClient.translateAllowedProblemSlugsToJids(actorJid, slugs);
+        Map<String, String> slugToJidMap = problemService.translateAllowedProblemSlugsToJids(actorJid, slugs);
 
         Set<String> notAllowedSlugs = data.stream()
                 .map(ContestProblemData::getSlug)
@@ -116,7 +116,7 @@ public class ContestProblemResource {
         List<ContestProblem> problems = problemStore.getProblems(contestJid);
 
         var problemJids = Lists.transform(problems, ContestProblem::getProblemJid);
-        Map<String, ProblemInfo> problemsMap = sandalphonClient.getProblems(problemJids);
+        Map<String, ProblemInfo> problemsMap = problemService.getProblems(problemJids);
         Map<String, Long> totalSubmissionsMap =
                 submissionStore.getTotalSubmissionsMap(contestJid, actorJid, problemJids);
 
@@ -164,7 +164,7 @@ public class ContestProblemResource {
 
         ContestProblem problem = checkFound(problemStore.getProblemByAlias(contestJid, problemAlias));
         String problemJid = problem.getProblemJid();
-        ProblemInfo problemInfo = sandalphonClient.getProblem(problemJid);
+        ProblemInfo problemInfo = problemService.getProblem(problemJid);
 
         if (problemInfo.getType() != ProblemType.PROGRAMMING) {
             throw ContestErrors.wrongProblemType(problemInfo.getType());
@@ -176,7 +176,7 @@ public class ContestProblemResource {
                 roleChecker.canSubmit(actorJid, contest, problem, totalSubmissions);
 
         judgels.api.problem.programming.ProblemWorksheet worksheet =
-                sandalphonClient.getProgrammingProblemWorksheet(req, uriInfo, problemJid, language);
+                problemService.getProgrammingProblemWorksheet(req, uriInfo, problemJid, language);
 
         LanguageRestriction contestGradingLanguageRestriction =
                 moduleStore.getStyleModuleConfig(contestJid, contest.getStyle()).getGradingLanguageRestriction();
@@ -223,7 +223,7 @@ public class ContestProblemResource {
 
         ContestProblem problem = checkFound(problemStore.getProblemByAlias(contestJid, problemAlias));
         String problemJid = problem.getProblemJid();
-        ProblemInfo problemInfo = sandalphonClient.getProblem(problemJid);
+        ProblemInfo problemInfo = problemService.getProblem(problemJid);
 
         if (problemInfo.getType() != ProblemType.BUNDLE) {
             throw ContestErrors.wrongProblemType(problemInfo.getType());
@@ -235,7 +235,7 @@ public class ContestProblemResource {
                 roleChecker.canSubmit(actorJid, contest, problem, totalSubmissions);
 
         judgels.api.problem.bundle.ProblemWorksheet worksheet =
-                sandalphonClient.getBundleProblemWorksheetWithoutAnswerKey(req, uriInfo, problemJid, language);
+                problemService.getBundleProblemWorksheetWithoutAnswerKey(req, uriInfo, problemJid, language);
 
         judgels.api.problem.bundle.ProblemWorksheet
                 finalWorksheet = new judgels.api.problem.bundle.ProblemWorksheet.Builder()

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
@@ -37,8 +37,8 @@ import judgels.contest.contestant.ContestContestantStore;
 import judgels.contest.module.ContestModuleStore;
 import judgels.contest.problem.ContestProblemStore;
 import judgels.gabriel.api.ScoringConfig;
+import judgels.problem.ProblemService;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonClient;
 import judgels.submission.bundle.ItemSubmissionStore;
 import judgels.submission.programming.SubmissionStore;
 
@@ -56,7 +56,7 @@ public class ContestScoreboardUpdater {
     private final ScoreboardProcessorRegistry scoreboardProcessorRegistry;
     private final ContestScoreboardPusher scoreboardPusher;
     private final ProfileStore profileStore;
-    private final SandalphonClient sandalphonClient;
+    private final ProblemService problemService;
 
     public ContestScoreboardUpdater(
             ObjectMapper objectMapper,
@@ -72,7 +72,7 @@ public class ContestScoreboardUpdater {
             ScoreboardProcessorRegistry scoreboardProcessorRegistry,
             ContestScoreboardPusher scoreboardPusher,
             ProfileStore profileStore,
-            SandalphonClient sandalphonClient) {
+            ProblemService problemService) {
 
         this.objectMapper = objectMapper;
         this.contestTimer = contestTimer;
@@ -87,7 +87,7 @@ public class ContestScoreboardUpdater {
         this.scoreboardProcessorRegistry = scoreboardProcessorRegistry;
         this.scoreboardPusher = scoreboardPusher;
         this.profileStore = profileStore;
-        this.sandalphonClient = sandalphonClient;
+        this.problemService = problemService;
     }
 
     @UnitOfWork
@@ -181,7 +181,7 @@ public class ContestScoreboardUpdater {
 
         Map<String, ScoringConfig> problemScoringConfigsMap = contest.getStyle() == ContestStyle.BUNDLE
                 ? Map.of()
-                : sandalphonClient.getProgrammingProblemScoringConfigs(problemJidsSet);
+                : problemService.getProgrammingProblemScoringConfigs(problemJidsSet);
 
 
         Map<ContestScoreboardType, Scoreboard> scoreboards = new HashMap<>();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdaterModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdaterModule.java
@@ -11,8 +11,8 @@ import judgels.contest.ContestTimer;
 import judgels.contest.contestant.ContestContestantStore;
 import judgels.contest.module.ContestModuleStore;
 import judgels.contest.problem.ContestProblemStore;
+import judgels.problem.ProblemService;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonClient;
 import judgels.service.JudgelsScheduler;
 import judgels.submission.bundle.ItemSubmissionStore;
 import judgels.submission.programming.SubmissionStore;
@@ -64,7 +64,7 @@ public class ContestScoreboardUpdaterModule {
             ScoreboardProcessorRegistry scoreboardProcessorRegistry,
             ContestScoreboardPusher scoreboardPusher,
             ProfileStore profileStore,
-            SandalphonClient sandalphonClient) {
+            ProblemService problemService) {
 
         return unitOfWorkAwareProxyFactory.create(
                 ContestScoreboardUpdater.class,
@@ -82,7 +82,7 @@ public class ContestScoreboardUpdaterModule {
                         ScoreboardProcessorRegistry.class,
                         ContestScoreboardPusher.class,
                         ProfileStore.class,
-                        SandalphonClient.class},
+                        ProblemService.class},
                 new Object[] {
                         objectMapper,
                         contestTimer,
@@ -97,6 +97,6 @@ public class ContestScoreboardUpdaterModule {
                         scoreboardProcessorRegistry,
                         scoreboardPusher,
                         profileStore,
-                        sandalphonClient});
+                        problemService});
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/submission/bundle/ContestItemSubmissionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/submission/bundle/ContestItemSubmissionResource.java
@@ -50,8 +50,8 @@ import judgels.contest.problem.ContestProblemRoleChecker;
 import judgels.contest.problem.ContestProblemStore;
 import judgels.contest.submission.ContestSubmissionRoleChecker;
 import judgels.persistence.api.Page;
+import judgels.problem.ProblemService;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonClient;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.submission.bundle.ItemSubmissionGraderRegistry;
@@ -75,7 +75,7 @@ public class ContestItemSubmissionResource {
     @Inject protected ItemSubmissionRegrader itemSubmissionRegrader;
     @Inject protected ProfileStore profileStore;
     @Inject protected UserStore userStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
 
     @Inject public ContestItemSubmissionResource() {}
 
@@ -145,7 +145,7 @@ public class ContestItemSubmissionResource {
         Map<String, String> problemAliasesMap = problemStore.getProblemAliasesByJids(contestJid, problemJids);
 
         var itemJids = Lists.transform(submissions.getPage(), ItemSubmission::getItemJid);
-        Map<String, BundleItem> itemsMap = sandalphonClient.getItems(problemJids, itemJids);
+        Map<String, BundleItem> itemsMap = problemService.getItems(problemJids, itemJids);
         Map<String, Integer> itemNumbersMap = itemsMap.entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
@@ -179,7 +179,7 @@ public class ContestItemSubmissionResource {
         ContestProblem problem = checkFound(problemStore.getProblem(data.getContainerJid(), data.getProblemJid()));
         checkAllowed(problemRoleChecker.canSubmit(actorJid, contest, problem, 0));
 
-        Optional<Item> item = sandalphonClient.getItem(data.getProblemJid(), data.getItemJid());
+        Optional<Item> item = problemService.getItem(data.getProblemJid(), data.getItemJid());
         checkFound(item);
 
         if (data.getAnswer().trim().isEmpty()) {
@@ -260,7 +260,7 @@ public class ContestItemSubmissionResource {
                 .collect(Collectors.toMap(ItemSubmission::getItemJid, Function.identity()));
 
         List<String> bundleProblemJidsSortedByAlias = problemStore.getProblemJids(contestJid).stream()
-                .filter(problemJid -> sandalphonClient.getProblem(problemJid).getType().equals(ProblemType.BUNDLE))
+                .filter(problemJid -> problemService.getProblem(problemJid).getType().equals(ProblemType.BUNDLE))
                 .collect(Collectors.toList());
         Map<String, String> problemAliasesByProblemJid = problemStore.getProblemAliasesByJids(
                 contestJid, ImmutableSet.copyOf(bundleProblemJidsSortedByAlias));
@@ -268,7 +268,7 @@ public class ContestItemSubmissionResource {
         Map<String, List<String>> itemJidsByProblemJid = new HashMap<>();
         Map<String, ItemType> itemTypesByItemJid = new HashMap<>();
         for (String problemJid : bundleProblemJidsSortedByAlias) {
-            ProblemWorksheet worksheet = sandalphonClient.getBundleProblemWorksheet(null, null, problemJid, language);
+            ProblemWorksheet worksheet = problemService.getBundleProblemWorksheet(null, null, problemJid, language);
             List<Item> items = worksheet.getItems().stream()
                     .filter(item -> !item.getType().equals(ItemType.STATEMENT))
                     .collect(Collectors.toList());
@@ -282,7 +282,7 @@ public class ContestItemSubmissionResource {
             );
         }
 
-        Map<String, String> problemNamesByProblemJid = sandalphonClient.getProblemNames(
+        Map<String, String> problemNamesByProblemJid = problemService.getProblemNames(
                 ImmutableSet.copyOf(bundleProblemJidsSortedByAlias), language);
 
         Profile profile = profileStore.getProfile(userJid, contest.getBeginTime());

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/submission/programming/ContestSubmissionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/submission/programming/ContestSubmissionResource.java
@@ -61,8 +61,8 @@ import judgels.contest.supervisor.ContestSupervisorStore;
 import judgels.gabriel.api.LanguageRestriction;
 import judgels.gabriel.api.SubmissionSource;
 import judgels.persistence.api.Page;
+import judgels.problem.ProblemService;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonClient;
 import judgels.sandalphon.SandalphonUtils;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
@@ -98,7 +98,7 @@ public class ContestSubmissionResource {
     @Inject protected ContestProblemStore problemStore;
     @Inject protected ProfileStore profileStore;
     @Inject protected UserStore userStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
 
     @Inject public ContestSubmissionResource() {}
 
@@ -218,7 +218,7 @@ public class ContestSubmissionResource {
 
         ContestProblem contestProblem =
                 checkFound(problemStore.getProblem(contest.getJid(), submission.getProblemJid()));
-        ProblemInfo problem = sandalphonClient.getProblem(contestProblem.getProblemJid());
+        ProblemInfo problem = problemService.getProblem(contestProblem.getProblemJid());
 
         String userJid = submission.getUserJid();
         Profile profile = checkFound(Optional.ofNullable(profileStore.getProfile(userJid, contest.getBeginTime())));
@@ -322,7 +322,7 @@ public class ContestSubmissionResource {
                 .additionalGradingLanguageRestriction(contestGradingLanguageRestriction)
                 .build();
         SubmissionSource source = submissionSourceBuilder.fromNewSubmission(parts);
-        ProblemSubmissionConfig config = sandalphonClient.getProgrammingProblemSubmissionConfig(data.getProblemJid());
+        ProblemSubmissionConfig config = problemService.getProgrammingProblemSubmissionConfig(data.getProblemJid());
         Submission submission = submissionClient.submit(data, source, config);
 
         submissionSourceBuilder.storeSubmissionSource(submission.getJid(), source);
@@ -342,7 +342,7 @@ public class ContestSubmissionResource {
         Contest contest = checkFound(contestStore.getContestByJid(submission.getContainerJid()));
         checkAllowed(submissionRoleChecker.canManage(actorJid, contest));
 
-        ProblemSubmissionConfig config = sandalphonClient.getProgrammingProblemSubmissionConfig(submission.getProblemJid());
+        ProblemSubmissionConfig config = problemService.getProgrammingProblemSubmissionConfig(submission.getProblemJid());
         submissionRegrader.regradeSubmission(submission, config);
 
         scoreboardIncrementalMarker.invalidateMark(contest.getJid());
@@ -380,7 +380,7 @@ public class ContestSubmissionResource {
             }
 
             var problemJids = Lists.transform(submissions, Submission::getProblemJid);
-            configsMap.putAll(sandalphonClient.getProgrammingProblemSubmissionConfigs(
+            configsMap.putAll(problemService.getProgrammingProblemSubmissionConfigs(
                     Sets.difference(Set.copyOf(problemJids), configsMap.keySet())));
 
             submissionRegrader.regradeSubmissions(submissions, configsMap);

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/submission/programming/ContestSubmissionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/submission/programming/ContestSubmissionResource.java
@@ -62,8 +62,8 @@ import judgels.gabriel.api.LanguageRestriction;
 import judgels.gabriel.api.SubmissionSource;
 import judgels.persistence.api.Page;
 import judgels.problem.ProblemService;
+import judgels.problem.ProblemUtils;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonUtils;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.submission.programming.SubmissionClient;
@@ -233,7 +233,7 @@ public class ContestSubmissionResource {
                 .data(submissionWithSource)
                 .profile(profile)
                 .problemAlias(contestProblem.getAlias())
-                .problemName(SandalphonUtils.getProblemName(problem, language))
+                .problemName(ProblemUtils.getProblemName(problem, language))
                 .containerName(contest.getName())
                 .build();
     }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/lesson/LessonService.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/lesson/LessonService.java
@@ -1,0 +1,79 @@
+package judgels.lesson;
+
+import static judgels.resource.LanguageUtils.simplifyLanguageCode;
+
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.UriInfo;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import judgels.api.lesson.Lesson;
+import judgels.api.lesson.LessonInfo;
+import judgels.api.lesson.LessonStatement;
+import judgels.lesson.statement.LessonStatementStore;
+import judgels.resource.StatementLanguageStatus;
+import judgels.role.ProblemAdminRoleChecker;
+import judgels.sandalphon.SandalphonUtils;
+
+public class LessonService {
+    @Inject protected ProblemAdminRoleChecker roleChecker;
+    @Inject protected LessonStore lessonStore;
+    @Inject protected LessonStatementStore lessonStatementStore;
+
+    @Inject public LessonService() {}
+
+    public Map<String, String> translateAllowedLessonSlugsToJids(String actorJid, Collection<String> slugs) {
+        Optional<String> userJid = roleChecker.isAdmin(actorJid)
+                ? Optional.empty()
+                : Optional.of(actorJid);
+        return lessonStore.translateAllowedSlugsToJids(userJid, slugs);
+    }
+
+    public LessonInfo getLesson(String lessonJid) {
+        Lesson lesson = lessonStore.getLessonByJid(lessonJid).get();
+
+        return new LessonInfo.Builder()
+                .slug(lesson.getSlug())
+                .defaultLanguage(simplifyLanguageCode(lessonStatementStore.getDefaultLanguage(null, lessonJid)))
+                .titlesByLanguage(lessonStatementStore.getTitlesByLanguage(null, lessonJid).entrySet()
+                        .stream()
+                        .collect(Collectors.toMap(e -> simplifyLanguageCode(e.getKey()), e -> e.getValue())))
+                .build();
+    }
+
+    public Map<String, LessonInfo> getLessons(Collection<String> lessonJids) {
+        return Set.copyOf(lessonJids).stream().collect(Collectors.toMap(jid -> jid, this::getLesson));
+    }
+
+    public LessonStatement getLessonStatement(
+            HttpServletRequest req,
+            UriInfo uriInfo,
+            String lessonJid, Optional<String> language) {
+
+        String sanitizedLanguage = sanitizeLessonStatementLanguage(lessonJid, language);
+        LessonStatement statement = lessonStatementStore.getStatement(null, lessonJid, sanitizedLanguage);
+        String apiUrl = SandalphonUtils.getApiUrl(req, uriInfo);
+
+        return new LessonStatement.Builder()
+                .from(statement)
+                .text(SandalphonUtils.replaceLessonRenderUrls(statement.getText(), apiUrl, lessonJid))
+                .build();
+    }
+
+    private String sanitizeLessonStatementLanguage(String problemJid, Optional<String> language) {
+        Map<String, StatementLanguageStatus> availableLanguages = lessonStatementStore.getAvailableLanguages(null, problemJid);
+        Map<String, String> simplifiedLanguages = availableLanguages.entrySet()
+                .stream()
+                .collect(Collectors.toMap(e -> simplifyLanguageCode(e.getKey()), e -> e.getKey()));
+
+        String lang = language.orElse("");
+        if (!simplifiedLanguages.containsKey(lang) || availableLanguages.get(simplifiedLanguages.get(lang)) == StatementLanguageStatus.DISABLED) {
+            lang = simplifyLanguageCode(lessonStatementStore.getDefaultLanguage(null, problemJid));
+        }
+
+        return simplifiedLanguages.get(lang);
+    }
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/lesson/LessonService.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/lesson/LessonService.java
@@ -16,7 +16,6 @@ import judgels.api.lesson.LessonStatement;
 import judgels.lesson.statement.LessonStatementStore;
 import judgels.resource.StatementLanguageStatus;
 import judgels.role.ProblemAdminRoleChecker;
-import judgels.sandalphon.SandalphonUtils;
 
 public class LessonService {
     @Inject protected ProblemAdminRoleChecker roleChecker;
@@ -55,11 +54,11 @@ public class LessonService {
 
         String sanitizedLanguage = sanitizeLessonStatementLanguage(lessonJid, language);
         LessonStatement statement = lessonStatementStore.getStatement(null, lessonJid, sanitizedLanguage);
-        String apiUrl = SandalphonUtils.getApiUrl(req, uriInfo);
+        String apiUrl = LessonUtils.getApiUrl(req, uriInfo);
 
         return new LessonStatement.Builder()
                 .from(statement)
-                .text(SandalphonUtils.replaceLessonRenderUrls(statement.getText(), apiUrl, lessonJid))
+                .text(LessonUtils.replaceLessonRenderUrls(statement.getText(), apiUrl, lessonJid))
                 .build();
     }
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/lesson/LessonUtils.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/lesson/LessonUtils.java
@@ -1,0 +1,37 @@
+package judgels.lesson;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.UriInfo;
+
+public class LessonUtils {
+    private LessonUtils() {}
+
+    public static String replaceLessonRenderUrls(String text, String apiUrl, String lessonJid) {
+        return text
+                .replaceAll(
+                        "src=\"render/",
+                        String.format("src=\"%sapi/v2/lessons/%s/render/", apiUrl, lessonJid))
+                .replaceAll(
+                        "url=render/",
+                        String.format("url=%sapi/v2/lessons/%s/render/", apiUrl, lessonJid))
+                .replaceAll(
+                        "href=\"render/",
+                        String.format("href=\"%sapi/v2/lessons/%s/render/", apiUrl, lessonJid));
+    }
+
+    public static String getApiUrl(HttpServletRequest req, UriInfo uriInfo) {
+        if (req == null) {
+            return "";
+        }
+
+        String oldScheme = uriInfo.getBaseUri().getScheme();
+        String newScheme = oldScheme;
+
+        String forwardedProto = req.getHeader("X-Forwarded-Proto");
+        if (forwardedProto != null && !forwardedProto.isEmpty()) {
+            newScheme = forwardedProto;
+        }
+
+        return newScheme + uriInfo.getBaseUri().toString().substring(oldScheme.length());
+    }
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/problem/ProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/problem/ProblemResource.java
@@ -18,7 +18,6 @@ import judgels.api.problem.ProblemSetProblemInfo;
 import judgels.api.problem.ProblemsResponse;
 import judgels.difficulty.ProblemDifficultyStore;
 import judgels.persistence.api.Page;
-import judgels.sandalphon.SandalphonClient;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.stats.StatsStore;
@@ -31,7 +30,7 @@ public class ProblemResource {
     @Inject protected ProblemStore problemStore;
     @Inject protected StatsStore statsStore;
     @Inject protected ProblemDifficultyStore difficultyStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
 
     @Inject public ProblemResource() {}
 
@@ -55,7 +54,7 @@ public class ProblemResource {
 
         Set<String> allowedProblemJids = null;
         if (!tags.isEmpty()) {
-            allowedProblemJids = sandalphonClient.getProblemJidsByTags(tags);
+            allowedProblemJids = problemService.getProblemJidsByTags(tags);
         }
 
         Page<ProblemSetProblemInfo> problems = problemStore.getProblems(allowedProblemJids, pageNumber, PAGE_SIZE);
@@ -63,8 +62,8 @@ public class ProblemResource {
 
         return new ProblemsResponse.Builder()
                 .data(problems)
-                .problemsMap(sandalphonClient.getProblems(problemJids))
-                .problemMetadatasMap(sandalphonClient.getProblemMetadatas(problemJids))
+                .problemsMap(problemService.getProblems(problemJids))
+                .problemMetadatasMap(problemService.getProblemMetadatas(problemJids))
                 .problemDifficultiesMap(difficultyStore.getProblemDifficultiesMap(problemJids))
                 .problemProgressesMap(statsStore.getProblemProgressesMap(actorJid, problemJids))
                 .build();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/problem/ProblemService.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/problem/ProblemService.java
@@ -39,7 +39,6 @@ import judgels.problem.bundle.item.BundleItemStore;
 import judgels.problem.programming.ProgrammingProblemStore;
 import judgels.resource.StatementLanguageStatus;
 import judgels.role.ProblemAdminRoleChecker;
-import judgels.sandalphon.SandalphonUtils;
 
 public class ProblemService {
     @Inject protected ProblemAdminRoleChecker roleChecker;
@@ -105,7 +104,7 @@ public class ProblemService {
                 .stream()
                 .collect(toMap(
                         Map.Entry::getKey,
-                        e -> SandalphonUtils.getProblemName(e.getValue(), language)
+                        e -> ProblemUtils.getProblemName(e.getValue(), language)
                 ));
     }
 
@@ -166,12 +165,12 @@ public class ProblemService {
         GradingConfig config = programmingProblemStore.getGradingConfig(null, problemJid);
         String sanitizedLanguage = sanitizeProblemStatementLanguage(problemJid, language);
         ProblemStatement statement = problemStatementStore.getStatement(null, problemJid, sanitizedLanguage);
-        String apiUrl = SandalphonUtils.getApiUrl(req, uriInfo);
+        String apiUrl = ProblemUtils.getApiUrl(req, uriInfo);
 
         return new judgels.api.problem.programming.ProblemWorksheet.Builder()
                 .statement(new ProblemStatement.Builder()
                         .from(statement)
-                        .text(SandalphonUtils.replaceProblemRenderUrls(statement.getText(), apiUrl, problemJid))
+                        .text(ProblemUtils.replaceProblemRenderUrls(statement.getText(), apiUrl, problemJid))
                         .build())
                 .limits(new ProblemLimits.Builder()
                         .timeLimit(config.getTimeLimit())
@@ -209,12 +208,12 @@ public class ProblemService {
         }
 
         ProblemStatement statement = problemStatementStore.getStatement(null, problemJid, sanitizedLanguage);
-        String apiUrl = SandalphonUtils.getApiUrl(req, uriInfo);
+        String apiUrl = ProblemUtils.getApiUrl(req, uriInfo);
 
         return new judgels.api.problem.bundle.ProblemWorksheet.Builder()
                 .statement(new ProblemStatement.Builder()
                         .from(statement)
-                        .text(SandalphonUtils.replaceProblemRenderUrls(statement.getText(), apiUrl, problemJid))
+                        .text(ProblemUtils.replaceProblemRenderUrls(statement.getText(), apiUrl, problemJid))
                         .build())
                 .items(itemsWithConfig
                         .stream()
@@ -247,10 +246,10 @@ public class ProblemService {
 
         String sanitizedLanguage = sanitizeProblemEditorialLanguage(problemJid, language);
         ProblemEditorial editorial = problemEditorialStore.getEditorial(null, problemJid, sanitizedLanguage);
-        String apiUrl = SandalphonUtils.getApiUrl(req, uriInfo);
+        String apiUrl = ProblemUtils.getApiUrl(req, uriInfo);
 
         return Optional.of(new ProblemEditorialInfo.Builder()
-                .text(SandalphonUtils.replaceProblemEditorialRenderUrls(editorial.getText(), apiUrl, problemJid))
+                .text(ProblemUtils.replaceProblemEditorialRenderUrls(editorial.getText(), apiUrl, problemJid))
                 .defaultLanguage(simplifyLanguageCode(problemEditorialStore.getEditorialDefaultLanguage(null, problemJid)))
                 .languages(problemEditorialStore.getEditorialLanguages(null, problemJid).stream()
                         .map(lang -> simplifyLanguageCode(lang))

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/problem/ProblemService.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/problem/ProblemService.java
@@ -1,8 +1,9 @@
-package judgels.sandalphon;
+package judgels.problem;
 
 import static java.util.stream.Collectors.toMap;
 import static judgels.resource.LanguageUtils.simplifyLanguageCode;
 
+import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.UriInfo;
 import java.util.ArrayList;
@@ -14,10 +15,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.inject.Inject;
-import judgels.api.lesson.Lesson;
-import judgels.api.lesson.LessonInfo;
-import judgels.api.lesson.LessonStatement;
 import judgels.api.problem.Problem;
 import judgels.api.problem.ProblemEditorial;
 import judgels.api.problem.ProblemEditorialInfo;
@@ -33,8 +30,6 @@ import judgels.api.problem.programming.ProblemSkeleton;
 import judgels.api.problem.programming.ProblemSubmissionConfig;
 import judgels.gabriel.api.GradingConfig;
 import judgels.gabriel.api.ScoringConfig;
-import judgels.lesson.LessonStore;
-import judgels.lesson.statement.LessonStatementStore;
 import judgels.problem.base.ProblemStore;
 import judgels.problem.base.editorial.ProblemEditorialStore;
 import judgels.problem.base.statement.ProblemStatementStore;
@@ -44,8 +39,9 @@ import judgels.problem.bundle.item.BundleItemStore;
 import judgels.problem.programming.ProgrammingProblemStore;
 import judgels.resource.StatementLanguageStatus;
 import judgels.role.ProblemAdminRoleChecker;
+import judgels.sandalphon.SandalphonUtils;
 
-public class SandalphonClient {
+public class ProblemService {
     @Inject protected ProblemAdminRoleChecker roleChecker;
     @Inject protected ProblemStore problemStore;
     @Inject protected ProblemStatementStore problemStatementStore;
@@ -54,10 +50,8 @@ public class SandalphonClient {
     @Inject protected ProgrammingProblemStore programmingProblemStore;
     @Inject protected BundleItemStore bundleItemStore;
     @Inject protected ItemProcessorRegistry itemProcessorRegistry;
-    @Inject protected LessonStore lessonStore;
-    @Inject protected LessonStatementStore lessonStatementStore;
 
-    @Inject public SandalphonClient() {}
+    @Inject public ProblemService() {}
 
     public Map<String, String> translateAllowedProblemSlugsToJids(String actorJid, Set<String> slugs) {
         Optional<String> userJid = roleChecker.isAdmin(actorJid)
@@ -172,7 +166,7 @@ public class SandalphonClient {
         GradingConfig config = programmingProblemStore.getGradingConfig(null, problemJid);
         String sanitizedLanguage = sanitizeProblemStatementLanguage(problemJid, language);
         ProblemStatement statement = problemStatementStore.getStatement(null, problemJid, sanitizedLanguage);
-        String apiUrl = getApiUrl(req, uriInfo);
+        String apiUrl = SandalphonUtils.getApiUrl(req, uriInfo);
 
         return new judgels.api.problem.programming.ProblemWorksheet.Builder()
                 .statement(new ProblemStatement.Builder()
@@ -215,7 +209,7 @@ public class SandalphonClient {
         }
 
         ProblemStatement statement = problemStatementStore.getStatement(null, problemJid, sanitizedLanguage);
-        String apiUrl = getApiUrl(req, uriInfo);
+        String apiUrl = SandalphonUtils.getApiUrl(req, uriInfo);
 
         return new judgels.api.problem.bundle.ProblemWorksheet.Builder()
                 .statement(new ProblemStatement.Builder()
@@ -253,7 +247,7 @@ public class SandalphonClient {
 
         String sanitizedLanguage = sanitizeProblemEditorialLanguage(problemJid, language);
         ProblemEditorial editorial = problemEditorialStore.getEditorial(null, problemJid, sanitizedLanguage);
-        String apiUrl = getApiUrl(req, uriInfo);
+        String apiUrl = SandalphonUtils.getApiUrl(req, uriInfo);
 
         return Optional.of(new ProblemEditorialInfo.Builder()
                 .text(SandalphonUtils.replaceProblemEditorialRenderUrls(editorial.getText(), apiUrl, problemJid))
@@ -301,73 +295,5 @@ public class SandalphonClient {
         }
 
         return simplifiedLanguages.get(lang);
-    }
-
-    public Map<String, String> translateAllowedLessonSlugsToJids(String actorJid, Collection<String> slugs) {
-        Optional<String> userJid = roleChecker.isAdmin(actorJid)
-                ? Optional.empty()
-                : Optional.of(actorJid);
-        return lessonStore.translateAllowedSlugsToJids(userJid, slugs);
-    }
-
-    public LessonInfo getLesson(String lessonJid) {
-        Lesson lesson = lessonStore.getLessonByJid(lessonJid).get();
-
-        return new LessonInfo.Builder()
-                .slug(lesson.getSlug())
-                .defaultLanguage(simplifyLanguageCode(lessonStatementStore.getDefaultLanguage(null, lessonJid)))
-                .titlesByLanguage(lessonStatementStore.getTitlesByLanguage(null, lessonJid).entrySet()
-                        .stream()
-                        .collect(Collectors.toMap(e -> simplifyLanguageCode(e.getKey()), e -> e.getValue())))
-                .build();
-    }
-
-    public Map<String, LessonInfo> getLessons(Collection<String> lessonJids) {
-        return Set.copyOf(lessonJids).stream().collect(Collectors.toMap(jid -> jid, this::getLesson));
-    }
-
-    public LessonStatement getLessonStatement(
-            HttpServletRequest req,
-            UriInfo uriInfo,
-            String lessonJid, Optional<String> language) {
-
-        String sanitizedLanguage = sanitizeLessonStatementLanguage(lessonJid, language);
-        LessonStatement statement = lessonStatementStore.getStatement(null, lessonJid, sanitizedLanguage);
-        String apiUrl = getApiUrl(req, uriInfo);
-
-        return new LessonStatement.Builder()
-                .from(statement)
-                .text(SandalphonUtils.replaceLessonRenderUrls(statement.getText(), apiUrl, lessonJid))
-                .build();
-    }
-
-    private String sanitizeLessonStatementLanguage(String problemJid, Optional<String> language) {
-        Map<String, StatementLanguageStatus> availableLanguages = lessonStatementStore.getAvailableLanguages(null, problemJid);
-        Map<String, String> simplifiedLanguages = availableLanguages.entrySet()
-                .stream()
-                .collect(Collectors.toMap(e -> simplifyLanguageCode(e.getKey()), e -> e.getKey()));
-
-        String lang = language.orElse("");
-        if (!simplifiedLanguages.containsKey(lang) || availableLanguages.get(simplifiedLanguages.get(lang)) == StatementLanguageStatus.DISABLED) {
-            lang = simplifyLanguageCode(lessonStatementStore.getDefaultLanguage(null, problemJid));
-        }
-
-        return simplifiedLanguages.get(lang);
-    }
-
-    private static String getApiUrl(HttpServletRequest req, UriInfo uriInfo) {
-        if (req == null) {
-            return "";
-        }
-
-        String oldScheme = uriInfo.getBaseUri().getScheme();
-        String newScheme = oldScheme;
-
-        String forwardedProto = req.getHeader("X-Forwarded-Proto");
-        if (forwardedProto != null && !forwardedProto.isEmpty()) {
-            newScheme = forwardedProto;
-        }
-
-        return newScheme + uriInfo.getBaseUri().toString().substring(oldScheme.length());
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/problem/ProblemUtils.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/problem/ProblemUtils.java
@@ -1,29 +1,12 @@
-package judgels.sandalphon;
+package judgels.problem;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.UriInfo;
 import java.util.Optional;
-import judgels.api.lesson.LessonInfo;
 import judgels.api.problem.ProblemInfo;
 
-public class SandalphonUtils {
-    private SandalphonUtils() {}
-
-    public static String getApiUrl(HttpServletRequest req, UriInfo uriInfo) {
-        if (req == null) {
-            return "";
-        }
-
-        String oldScheme = uriInfo.getBaseUri().getScheme();
-        String newScheme = oldScheme;
-
-        String forwardedProto = req.getHeader("X-Forwarded-Proto");
-        if (forwardedProto != null && !forwardedProto.isEmpty()) {
-            newScheme = forwardedProto;
-        }
-
-        return newScheme + uriInfo.getBaseUri().toString().substring(oldScheme.length());
-    }
+public class ProblemUtils {
+    private ProblemUtils() {}
 
     public static String getProblemName(ProblemInfo problem, Optional<String> language) {
         String finalLanguage = problem.getDefaultLanguage();
@@ -31,14 +14,6 @@ public class SandalphonUtils {
             finalLanguage = language.get();
         }
         return problem.getTitlesByLanguage().get(finalLanguage);
-    }
-
-    public static String getLessonName(LessonInfo lesson, Optional<String> language) {
-        String finalLanguage = lesson.getDefaultLanguage();
-        if (language.isPresent() && lesson.getTitlesByLanguage().containsKey(language.get())) {
-            finalLanguage = language.get();
-        }
-        return lesson.getTitlesByLanguage().get(finalLanguage);
     }
 
     public static String replaceProblemRenderUrls(String text, String apiUrl, String problemJid) {
@@ -67,16 +42,19 @@ public class SandalphonUtils {
                         String.format("href=\"%sapi/v2/problems/%s/editorials/render/", apiUrl, problemJid));
     }
 
-    public static String replaceLessonRenderUrls(String text, String apiUrl, String lessonJid) {
-        return text
-                .replaceAll(
-                        "src=\"render/",
-                        String.format("src=\"%sapi/v2/lessons/%s/render/", apiUrl, lessonJid))
-                .replaceAll(
-                        "url=render/",
-                        String.format("url=%sapi/v2/lessons/%s/render/", apiUrl, lessonJid))
-                .replaceAll(
-                        "href=\"render/",
-                        String.format("href=\"%sapi/v2/lessons/%s/render/", apiUrl, lessonJid));
+    public static String getApiUrl(HttpServletRequest req, UriInfo uriInfo) {
+        if (req == null) {
+            return "";
+        }
+
+        String oldScheme = uriInfo.getBaseUri().getScheme();
+        String newScheme = oldScheme;
+
+        String forwardedProto = req.getHeader("X-Forwarded-Proto");
+        if (forwardedProto != null && !forwardedProto.isEmpty()) {
+            newScheme = forwardedProto;
+        }
+
+        return newScheme + uriInfo.getBaseUri().toString().substring(oldScheme.length());
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/problem/bundle/EssayItemProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/problem/bundle/EssayItemProcessor.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import judgels.api.problem.bundle.EssayItemConfig;
 import judgels.api.problem.bundle.Item;
 import judgels.api.problem.bundle.ItemConfig;
-import judgels.sandalphon.SandalphonUtils;
+import judgels.problem.ProblemUtils;
 
 public class EssayItemProcessor implements ItemProcessor {
     @Override
@@ -20,7 +20,7 @@ public class EssayItemProcessor implements ItemProcessor {
                 .config(new EssayItemConfig.Builder()
                         .from(item.getConfig())
                         .statement(
-                                SandalphonUtils.replaceProblemRenderUrls(
+                                ProblemUtils.replaceProblemRenderUrls(
                                         item.getConfig().getStatement(),
                                         apiUrl,
                                         problemJid))

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/problem/bundle/MultipleChoiceItemProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/problem/bundle/MultipleChoiceItemProcessor.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 import judgels.api.problem.bundle.Item;
 import judgels.api.problem.bundle.ItemConfig;
 import judgels.api.problem.bundle.MultipleChoiceItemConfig;
-import judgels.sandalphon.SandalphonUtils;
+import judgels.problem.ProblemUtils;
 
 public class MultipleChoiceItemProcessor implements ItemProcessor {
     @Override
@@ -23,7 +23,7 @@ public class MultipleChoiceItemProcessor implements ItemProcessor {
         List<MultipleChoiceItemConfig.Choice> choices = itemConfig.getChoices().stream()
                 .map(choice -> new MultipleChoiceItemConfig.Choice.Builder()
                         .from(choice)
-                        .content(SandalphonUtils.replaceProblemRenderUrls(
+                        .content(ProblemUtils.replaceProblemRenderUrls(
                                 choice.getContent(),
                                 apiUrl,
                                 problemJid))
@@ -35,7 +35,7 @@ public class MultipleChoiceItemProcessor implements ItemProcessor {
                 .config(new MultipleChoiceItemConfig.Builder()
                         .from(itemConfig)
                         .statement(
-                                SandalphonUtils.replaceProblemRenderUrls(
+                                ProblemUtils.replaceProblemRenderUrls(
                                         item.getConfig().getStatement(),
                                         apiUrl,
                                         problemJid))

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/problem/bundle/ShortAnswerItemProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/problem/bundle/ShortAnswerItemProcessor.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import judgels.api.problem.bundle.Item;
 import judgels.api.problem.bundle.ItemConfig;
 import judgels.api.problem.bundle.ShortAnswerItemConfig;
-import judgels.sandalphon.SandalphonUtils;
+import judgels.problem.ProblemUtils;
 
 public class ShortAnswerItemProcessor implements ItemProcessor {
     @Override
@@ -21,7 +21,7 @@ public class ShortAnswerItemProcessor implements ItemProcessor {
                 .config(new ShortAnswerItemConfig.Builder()
                         .from(item.getConfig())
                         .statement(
-                                SandalphonUtils.replaceProblemRenderUrls(
+                                ProblemUtils.replaceProblemRenderUrls(
                                         item.getConfig().getStatement(),
                                         apiUrl,
                                         problemJid))

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/problem/bundle/StatementItemProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/problem/bundle/StatementItemProcessor.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import judgels.api.problem.bundle.Item;
 import judgels.api.problem.bundle.ItemConfig;
 import judgels.api.problem.bundle.StatementItemConfig;
-import judgels.sandalphon.SandalphonUtils;
+import judgels.problem.ProblemUtils;
 
 public class StatementItemProcessor implements ItemProcessor {
     @Override
@@ -20,7 +20,7 @@ public class StatementItemProcessor implements ItemProcessor {
                 .config(new StatementItemConfig.Builder()
                         .from(item.getConfig())
                         .statement(
-                                SandalphonUtils.replaceProblemRenderUrls(
+                                ProblemUtils.replaceProblemRenderUrls(
                                         item.getConfig().getStatement(),
                                         apiUrl,
                                         problemJid))

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/problemset/problem/ProblemSetProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/problemset/problem/ProblemSetProblemResource.java
@@ -46,10 +46,10 @@ import judgels.api.problemset.problem.ProblemSetProblemsResponse;
 import judgels.api.profile.Profile;
 import judgels.contest.ContestStore;
 import judgels.difficulty.ProblemDifficultyStore;
+import judgels.problem.ProblemService;
 import judgels.problemset.ProblemSetStore;
 import judgels.profile.ProfileStore;
 import judgels.role.TrainingAdminRoleChecker;
-import judgels.sandalphon.SandalphonClient;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.stats.StatsStore;
@@ -63,7 +63,7 @@ public class ProblemSetProblemResource {
     @Inject protected ProblemDifficultyStore difficultyStore;
     @Inject protected StatsStore statsStore;
     @Inject protected ProfileStore profileStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
     @Inject protected ContestStore contestStore;
 
     @Inject public ProblemSetProblemResource() {}
@@ -87,7 +87,7 @@ public class ProblemSetProblemResource {
         checkArgument(aliases.size() == data.size(), "Problem aliases must be unique");
         checkArgument(slugs.size() == data.size(), "Problem slugs must be unique");
 
-        Map<String, String> slugToJidMap = sandalphonClient.translateAllowedProblemSlugsToJids(actorJid, slugs);
+        Map<String, String> slugToJidMap = problemService.translateAllowedProblemSlugsToJids(actorJid, slugs);
 
         Set<String> contestSlugs = data.stream()
                 .map(ProblemSetProblemData::getContestSlugs)
@@ -119,7 +119,7 @@ public class ProblemSetProblemResource {
                 .collect(Collectors.toList());
 
         Map<String, Boolean> problemVisibilitiesMap = problemStore.setProblems(problemSetJid, setData);
-        sandalphonClient.setProblemVisibilityTagsByJids(problemVisibilitiesMap);
+        problemService.setProblemVisibilityTagsByJids(problemVisibilitiesMap);
     }
 
     @GET
@@ -142,8 +142,8 @@ public class ProblemSetProblemResource {
 
         return new ProblemSetProblemsResponse.Builder()
                 .data(problems)
-                .problemsMap(sandalphonClient.getProblems(problemJids))
-                .problemMetadatasMap(sandalphonClient.getProblemMetadatas(problemJids))
+                .problemsMap(problemService.getProblems(problemJids))
+                .problemMetadatasMap(problemService.getProblemMetadatas(problemJids))
                 .problemDifficultiesMap(difficultyStore.getProblemDifficultiesMap(problemJids))
                 .problemProgressesMap(statsStore.getProblemProgressesMap(actorJid, problemJids))
                 .contestsMap(roleChecker.isAdmin(actorJid)
@@ -184,7 +184,7 @@ public class ProblemSetProblemResource {
 
         ProblemSetProblem problem = checkFound(problemStore.getProblemByAlias(problemSetJid, problemAlias));
         String problemJid = problem.getProblemJid();
-        ProblemInfo problemInfo = sandalphonClient.getProblem(problemJid);
+        ProblemInfo problemInfo = problemService.getProblem(problemJid);
 
         Optional<String> reasonNotAllowedToSubmit = authHeader.isPresent()
                 ? Optional.empty()
@@ -196,7 +196,7 @@ public class ProblemSetProblemResource {
                     .languages(problemInfo.getTitlesByLanguage().keySet())
                     .problem(problem)
                     .worksheet(new judgels.api.problem.programming.ProblemWorksheet.Builder()
-                            .from(sandalphonClient.getProgrammingProblemWorksheet(req, uriInfo, problemJid, language))
+                            .from(problemService.getProgrammingProblemWorksheet(req, uriInfo, problemJid, language))
                             .reasonNotAllowedToSubmit(reasonNotAllowedToSubmit)
                             .build())
                     .build();
@@ -206,7 +206,7 @@ public class ProblemSetProblemResource {
                     .languages(problemInfo.getTitlesByLanguage().keySet())
                     .problem(problem)
                     .worksheet(new judgels.api.problem.bundle.ProblemWorksheet.Builder()
-                            .from(sandalphonClient.getBundleProblemWorksheetWithoutAnswerKey(req, uriInfo, problemJid, language))
+                            .from(problemService.getBundleProblemWorksheetWithoutAnswerKey(req, uriInfo, problemJid, language))
                             .reasonNotAllowedToSubmit(reasonNotAllowedToSubmit)
                             .build())
                     .build();
@@ -229,7 +229,7 @@ public class ProblemSetProblemResource {
         String problemJid = problem.getProblemJid();
         Set<String> problemJids = ImmutableSet.of(problemJid);
 
-        ProblemMetadata metadata = sandalphonClient.getProblemMetadata(problem.getProblemJid());
+        ProblemMetadata metadata = problemService.getProblemMetadata(problem.getProblemJid());
         ProblemDifficulty difficulty = difficultyStore.getProblemDifficultiesMap(problemJids).get(problemJid);
         ProblemTopStats topStats = statsStore.getProblemTopStats(problemJid);
         ProblemProgress progress = statsStore.getProblemProgressesMap(actorJid, problemJids).get(problemJid);
@@ -271,7 +271,7 @@ public class ProblemSetProblemResource {
         checkFound(problemSetStore.getProblemSetByJid(problemSetJid));
 
         ProblemSetProblem problem = checkFound(problemStore.getProblemByAlias(problemSetJid, problemAlias));
-        ProblemEditorialInfo editorial = checkFound(sandalphonClient.getProblemEditorial(req, uriInfo, problem.getProblemJid(), language));
+        ProblemEditorialInfo editorial = checkFound(problemService.getProblemEditorial(req, uriInfo, problem.getProblemJid(), language));
         return new ProblemEditorialResponse.Builder()
                 .editorial(editorial)
                 .build();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/sandalphon/SandalphonUtils.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/sandalphon/SandalphonUtils.java
@@ -1,11 +1,29 @@
 package judgels.sandalphon;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.UriInfo;
 import java.util.Optional;
 import judgels.api.lesson.LessonInfo;
 import judgels.api.problem.ProblemInfo;
 
 public class SandalphonUtils {
     private SandalphonUtils() {}
+
+    public static String getApiUrl(HttpServletRequest req, UriInfo uriInfo) {
+        if (req == null) {
+            return "";
+        }
+
+        String oldScheme = uriInfo.getBaseUri().getScheme();
+        String newScheme = oldScheme;
+
+        String forwardedProto = req.getHeader("X-Forwarded-Proto");
+        if (forwardedProto != null && !forwardedProto.isEmpty()) {
+            newScheme = forwardedProto;
+        }
+
+        return newScheme + uriInfo.getBaseUri().toString().substring(oldScheme.length());
+    }
 
     public static String getProblemName(ProblemInfo problem, Optional<String> language) {
         String finalLanguage = problem.getDefaultLanguage();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/bundle/ContestItemSubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/bundle/ContestItemSubmissionModule.java
@@ -4,7 +4,7 @@ import dagger.Module;
 import dagger.Provides;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import jakarta.inject.Singleton;
-import judgels.sandalphon.SandalphonClient;
+import judgels.problem.ProblemService;
 
 @Module
 public class ContestItemSubmissionModule {
@@ -16,19 +16,19 @@ public class ContestItemSubmissionModule {
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             ItemSubmissionGraderRegistry itemSubmissionGraderRegistry,
             ItemSubmissionStore itemSubmissionStore,
-            SandalphonClient sandalphonClient) {
+            ProblemService problemService) {
 
         return unitOfWorkAwareProxyFactory.create(
                 ItemSubmissionRegradeProcessor.class,
                 new Class<?>[] {
                         ItemSubmissionGraderRegistry.class,
                         ItemSubmissionStore.class,
-                        SandalphonClient.class
+                        ProblemService.class
                 },
                 new Object[] {
                         itemSubmissionGraderRegistry,
                         itemSubmissionStore,
-                        sandalphonClient
+                        problemService
                 }
         );
     }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/bundle/ItemSubmissionRegradeProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/bundle/ItemSubmissionRegradeProcessor.java
@@ -7,28 +7,28 @@ import java.util.Optional;
 import judgels.api.problem.bundle.Item;
 import judgels.api.submission.bundle.Grading;
 import judgels.api.submission.bundle.ItemSubmission;
-import judgels.sandalphon.SandalphonClient;
+import judgels.problem.ProblemService;
 
 public class ItemSubmissionRegradeProcessor {
     private final ItemSubmissionGraderRegistry itemSubmissionGraderRegistry;
     private final ItemSubmissionStore itemSubmissionStore;
-    private final SandalphonClient sandalphonClient;
+    private final ProblemService problemService;
 
     @Inject
     public ItemSubmissionRegradeProcessor(
             ItemSubmissionGraderRegistry itemSubmissionGraderRegistry,
             ItemSubmissionStore itemSubmissionStore,
-            SandalphonClient sandalphonClient) {
+            ProblemService problemService) {
 
         this.itemSubmissionGraderRegistry = itemSubmissionGraderRegistry;
         this.itemSubmissionStore = itemSubmissionStore;
-        this.sandalphonClient = sandalphonClient;
+        this.problemService = problemService;
     }
 
     @UnitOfWork
     public void process(List<ItemSubmission> submissions) {
         for (ItemSubmission submission : submissions) {
-            Optional<Item> item = sandalphonClient.getItem(submission.getProblemJid(), submission.getItemJid());
+            Optional<Item> item = problemService.getItem(submission.getProblemJid(), submission.getItemJid());
             if (item.isPresent()) {
                 Grading grading = itemSubmissionGraderRegistry
                         .get(item.get().getType())

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/bundle/ItemSubmissionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/bundle/ItemSubmissionResource.java
@@ -40,9 +40,9 @@ import judgels.api.submission.bundle.TrainingItemSubmissionsResponse;
 import judgels.api.submission.bundle.TrainingSubmissionSummaryResponse;
 import judgels.chapter.problem.ChapterProblemStore;
 import judgels.persistence.api.Page;
+import judgels.problem.ProblemService;
 import judgels.problemset.problem.ProblemSetProblemStore;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonClient;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.submission.SubmissionRoleChecker;
@@ -60,7 +60,7 @@ public class ItemSubmissionResource {
     @Inject protected ItemSubmissionRegrader itemSubmissionRegrader;
     @Inject protected ProfileStore profileStore;
     @Inject protected UserStore userStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
     @Inject protected ItemSubmissionConsumer itemSubmissionConsumer;
 
     @Inject protected ProblemSetProblemStore problemSetProblemStore;
@@ -104,7 +104,7 @@ public class ItemSubmissionResource {
         Map<String, String> problemAliasesMap = getProblemAliasesMap(containerJid, problemJids);
 
         var itemJids = Lists.transform(submissions.getPage(), ItemSubmission::getItemJid);
-        Map<String, BundleItem> itemsMap = sandalphonClient.getItems(problemJids, itemJids);
+        Map<String, BundleItem> itemsMap = problemService.getItems(problemJids, itemJids);
         Map<String, Integer> itemNumbersMap = itemsMap.entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
@@ -133,7 +133,7 @@ public class ItemSubmissionResource {
 
         String actorJid = actorChecker.check(authHeader);
 
-        Item item = checkFound(sandalphonClient.getItem(data.getProblemJid(), data.getItemJid()));
+        Item item = checkFound(problemService.getItem(data.getProblemJid(), data.getItemJid()));
 
         if (data.getAnswer().trim().isEmpty()) {
             submissionStore.deleteSubmission(
@@ -157,7 +157,7 @@ public class ItemSubmissionResource {
                     actorJid);
 
             Map<String, Optional<Grading>> itemGradingsMap = new HashMap<>();
-            for (BundleItem bundleItem : sandalphonClient.getItems(data.getProblemJid())) {
+            for (BundleItem bundleItem : problemService.getItems(data.getProblemJid())) {
                 if (bundleItem.getNumber().isPresent()) {
                     itemGradingsMap.put(bundleItem.getJid(), Optional.empty());
                 }
@@ -246,14 +246,14 @@ public class ItemSubmissionResource {
         Map<String, ItemType> itemTypesByItemJid = new HashMap<>();
 
         for (String pJid : problemJids) {
-            List<BundleItem> items = sandalphonClient.getItems(pJid).stream()
+            List<BundleItem> items = problemService.getItems(pJid).stream()
                     .filter(item -> item.getNumber().isPresent())
                     .collect(Collectors.toList());
             items.stream().forEach(item -> itemTypesByItemJid.put(item.getJid(), item.getType()));
             itemJidsByProblemJid.put(pJid, items.stream().map(BundleItem::getJid).collect(Collectors.toList()));
         }
 
-        Map<String, String> problemNamesMap = sandalphonClient.getProblemNames(ImmutableSet.copyOf(problemJids), language);
+        Map<String, String> problemNamesMap = problemService.getProblemNames(ImmutableSet.copyOf(problemJids), language);
         Profile profile = profileStore.getProfile(userJid);
 
         SubmissionConfig config = new SubmissionConfig.Builder()

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/bundle/TrainingItemSubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/bundle/TrainingItemSubmissionModule.java
@@ -5,7 +5,7 @@ import dagger.Provides;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import jakarta.inject.Singleton;
 import judgels.jerahmeel.persistence.BundleItemSubmissionDao;
-import judgels.sandalphon.SandalphonClient;
+import judgels.problem.ProblemService;
 import judgels.stats.StatsConfiguration;
 
 @Module
@@ -34,19 +34,19 @@ public class TrainingItemSubmissionModule {
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             ItemSubmissionGraderRegistry itemSubmissionGraderRegistry,
             ItemSubmissionStore itemSubmissionStore,
-            SandalphonClient sandalphonClient) {
+            ProblemService problemService) {
 
         return unitOfWorkAwareProxyFactory.create(
                 ItemSubmissionRegradeProcessor.class,
                 new Class<?>[] {
                         ItemSubmissionGraderRegistry.class,
                         ItemSubmissionStore.class,
-                        SandalphonClient.class
+                        ProblemService.class
                 },
                 new Object[] {
                         itemSubmissionGraderRegistry,
                         itemSubmissionStore,
-                        sandalphonClient
+                        problemService
                 }
         );
     }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/programming/SubmissionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/programming/SubmissionResource.java
@@ -46,10 +46,10 @@ import judgels.chapter.problem.ChapterProblemStore;
 import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.SubmissionSource;
 import judgels.persistence.api.CursorPage;
+import judgels.problem.ProblemService;
 import judgels.problemset.ProblemSetStore;
 import judgels.problemset.problem.ProblemSetProblemStore;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonClient;
 import judgels.sandalphon.SandalphonUtils;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
@@ -71,7 +71,7 @@ public class SubmissionResource {
     @Inject protected SubmissionRoleChecker submissionRoleChecker;
     @Inject protected ProfileStore profileStore;
     @Inject protected UserStore userStore;
-    @Inject protected SandalphonClient sandalphonClient;
+    @Inject protected ProblemService problemService;
 
     @Inject protected ProblemSetStore problemSetStore;
     @Inject protected ProblemSetProblemStore problemSetProblemStore;
@@ -129,7 +129,7 @@ public class SubmissionResource {
 
         Map<String, String> problemNamesMap = new HashMap<>();
         if (!containerJid.isPresent()) {
-            problemNamesMap = sandalphonClient.getProblemNames(problemJids, Optional.empty());
+            problemNamesMap = problemService.getProblemNames(problemJids, Optional.empty());
         }
 
         Map<String, String> containerNamesMap = new HashMap<>();
@@ -200,7 +200,7 @@ public class SubmissionResource {
             reasonNotAllowedToViewSource = submissionRoleChecker.canViewChapterSource(actorJid, userJid, problemJid);
         }
 
-        ProblemInfo problem = sandalphonClient.getProblem(submission.getProblemJid());
+        ProblemInfo problem = problemService.getProblem(submission.getProblemJid());
 
         Profile profile = checkFound(Optional.ofNullable(profileStore.getProfile(userJid)));
 
@@ -265,7 +265,7 @@ public class SubmissionResource {
                 .gradingLanguage(gradingLanguage)
                 .build();
         SubmissionSource source = submissionSourceBuilder.fromNewSubmission(parts);
-        ProblemSubmissionConfig config = sandalphonClient.getProgrammingProblemSubmissionConfig(data.getProblemJid());
+        ProblemSubmissionConfig config = problemService.getProgrammingProblemSubmissionConfig(data.getProblemJid());
         GradingOptions options = new GradingOptions.Builder().shouldRevealEvaluation(true).build();
         Submission submission = submissionClient.submit(data, source, config, options);
 
@@ -285,7 +285,7 @@ public class SubmissionResource {
         Submission submission = checkFound(submissionStore.getSubmissionByJid(submissionJid));
         checkAllowed(submissionRoleChecker.canManage(actorJid));
 
-        ProblemSubmissionConfig config = sandalphonClient.getProgrammingProblemSubmissionConfig(submission.getProblemJid());
+        ProblemSubmissionConfig config = problemService.getProgrammingProblemSubmissionConfig(submission.getProblemJid());
         submissionRegrader.regradeSubmission(submission, config);
     }
 
@@ -317,7 +317,7 @@ public class SubmissionResource {
             }
 
             var problemJids = Lists.transform(submissions, Submission::getProblemJid);
-            configsMap.putAll(sandalphonClient.getProgrammingProblemSubmissionConfigs(
+            configsMap.putAll(problemService.getProgrammingProblemSubmissionConfigs(
                     Sets.difference(Set.copyOf(problemJids), configsMap.keySet())));
 
             submissionRegrader.regradeSubmissions(submissions, configsMap);

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/programming/SubmissionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/programming/SubmissionResource.java
@@ -47,10 +47,10 @@ import judgels.gabriel.api.GradingOptions;
 import judgels.gabriel.api.SubmissionSource;
 import judgels.persistence.api.CursorPage;
 import judgels.problem.ProblemService;
+import judgels.problem.ProblemUtils;
 import judgels.problemset.ProblemSetStore;
 import judgels.problemset.problem.ProblemSetProblemStore;
 import judgels.profile.ProfileStore;
-import judgels.sandalphon.SandalphonUtils;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.submission.JerahmeelSubmissionStore;
@@ -220,7 +220,7 @@ public class SubmissionResource {
                 .data(submissionWithSource)
                 .profile(profile)
                 .problemAlias(problemAlias)
-                .problemName(SandalphonUtils.getProblemName(problem, language))
+                .problemName(ProblemUtils.getProblemName(problem, language))
                 .containerPath(containerPath)
                 .containerName(containerName)
                 .build();


### PR DESCRIPTION
## Context

Final step of the archangel-flattening series (after #903 and #905). `SandalphonClient` was the last archangel-named in-process facade, and `SandalphonUtils` the last archangel-named helper. Unlike the thin `JophielClient`/`UrielClient` (deleted in #905), `SandalphonClient` carries real shared aggregation logic over ~8 stores, so it can't be dissolved into direct store injections — **but it cleanly bisects by domain and no consumer used both sides**, so it's split instead. `SandalphonUtils` splits the same way.

This PR has two commits:

### 1. Split `SandalphonClient` → `ProblemService` + `LessonService`

- **New `judgels.problem.ProblemService`** — all problem-domain methods moved verbatim (slug translation, `getProblem(s)`/`getProblemMetadata(s)`/`getProblemNames`, items, programming submission/scoring configs, programming/bundle worksheets, editorials, skeletons + the two statement/editorial language sanitizers).
- **New `judgels.lesson.LessonService`** — the four lesson methods (`translateAllowedLessonSlugsToJids`, `getLesson`, `getLessons`, `getLessonStatement`) + the lesson statement language sanitizer.
- **Delete `SandalphonClient`.**

Consumers rewired with **zero behavior change**: 10 problem-only field-injected resources, `ContestScoreboardUpdater` + `ItemSubmissionRegradeProcessor` (constructor-wired) and their 3 Dagger factory modules, and the single lesson-only consumer (`ChapterLessonResource` → `LessonService`). The split services `@Inject` the same stores `SandalphonClient` used, all already in every relevant Dagger component graph, so **no component/module graph changes**.

### 2. Split `SandalphonUtils` → `ProblemUtils` + `LessonUtils`

- **New `judgels.problem.ProblemUtils`** — `getProblemName`, `replaceProblemRenderUrls`, `replaceProblemEditorialRenderUrls`, `getApiUrl`.
- **New `judgels.lesson.LessonUtils`** — `replaceLessonRenderUrls`, `getApiUrl`.
- `getApiUrl` is duplicated as `public static` into both (its only callers are `ProblemService`/`LessonService`; avoids re-introducing a shared cross-domain util).
- **Dropped `getLessonName`** — it had zero callers (dead archangel code).
- **Delete `SandalphonUtils`.**

Consumers repointed with zero behavior change: `ProblemService`, `LessonService`, `ContestSubmissionResource`, `SubmissionResource`, and the four bundle item processors (Essay/MultipleChoice/ShortAnswer/Statement).

## Out of scope (later pass, if ever)

`SandalphonClientModule`, `SandalphonComponent`, `SandalphonConfiguration`, and the `Git`/`LocalGit`/`GitCommit` infrastructure remaining in `judgels.sandalphon` — lower-value, higher-risk archangel artifacts.

## Verification

- ✅ `:judgels-server-app:compileJava` (incl. Dagger) — passes
- ✅ `:judgels-server-app:checkstyleMain` — passes (strict single-group import ordering preserved; same-package imports skipped to satisfy `RedundantImport`)
- ✅ `:judgels-server-app:test` (unit) — passes
- ⚠️ `:judgels-server-app:integTest` — 120 tests, 6 failed: the same pre-existing `ContestSubmission*` failures confirmed unrelated/pre-existing on master in #905. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)