### PR TITLE
Refactor: De-archangel tlx.* packages

### DIFF
--- a/judgels-backends/judgels-server-api/src/main/java/tlx/api/user/rating/TlxRating.java
+++ b/judgels-backends/judgels-server-api/src/main/java/tlx/api/user/rating/TlxRating.java
@@ -1,4 +1,4 @@
-package tlx.jophiel.api.user.rating;
+package tlx.api.user.rating;
 
 public class TlxRating {
     public static final int INITIAL_RATING = 1800;

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
@@ -32,7 +32,7 @@ import judgels.user.account.UserResetPasswordModule;
 import judgels.user.superadmin.SuperadminModule;
 import judgels.user.web.WebModule;
 import org.eclipse.jetty.server.session.SessionHandler;
-import tlx.uriel.contest.rating.TlxContestRatingProvider;
+import tlx.contest.rating.TlxContestRatingProvider;
 
 public class JudgelsServerApplication extends Application<JudgelsServerApplicationConfiguration> {
     private final HibernateBundle<JudgelsServerApplicationConfiguration> hibernateBundle = new JudgelsServerHibernateBundle();

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/contest/rating/TlxContestRatingProvider.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/contest/rating/TlxContestRatingProvider.java
@@ -1,4 +1,4 @@
-package tlx.uriel.contest.rating;
+package tlx.contest.rating;
 
 import java.util.HashMap;
 import java.util.List;
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 import judgels.api.user.rating.UserRating;
 import judgels.contrib.contest.rating.ContestRatingProvider;
-import tlx.jophiel.api.user.rating.TlxRating;
+import tlx.api.user.rating.TlxRating;
 
 public class TlxContestRatingProvider implements ContestRatingProvider {
     @Override

--- a/judgels-backends/judgels-server-app/src/test/java/tlx/contest/rating/TlxContestRatingProviderTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/tlx/contest/rating/TlxContestRatingProviderTests.java
@@ -1,4 +1,4 @@
-package tlx.uriel.contest.rating;
+package tlx.contest.rating;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
## Context

Continues the archangel-codename cleanup (Michael intentionally excluded). Renames the last archangel-named `tlx.*` packages to neutral domain names.

## Changes

- `tlx.jophiel.api.user.rating` → `tlx.api.user.rating` — `TlxRating` (in the `judgels-server-api` module)
- `tlx.uriel.contest.rating` → `tlx.contest.rating` — `TlxContestRatingProvider` + `TlxContestRatingProviderTests` (in `judgels-server-app`)

Empty `tlx/jophiel` and `tlx/uriel` directory trees removed.

## Approach & verification

Pure relocation — no behavior change. Files moved via `git mv` (history preserved); package declarations rewritten; the 2 import sites updated (`TlxContestRatingProvider`'s import of `TlxRating`; `JudgelsServerApplication`'s import of the provider). `TlxRating` has no external/feign/frontend consumers — only `TlxContestRatingProvider` uses it.

- ✅ `checkstyleMain` / `checkstyleTest` / `checkstyleIntegTest`
- ✅ `judgels-server-api` + `judgels-server-app` compile
- ✅ Test suite: **135 tests, 0 failures**
- ✅ `git grep` confirms no `tlx.uriel` / `tlx.jophiel` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)