### PR TITLE
Refactor: Remove gabriel from judgels-grader-app's own code

### DIFF
--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderApplication.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderApplication.java
@@ -2,11 +2,8 @@ package judgels;
 
 import io.dropwizard.core.Application;
 import io.dropwizard.core.setup.Environment;
-import judgels.gabriel.DaggerGabrielComponent;
-import judgels.gabriel.GabrielComponent;
-import judgels.gabriel.JudgelsGraderModule;
-import judgels.gabriel.grading.GradingModule;
 import judgels.grading.CacheModule;
+import judgels.grading.GradingModule;
 import judgels.isolate.IsolateModule;
 import judgels.messaging.rabbitmq.RabbitMQModule;
 
@@ -17,13 +14,13 @@ public class JudgelsGraderApplication extends Application<JudgelsGraderApplicati
 
     @Override
     public void run(JudgelsGraderApplicationConfiguration config, Environment env) throws Exception {
-        runGabriel(config, env);
+        runGrader(config, env);
     }
 
-    private void runGabriel(JudgelsGraderApplicationConfiguration config, Environment env) {
+    private void runGrader(JudgelsGraderApplicationConfiguration config, Environment env) {
         JudgelsGraderConfiguration judgelsConfig = config.getJudgelsConfig();
 
-        GabrielComponent component = DaggerGabrielComponent.builder()
+        JudgelsGraderComponent component = DaggerJudgelsGraderComponent.builder()
                 .judgelsGraderModule(new JudgelsGraderModule(judgelsConfig))
                 .rabbitMQModule(new RabbitMQModule(judgelsConfig.getRabbitMQConfig()))
                 .isolateModule(new IsolateModule(judgelsConfig.getIsolateConfig()))

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderComponent.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderComponent.java
@@ -1,10 +1,10 @@
-package judgels.gabriel;
+package judgels;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
-import judgels.gabriel.grading.GradingModule;
-import judgels.gabriel.grading.GradingRequestPoller;
 import judgels.grading.CacheModule;
+import judgels.grading.GradingModule;
+import judgels.grading.GradingRequestPoller;
 import judgels.isolate.IsolateModule;
 import judgels.messaging.rabbitmq.RabbitMQModule;
 import judgels.service.JudgelsModule;
@@ -22,6 +22,6 @@ import judgels.service.JudgelsModule;
         GradingModule.class,
         CacheModule.class})
 @Singleton
-public interface GabrielComponent {
+public interface JudgelsGraderComponent {
     GradingRequestPoller gradingRequestPoller();
 }

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderModule.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderModule.java
@@ -1,11 +1,10 @@
-package judgels.gabriel;
+package judgels;
 
 import dagger.Module;
 import dagger.Provides;
 import jakarta.inject.Singleton;
 import java.nio.file.Path;
 import java.time.Clock;
-import judgels.JudgelsGraderConfiguration;
 import judgels.service.JudgelsBaseDataDir;
 
 @Module

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/GradingModule.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/GradingModule.java
@@ -1,4 +1,4 @@
-package judgels.gabriel.grading;
+package judgels.grading;
 
 import dagger.Module;
 import dagger.Provides;
@@ -9,7 +9,6 @@ import jakarta.inject.Singleton;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
-import judgels.grading.JudgelsGraderGradingConfiguration;
 import judgels.messaging.MessageListener;
 import judgels.service.JudgelsBaseDataDir;
 

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/GradingRequestPoller.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/GradingRequestPoller.java
@@ -1,4 +1,4 @@
-package judgels.gabriel.grading;
+package judgels.grading;
 
 import io.dropwizard.lifecycle.Managed;
 import jakarta.inject.Provider;

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/GradingWorker.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/GradingWorker.java
@@ -1,4 +1,4 @@
-package judgels.gabriel.grading;
+package judgels.grading;
 
 import static java.util.stream.Collectors.toMap;
 
@@ -33,8 +33,6 @@ import judgels.gabriel.engines.GradingEngineRegistry;
 import judgels.gabriel.languages.GradingLanguageRegistry;
 import judgels.gabriel.sandboxes.fake.FakeSandboxFactory;
 import judgels.gabriel.sandboxes.isolate.IsolateSandboxFactory;
-import judgels.grading.JudgelsGraderGradingConfiguration;
-import judgels.grading.ProblemCache;
 import judgels.messaging.MessageClient;
 import judgels.messaging.api.Message;
 import org.slf4j.Logger;


### PR DESCRIPTION
## Summary

Follow-up to #912. Removes `gabriel` from the code `judgels-grader-app` itself defines, so the app no longer ships its own `judgels.gabriel*` packages or a `GabrielComponent`.

- `GabrielComponent` → `judgels.JudgelsGraderComponent` (Dagger now generates `DaggerJudgelsGraderComponent`)
- `judgels.gabriel.JudgelsGraderModule` → `judgels.JudgelsGraderModule`
- `judgels.gabriel.grading.{GradingModule,GradingRequestPoller,GradingWorker}` → `judgels.grading.*` (consolidated with the existing `judgels.grading` package)
- `JudgelsGraderApplication` rewired; private `runGabriel` → `runGrader`
- Empty `judgels/gabriel/` source dir removed

## Out of scope (intentional)

The Gabriel **engine library** — `judgels.gabriel.api/engines/languages/sandboxes`, defined in `judgels-grader-api`/`judgels-grader-engines` and consumed identically by `judgels-server-app` (incl. DB-persisted grading-config classes) — is **not** renamed. `GradingWorker`/`IsolateModule` still import it; that's the engine's identity, a separate massive cross-module change. The `gabriel-grading-request` queue name and `gabriel_grading_numWorkerThreads` ansible var are also left as-is (deploy-coupled).

## Verification

- `./gradlew :judgels-grader-app:compileJava :judgels-grader-app:checkstyleMain :judgels-server-app:compileJava` → BUILD SUCCESSFUL (server-app unaffected, sanity-checked).
- Grep gate clean: no `judgels.gabriel.grading` / `GabrielComponent` / `DaggerGabrielComponent` / `runGabriel` anywhere in grader-app; `src/main/java/judgels/gabriel/` removed. Remaining `judgels.gabriel.{api,engines,languages,sandboxes}` imports are the engine library (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)