### PR TITLE
Breaking: De-archangel JerahmeelConfiguration -> TrainingConfiguration

### DIFF
--- a/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
+++ b/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
@@ -129,20 +129,20 @@ jophiel:
   web:
     announcements: []
 
-jerahmeel:
-{% if jerahmeel_aws_accessKey is defined %}
+training:
+{% if training_aws_accessKey is defined %}
   aws:
-    accessKey: {{ jerahmeel_aws_accessKey }}
-    secretKey: {{ jerahmeel_aws_secretKey }}
-    s3BucketRegionId: {{ jerahmeel_aws_s3BucketRegionId }}
+    accessKey: {{ training_aws_accessKey }}
+    secretKey: {{ training_aws_secretKey }}
+    s3BucketRegionId: {{ training_aws_s3BucketRegionId }}
 {% endif %}
 
   submission:
     fs:
-      type: {{ jerahmeel_submission_fs_type | default('local', true) }}
-{% if jerahmeel_submission_fs_type | default('local', true) != 'local' %}
-      s3BucketName: {{ jerahmeel_submission_fs_s3BucketName }}
+      type: {{ training_submission_fs_type | default('local', true) }}
+{% if training_submission_fs_type | default('local', true) != 'local' %}
+      s3BucketName: {{ training_submission_fs_s3BucketName }}
 {% endif %}
 
   stats:
-    enabled: {{ jerahmeel_stats_enabled | default(false, true) }}
+    enabled: {{ training_stats_enabled | default(false, true) }}

--- a/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
+++ b/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
@@ -130,19 +130,19 @@ jophiel:
     announcements: []
 
 training:
-{% if training_aws_accessKey is defined %}
+{% if jerahmeel_aws_accessKey is defined %}
   aws:
-    accessKey: {{ training_aws_accessKey }}
-    secretKey: {{ training_aws_secretKey }}
-    s3BucketRegionId: {{ training_aws_s3BucketRegionId }}
+    accessKey: {{ jerahmeel_aws_accessKey }}
+    secretKey: {{ jerahmeel_aws_secretKey }}
+    s3BucketRegionId: {{ jerahmeel_aws_s3BucketRegionId }}
 {% endif %}
 
   submission:
     fs:
-      type: {{ training_submission_fs_type | default('local', true) }}
-{% if training_submission_fs_type | default('local', true) != 'local' %}
-      s3BucketName: {{ training_submission_fs_s3BucketName }}
+      type: {{ jerahmeel_submission_fs_type | default('local', true) }}
+{% if jerahmeel_submission_fs_type | default('local', true) != 'local' %}
+      s3BucketName: {{ jerahmeel_submission_fs_s3BucketName }}
 {% endif %}
 
   stats:
-    enabled: {{ training_stats_enabled | default(false, true) }}
+    enabled: {{ jerahmeel_stats_enabled | default(false, true) }}

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/BaseJudgelsApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/BaseJudgelsApiIntegrationTests.java
@@ -40,13 +40,13 @@ import judgels.app.BaseJudgelsAppIntegrationTests;
 import judgels.app.JudgelsAppConfiguration;
 import judgels.contrib.user.registration.UserRegistrationConfiguration;
 import judgels.grading.JudgelsServerGradingConfiguration;
-import judgels.jerahmeel.JerahmeelConfiguration;
 import judgels.jophiel.JophielConfiguration;
 import judgels.mailer.MailerConfiguration;
 import judgels.service.feign.FeignClients;
 import judgels.session.SessionClient;
 import judgels.session.SessionConfiguration;
 import judgels.stats.StatsConfiguration;
+import judgels.training.TrainingConfiguration;
 import judgels.user.UserClient;
 import judgels.user.UserRoleClient;
 import judgels.user.account.UserResetPasswordConfiguration;
@@ -123,7 +123,7 @@ public abstract class BaseJudgelsApiIntegrationTests extends BaseJudgelsAppInteg
                 .webConfig(WebConfiguration.DEFAULT)
                 .build();
 
-        JerahmeelConfiguration jerahmeelConfig = new JerahmeelConfiguration.Builder()
+        TrainingConfiguration trainingConfig = new TrainingConfiguration.Builder()
                 .statsConfig(StatsConfiguration.DEFAULT)
                 .build();
 
@@ -132,7 +132,7 @@ public abstract class BaseJudgelsApiIntegrationTests extends BaseJudgelsAppInteg
                 webSecurityConfig,
                 judgelsConfig,
                 jophielConfig,
