### PR TITLE
Refactor: rename archangel SubmissionStore qualifiers to domain names

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/chapter/problem/ChapterProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/chapter/problem/ChapterProblemResource.java
@@ -44,7 +44,7 @@ import judgels.role.TrainingAdminRoleChecker;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.stats.StatsStore;
-import judgels.submission.JerahmeelSubmissionStore;
+import judgels.submission.TrainingSubmissionStore;
 import judgels.submission.programming.SubmissionSourceBuilder;
 import judgels.submission.programming.SubmissionStore;
 
@@ -57,7 +57,7 @@ public class ChapterProblemResource {
     @Inject protected ChapterProblemStore chapterProblemStore;
     @Inject protected ProblemSetProblemStore problemSetProblemStore;
     @Inject protected StatsStore statsStore;
-    @Inject @JerahmeelSubmissionStore protected SubmissionStore submissionStore;
+    @Inject @TrainingSubmissionStore protected SubmissionStore submissionStore;
     @Inject protected SubmissionSourceBuilder submissionSourceBuilder;
     @Inject protected ProblemService problemService;
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/ContestSubmissionStore.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/ContestSubmissionStore.java
@@ -7,4 +7,4 @@ import java.lang.annotation.Retention;
 
 @Qualifier
 @Retention(RUNTIME)
-public @interface JerahmeelSubmissionStore {}
+public @interface ContestSubmissionStore {}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/TrainingSubmissionStore.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/TrainingSubmissionStore.java
@@ -7,4 +7,4 @@ import java.lang.annotation.Retention;
 
 @Qualifier
 @Retention(RUNTIME)
-public @interface UrielSubmissionStore {}
+public @interface TrainingSubmissionStore {}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/programming/SubmissionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/programming/SubmissionResource.java
@@ -53,9 +53,9 @@ import judgels.problemset.problem.ProblemSetProblemStore;
 import judgels.profile.ProfileStore;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
-import judgels.submission.JerahmeelSubmissionStore;
 import judgels.submission.SubmissionRoleChecker;
 import judgels.submission.SubmissionUtils;
+import judgels.submission.TrainingSubmissionStore;
 import judgels.user.UserStore;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 
@@ -64,7 +64,7 @@ public class SubmissionResource {
     private static final int PAGE_SIZE = 20;
 
     @Inject protected ActorChecker actorChecker;
-    @Inject @JerahmeelSubmissionStore protected SubmissionStore submissionStore;
+    @Inject @TrainingSubmissionStore protected SubmissionStore submissionStore;
     @Inject protected SubmissionSourceBuilder submissionSourceBuilder;
     @Inject protected SubmissionClient submissionClient;
     @Inject protected SubmissionRegrader submissionRegrader;

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/programming/TrainingSubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/programming/TrainingSubmissionModule.java
@@ -21,8 +21,8 @@ import judgels.persistence.TrainingProgrammingSubmissionDao;
 import judgels.service.JudgelsBaseDataDir;
 import judgels.service.JudgelsScheduler;
 import judgels.stats.StatsConfiguration;
-import judgels.submission.JerahmeelSubmissionStore;
-import judgels.submission.UrielSubmissionStore;
+import judgels.submission.ContestSubmissionStore;
+import judgels.submission.TrainingSubmissionStore;
 import org.hibernate.SessionFactory;
 
 @Module
@@ -49,8 +49,8 @@ public class TrainingSubmissionModule {
 
     @Provides
     @Singleton
-    @JerahmeelSubmissionStore
-    static SubmissionStore jerahmeelSubmissionStore(
+    @TrainingSubmissionStore
+    static SubmissionStore trainingSubmissionStore(
             TrainingProgrammingSubmissionDao submissionDao,
             TrainingProgrammingGradingDao gradingDao,
             ObjectMapper mapper) {
@@ -60,8 +60,8 @@ public class TrainingSubmissionModule {
 
     @Provides
     @Singleton
-    @UrielSubmissionStore
-    static SubmissionStore urielSubmissionStore(
+    @ContestSubmissionStore
+    static SubmissionStore contestSubmissionStore(
             ContestProgrammingSubmissionDao submissionDao,
             ContestProgrammingGradingDao gradingDao,
             ObjectMapper mapper) {
@@ -79,7 +79,7 @@ public class TrainingSubmissionModule {
     @Singleton
     static SubmissionClient submissionClient(
             SessionFactory sessionFactory,
-            @JerahmeelSubmissionStore SubmissionStore submissionStore,
+            @TrainingSubmissionStore SubmissionStore submissionStore,
             @Named("gradingRequestQueueName") String gradingRequestQueueName,
             @Named("gradingResponseQueueName") String gradingResponseQueueName,
             MessageClient messageClient,
@@ -98,7 +98,7 @@ public class TrainingSubmissionModule {
     @Singleton
     static SubmissionRegrader submissionRegrader(
             JudgelsScheduler scheduler,
-            @JerahmeelSubmissionStore SubmissionStore submissionStore,
+            @TrainingSubmissionStore SubmissionStore submissionStore,
             SubmissionRegradeProcessor processor) {
 
         ExecutorService executorService = scheduler.createExecutorService("jerahmeel-submission-regrade-processor-%d", 5);
@@ -126,7 +126,7 @@ public class TrainingSubmissionModule {
     GradingResponseProcessor gradingResponseProcessor(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             ObjectMapper mapper,
-            @JerahmeelSubmissionStore SubmissionStore submissionStore,
+            @TrainingSubmissionStore SubmissionStore submissionStore,
             StatsProcessor statsProcessor) {
 
         return unitOfWorkAwareProxyFactory.create(

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/tasks/JerahmeelTaskModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/tasks/JerahmeelTaskModule.java
@@ -4,8 +4,8 @@ import dagger.Module;
 import dagger.Provides;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import jakarta.inject.Singleton;
-import judgels.submission.JerahmeelSubmissionStore;
-import judgels.submission.UrielSubmissionStore;
+import judgels.submission.ContestSubmissionStore;
+import judgels.submission.TrainingSubmissionStore;
 import judgels.submission.programming.StatsProcessor;
 import judgels.submission.programming.SubmissionStore;
 
@@ -17,7 +17,7 @@ public class JerahmeelTaskModule {
     @Singleton
     static RefreshContestStatsTask refreshContestStatsTask(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
-            @UrielSubmissionStore SubmissionStore submissionStore,
+            @ContestSubmissionStore SubmissionStore submissionStore,
             StatsProcessor statsProcessor) {
 
         return unitOfWorkAwareProxyFactory.create(
@@ -34,7 +34,7 @@ public class JerahmeelTaskModule {
     @Singleton
     static RefreshProblemSetStatsTask refreshProblemSetStatsTask(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
-            @JerahmeelSubmissionStore SubmissionStore submissionStore,
+            @TrainingSubmissionStore SubmissionStore submissionStore,
             StatsProcessor statsProcessor) {
 
         return unitOfWorkAwareProxyFactory.create(

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/tasks/RefreshContestStatsTask.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/tasks/RefreshContestStatsTask.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import judgels.api.submission.programming.Submission;
 import judgels.persistence.api.Page;
-import judgels.submission.UrielSubmissionStore;
+import judgels.submission.ContestSubmissionStore;
 import judgels.submission.programming.StatsProcessor;
 import judgels.submission.programming.SubmissionStore;
 
@@ -20,7 +20,7 @@ public class RefreshContestStatsTask extends Task {
     private final StatsProcessor statsProcessor;
 
     public RefreshContestStatsTask(
-            @UrielSubmissionStore SubmissionStore submissionStore,
+            @ContestSubmissionStore SubmissionStore submissionStore,
             StatsProcessor statsProcessor) {
 
         super("jerahmeel-refresh-contest-stats");

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/tasks/RefreshProblemSetStatsTask.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/tasks/RefreshProblemSetStatsTask.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import judgels.api.submission.programming.Submission;
 import judgels.persistence.api.Page;
-import judgels.submission.JerahmeelSubmissionStore;
+import judgels.submission.TrainingSubmissionStore;
 import judgels.submission.programming.StatsProcessor;
 import judgels.submission.programming.SubmissionStore;
 
@@ -20,7 +20,7 @@ public class RefreshProblemSetStatsTask extends Task {
     private final StatsProcessor statsProcessor;
 
     public RefreshProblemSetStatsTask(
-            @JerahmeelSubmissionStore SubmissionStore submissionStore,
+            @TrainingSubmissionStore SubmissionStore submissionStore,
             StatsProcessor statsProcessor) {
 
         super("jerahmeel-refresh-problem-set-stats");


### PR DESCRIPTION
## Context

`@JerahmeelSubmissionStore` and `@UrielSubmissionStore` (in `judgels.submission`) are Dagger `@Qualifier` annotations that disambiguate the multiple `SubmissionStore` bindings coexisting in one graph:

| Qualifier | Backing DAOs | Domain |
|---|---|---|
| `@JerahmeelSubmissionStore` | `TrainingProgrammingSubmissionDao` + `TrainingProgrammingGradingDao` | training / archive |
| `@UrielSubmissionStore` | `ContestProgrammingSubmissionDao` + `ContestProgrammingGradingDao` | contest |

They are genuinely needed (`JerahmeelComponent` holds both, for `RefreshProblemSetStatsTask` / `RefreshContestStatsTask`) — only the names were the last archangel leftovers, and inconsistent with the now `Training*`/`Contest*`-named DAOs and the already-de-archangeled sibling `@TrainingSubmissionFs`.

## Changes

- `@JerahmeelSubmissionStore` → `@TrainingSubmissionStore` (provider `jerahmeelSubmissionStore` → `trainingSubmissionStore`)
- `@UrielSubmissionStore` → `@ContestSubmissionStore` (provider `urielSubmissionStore` → `contestSubmissionStore`)

Pure rename across 8 files (qualifier defs + `TrainingSubmissionModule`, `JerahmeelTaskModule`, `RefreshContestStatsTask`, `RefreshProblemSetStatsTask`, `ChapterProblemResource`, `SubmissionResource`). Dagger keys bindings on qualifier+type, so the DI graph is validated at compile — no behavior change.

## Verification

- ✅ `:judgels-server-app:compileJava` (incl. Dagger annotation processing)
- ✅ `:judgels-server-app:checkstyleMain`
- ✅ `:judgels-server-app:compileIntegTestJava`
- ✅ `:judgels-server-app:test` (unit) — passes
- ⚠️ `:judgels-server-app:integTest` — 120 tests, 6 failed: the same pre-existing `ContestSubmission*` failures confirmed unrelated/pre-existing on master in #905. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)