### PR TITLE
Refactor: Move cache classes to judgels.grading.cache package

### DIFF
--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderApplication.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderApplication.java
@@ -2,8 +2,8 @@ package judgels;
 
 import io.dropwizard.core.Application;
 import io.dropwizard.core.setup.Environment;
-import judgels.grading.CacheModule;
 import judgels.grading.GradingModule;
+import judgels.grading.cache.CacheModule;
 import judgels.isolate.IsolateModule;
 import judgels.messaging.rabbitmq.RabbitMQModule;
 

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderComponent.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/JudgelsGraderComponent.java
@@ -2,9 +2,9 @@ package judgels;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
-import judgels.grading.CacheModule;
 import judgels.grading.GradingModule;
 import judgels.grading.GradingRequestPoller;
+import judgels.grading.cache.CacheModule;
 import judgels.isolate.IsolateModule;
 import judgels.messaging.rabbitmq.RabbitMQModule;
 import judgels.service.JudgelsModule;

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/GradingWorker.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/GradingWorker.java
@@ -33,6 +33,7 @@ import judgels.gabriel.engines.GradingEngineRegistry;
 import judgels.gabriel.languages.GradingLanguageRegistry;
 import judgels.gabriel.sandboxes.fake.FakeSandboxFactory;
 import judgels.gabriel.sandboxes.isolate.IsolateSandboxFactory;
+import judgels.grading.cache.ProblemCache;
 import judgels.messaging.MessageClient;
 import judgels.messaging.api.Message;
 import org.slf4j.Logger;

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/JudgelsGraderGradingConfiguration.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/JudgelsGraderGradingConfiguration.java
@@ -2,6 +2,7 @@ package judgels.grading;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import judgels.grading.cache.CacheConfiguration;
 import org.immutables.value.Value;
 
 @Value.Immutable

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/cache/CacheConfiguration.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/cache/CacheConfiguration.java
@@ -1,4 +1,4 @@
-package judgels.grading;
+package judgels.grading.cache;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.nio.file.Path;

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/cache/CacheModule.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/cache/CacheModule.java
@@ -1,4 +1,4 @@
-package judgels.grading;
+package judgels.grading.cache;
 
 import dagger.Module;
 import dagger.Provides;

--- a/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/cache/ProblemCache.java
+++ b/judgels-backends/judgels-grader-app/src/main/java/judgels/grading/cache/ProblemCache.java
@@ -1,4 +1,4 @@
-package judgels.grading;
+package judgels.grading.cache;
 
 import static java.util.stream.Collectors.joining;
 


### PR DESCRIPTION
## Summary

Moves the three cache classes in `judgels-grader-app` from `judgels.grading` into a `judgels.grading.cache` subpackage:

- `CacheConfiguration`, `CacheModule`, `ProblemCache` → `judgels.grading.cache.*` (via `git mv`, history preserved)
- Importers updated: `JudgelsGraderComponent`, `JudgelsGraderApplication`, `JudgelsGraderGradingConfiguration`, `GradingWorker` (added imports / re-sorted for checkstyle)

## Verification

`./gradlew :judgels-grader-app:compileJava :judgels-grader-app:checkstyleMain` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)