-                jerahmeelConfig) {
+                trainingConfig) {
             {
                 DefaultServerFactory serverFactory = (DefaultServerFactory) getServerFactory();
 

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/stats/StatsIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/stats/StatsIntegrationTests.java
@@ -50,8 +50,6 @@ import judgels.grading.api.SandboxExecutionStatus;
 import judgels.grading.api.TestCaseResult;
 import judgels.grading.api.TestGroupResult;
 import judgels.grading.api.Verdict;
-import judgels.jerahmeel.BaseJerahmeelIntegrationTests;
-import judgels.jerahmeel.JerahmeelIntegrationTestComponent;
 import judgels.persistence.ArchiveModel;
 import judgels.persistence.ChapterModel;
 import judgels.persistence.ChapterProblemModel;
@@ -65,6 +63,8 @@ import judgels.persistence.StatsUserProblemModel;
 import judgels.persistence.hibernate.WithHibernateSession;
 import judgels.problemset.ProblemSetStore;
 import judgels.problemset.problem.ProblemSetProblemStore;
+import judgels.training.BaseTrainingIntegrationTests;
+import judgels.training.TrainingIntegrationTestComponent;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,7 +80,7 @@ import org.junit.jupiter.api.Test;
         ProblemContestModel.class,
         StatsUserModel.class,
         StatsUserProblemModel.class})
-class StatsIntegrationTests extends BaseJerahmeelIntegrationTests {
+class StatsIntegrationTests extends BaseTrainingIntegrationTests {
     private static final String USER_JID_1 = "JIDUSER-1";
     private static final String USER_JID_2 = "JIDUSER-2";
     private static final String PROBLEM_JID_1 = "JIDPROG-1";
@@ -103,7 +103,7 @@ class StatsIntegrationTests extends BaseJerahmeelIntegrationTests {
 
     @BeforeEach
     void setUpSession(SessionFactory sessionFactory) {
-        JerahmeelIntegrationTestComponent component = createComponent(sessionFactory);
+        TrainingIntegrationTestComponent component = createComponent(sessionFactory);
 
         courseStore = component.courseStore();
         courseChapterStore = component.courseChapterStore();

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/training/BaseTrainingIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/training/BaseTrainingIntegrationTests.java
@@ -1,4 +1,4 @@
-package judgels.jerahmeel;
+package judgels.training;
 
 import java.time.Clock;
 import judgels.persistence.TestActorProvider;
@@ -6,9 +6,9 @@ import judgels.service.hibernate.JudgelsHibernateModule;
 import judgels.service.persistence.JudgelsPersistenceModule;
 import org.hibernate.SessionFactory;
 
-public abstract class BaseJerahmeelIntegrationTests {
-    protected static JerahmeelIntegrationTestComponent createComponent(SessionFactory sessionFactory) {
-        return DaggerJerahmeelIntegrationTestComponent.builder()
+public abstract class BaseTrainingIntegrationTests {
+    protected static TrainingIntegrationTestComponent createComponent(SessionFactory sessionFactory) {
+        return DaggerTrainingIntegrationTestComponent.builder()
                 .judgelsHibernateModule(new JudgelsHibernateModule(sessionFactory))
                 .judgelsPersistenceModule(new JudgelsPersistenceModule(Clock.systemUTC(), new TestActorProvider()))
                 .build();

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/training/TrainingIntegrationTestComponent.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/training/TrainingIntegrationTestComponent.java
@@ -1,4 +1,4 @@
-package judgels.jerahmeel;
+package judgels.training;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
@@ -23,7 +23,7 @@ import judgels.training.submission.bundle.TrainingItemSubmissionModule;
         JudgelsServerHibernateDaoModule.class,
         TrainingItemSubmissionModule.class})
 @Singleton
-public interface JerahmeelIntegrationTestComponent {
+public interface TrainingIntegrationTestComponent {
     CourseStore courseStore();
     CourseChapterStore courseChapterStore();
     ChapterStore chapterStore();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
@@ -17,7 +17,6 @@ import judgels.contrib.recaptcha.RecaptchaModule;
 import judgels.contrib.user.registration.UserRegistrationModule;
 import judgels.contrib.user.registration.web.UserRegistrationWebConfig;
 import judgels.grading.GradingClientModule;
-import judgels.jerahmeel.JerahmeelConfiguration;
 import judgels.jophiel.JophielConfiguration;
 import judgels.mailer.MailerModule;
 import judgels.messaging.rabbitmq.RabbitMQModule;
@@ -27,6 +26,7 @@ import judgels.service.JudgelsSchedulerModule;
 import judgels.service.hibernate.JudgelsHibernateModule;
 import judgels.service.jersey.JudgelsJerseyFeature;
 import judgels.session.SessionModule;
+import judgels.training.TrainingConfiguration;
 import judgels.training.submission.bundle.TrainingItemSubmissionModule;
 import judgels.user.account.UserResetPasswordModule;
 import judgels.user.superadmin.SuperadminModule;
@@ -109,7 +109,7 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
     private void runJudgelsServer(JudgelsServerApplicationConfiguration config, Environment env) {
         JudgelsServerConfiguration judgelsConfig = config.getJudgelsConfig();
         JophielConfiguration jophielConfig = config.getJophielConfig();
-        JerahmeelConfiguration jerahmeelConfig = config.getJerahmeelConfig();
+        TrainingConfiguration trainingConfig = config.getTrainingConfig();
 
         var componentBuilder = DaggerJudgelsServerComponent.builder()
                 .judgelsServerModule(new JudgelsServerModule(judgelsConfig))
@@ -123,8 +123,8 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
                 .userResetPasswordModule(new UserResetPasswordModule(jophielConfig.getUserResetPasswordConfig()))
                 .sessionModule(new SessionModule(jophielConfig.getSessionConfig()))
                 .webModule(new WebModule(jophielConfig.getWebConfig()))
-                .trainingSubmissionModule(new judgels.training.submission.programming.TrainingSubmissionModule(jerahmeelConfig.getStatsConfig()))
-                .trainingItemSubmissionModule(new TrainingItemSubmissionModule(jerahmeelConfig.getStatsConfig()));
+                .trainingSubmissionModule(new judgels.training.submission.programming.TrainingSubmissionModule(trainingConfig.getStatsConfig()))
+                .trainingItemSubmissionModule(new TrainingItemSubmissionModule(trainingConfig.getStatsConfig()));
 
         if (JudgelsApp.isTLX()) {
             componentBuilder
@@ -134,12 +134,12 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
                             UserRegistrationWebConfig.fromServerConfig(jophielConfig)))
                     .contestRatingModule(new ContestRatingModule(new TlxContestRatingProvider()));
 
-            if (jerahmeelConfig.getSubmissionConfig().isPresent()) {
-                if (jerahmeelConfig.getAwsConfig().isPresent() && jerahmeelConfig.getSubmissionConfig().get().getFs() instanceof AwsFsConfiguration) {
-                    AwsConfiguration awsConfig = jerahmeelConfig.getAwsConfig().get();
-                    AwsFsConfiguration submissionFsConfig = (AwsFsConfiguration) jerahmeelConfig.getSubmissionConfig().get().getFs();
+            if (trainingConfig.getSubmissionConfig().isPresent()) {
+                if (trainingConfig.getAwsConfig().isPresent() && trainingConfig.getSubmissionConfig().get().getFs() instanceof AwsFsConfiguration) {
+                    AwsConfiguration awsConfig = trainingConfig.getAwsConfig().get();
+                    AwsFsConfiguration submissionFsConfig = (AwsFsConfiguration) trainingConfig.getSubmissionConfig().get().getFs();
                     AwsFileSystem submissionFs = new AwsFileSystem(awsConfig, submissionFsConfig);
-                    componentBuilder.trainingSubmissionModule(new judgels.training.submission.programming.TrainingSubmissionModule(jerahmeelConfig.getStatsConfig(), submissionFs));
+                    componentBuilder.trainingSubmissionModule(new judgels.training.submission.programming.TrainingSubmissionModule(trainingConfig.getStatsConfig(), submissionFs));
                 }
             }
         }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplicationConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplicationConfiguration.java
@@ -3,28 +3,28 @@ package judgels;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.db.DataSourceFactory;
-import judgels.jerahmeel.JerahmeelConfiguration;
 import judgels.jophiel.JophielConfiguration;
+import judgels.training.TrainingConfiguration;
 
 public class JudgelsServerApplicationConfiguration extends Configuration {
     private final DataSourceFactory databaseConfig;
     private final WebSecurityConfiguration webSecurityConfig;
     private final JudgelsServerConfiguration judgelsConfig;
     private final JophielConfiguration jophielConfig;
-    private final JerahmeelConfiguration jerahmeelConfig;
+    private final TrainingConfiguration trainingConfig;
 
     public JudgelsServerApplicationConfiguration(
             @JsonProperty("database") DataSourceFactory databaseConfig,
             @JsonProperty("webSecurity") WebSecurityConfiguration webSecurityConfig,
             @JsonProperty("judgels") JudgelsServerConfiguration judgelsConfig,
             @JsonProperty("jophiel") JophielConfiguration jophielConfig,
-            @JsonProperty("jerahmeel") JerahmeelConfiguration jerahmeelConfig) {
+            @JsonProperty("training") TrainingConfiguration trainingConfig) {
 
         this.databaseConfig = databaseConfig;
         this.webSecurityConfig = webSecurityConfig;
         this.judgelsConfig = judgelsConfig;
         this.jophielConfig = jophielConfig;
-        this.jerahmeelConfig = jerahmeelConfig;
+        this.trainingConfig = trainingConfig;
     }
 
     public DataSourceFactory getDatabaseConfig() {
@@ -43,7 +43,7 @@ public class JudgelsServerApplicationConfiguration extends Configuration {
         return jophielConfig;
     }
 
-    public JerahmeelConfiguration getJerahmeelConfig() {
-        return jerahmeelConfig;
+    public TrainingConfiguration getTrainingConfig() {
+        return trainingConfig;
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/training/TrainingConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/training/TrainingConfiguration.java
@@ -1,4 +1,4 @@
-package judgels.jerahmeel;
+package judgels.training;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -8,8 +8,8 @@ import judgels.submission.programming.SubmissionConfiguration;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonDeserialize(as = ImmutableJerahmeelConfiguration.class)
-public interface JerahmeelConfiguration {
+@JsonDeserialize(as = ImmutableTrainingConfiguration.class)
+public interface TrainingConfiguration {
     @JsonProperty("stats")
     StatsConfiguration getStatsConfig();
 
@@ -19,5 +19,5 @@ public interface JerahmeelConfiguration {
     @JsonProperty("aws")
     Optional<judgels.contrib.fs.aws.AwsConfiguration> getAwsConfig();
 
-    class Builder extends ImmutableJerahmeelConfiguration.Builder {}
+    class Builder extends ImmutableTrainingConfiguration.Builder {}
 }

--- a/judgels-backends/judgels-server-app/var/conf/judgels-server.yml.example
+++ b/judgels-backends/judgels-server-app/var/conf/judgels-server.yml.example
@@ -82,6 +82,6 @@ jophiel:
   web:
     announcements: []
 
-jerahmeel:
+training:
   stats:
     enabled: false


### PR DESCRIPTION
## Context

Continues the archangel-codename cleanup (Michael intentionally kept; follows #917–#920). The `judgels.jerahmeel` package held only config + integTest scaffolding while the training domain code already lives under `judgels.training.*`. This eliminates `judgels.jerahmeel` entirely.

## Changes

- `judgels.jerahmeel.JerahmeelConfiguration` → **`judgels.training.TrainingConfiguration`**
- `judgels.jerahmeel.BaseJerahmeelIntegrationTests` → **`judgels.training.BaseTrainingIntegrationTests`**
- `judgels.jerahmeel.JerahmeelIntegrationTestComponent` → **`judgels.training.TrainingIntegrationTestComponent`**

**⚠️ BREAKING config change (accepted):** the YAML key `jerahmeel:` is renamed to `training:` — deployments must rename that block. Getter `getJerahmeelConfig()` → `getTrainingConfig()`; `@JsonProperty("jerahmeel")` → `"training"`. Nested sub-keys (`stats`/`submission`/`aws`) unchanged.

References updated: `JudgelsServerApplicationConfiguration`, `JudgelsServerApplication`, `BaseJudgelsApiIntegrationTests`, `StatsIntegrationTests`, and `judgels-server.yml.example`. (The local `judgels-server.yml` is gitignored — updated on disk for dev, not committed.) Files moved via `git mv` (history preserved); Immutables/Dagger generated names regenerate automatically.

## Out of scope (deliberately — separate, riskier follow-ups)

`UserRole.getJerahmeel()` + `jerahmeel` DB column, API error-code prefixes (`Jerahmeel:...`), `jerahmeel_*` DB entity/table names, Dropwizard admin task names, and the unrelated `judgels.api.BaseJerahmeelApiIntegrationTests` (a different class, mechanical test-only — good candidate for a future small PR).

## Verification

- ✅ `checkstyleMain` / `checkstyleTest` / `checkstyleIntegTest` (imports reordered for the single-group `ImportOrder` rule)
- ✅ `compileJava` + `compileIntegTestJava` (Immutables + Dagger regenerate against the new names)
- ✅ Test suite: **135 tests, 0 failures**
- ✅ `judgels.jerahmeel` source package fully removed; no config/package/import/YAML `jerahmeel` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)