### PR TITLE
De-archangel remaining integration-test base classes

### DIFF
--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ArchiveApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ArchiveApiIntegrationTests.java
@@ -8,7 +8,7 @@ import judgels.api.archive.ArchiveCreateData;
 import judgels.api.archive.ArchiveUpdateData;
 import org.junit.jupiter.api.Test;
 
-class ArchiveApiIntegrationTests extends BaseJerahmeelApiIntegrationTests {
+class ArchiveApiIntegrationTests extends BaseTrainingApiIntegrationTests {
     @Test
     void end_to_end_flow() {
         // as admin

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/BaseContestApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/BaseContestApiIntegrationTests.java
@@ -44,7 +44,7 @@ import org.hibernate.dialect.H2Dialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 
-public abstract class BaseUrielApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
+public abstract class BaseContestApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
     protected static final String ADMIN = "admin";
     protected static final String MANAGER = "manager";
     protected static final String SUPERVISOR = "supervisor";
@@ -93,7 +93,7 @@ public abstract class BaseUrielApiIntegrationTests extends BaseJudgelsApiIntegra
     protected ContestProblemClient problemClient = createClient(ContestProblemClient.class);
 
     @BeforeAll
-    static void setUpUriel() {
+    static void setUpContest() {
         manager = createUser("manager");
         managerToken = getToken(manager);
 

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/BaseTrainingApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/BaseTrainingApiIntegrationTests.java
@@ -17,7 +17,7 @@ import judgels.problemset.ProblemSetClient;
 import judgels.problemset.ProblemSetProblemClient;
 import org.junit.jupiter.api.BeforeAll;
 
-public abstract class BaseJerahmeelApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
+public abstract class BaseTrainingApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
     protected static final String ADMIN = "admin";
     protected static final String USER = "user";
     protected static final String USER_A = "userA";
@@ -61,7 +61,7 @@ public abstract class BaseJerahmeelApiIntegrationTests extends BaseJudgelsApiInt
     protected ProblemSetProblemClient problemSetProblemClient = createClient(ProblemSetProblemClient.class);
 
     @BeforeAll
-    static void setUpJerahmeel() {
+    static void setUpTraining() {
         userA = createUser("userA");
         userAToken = getToken(userA);
 

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ChapterApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ChapterApiIntegrationTests.java
@@ -7,7 +7,7 @@ import judgels.api.chapter.ChapterCreateData;
 import judgels.api.chapter.ChapterUpdateData;
 import org.junit.jupiter.api.Test;
 
-class ChapterApiIntegrationTests extends BaseJerahmeelApiIntegrationTests {
+class ChapterApiIntegrationTests extends BaseTrainingApiIntegrationTests {
     @Test
     void end_to_end_flow() {
         // as admin

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ChapterLessonApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ChapterLessonApiIntegrationTests.java
@@ -9,7 +9,7 @@ import judgels.api.chapter.lesson.ChapterLesson;
 import judgels.api.chapter.lesson.ChapterLessonData;
 import org.junit.jupiter.api.Test;
 
-class ChapterLessonApiIntegrationTests extends BaseJerahmeelApiIntegrationTests {
+class ChapterLessonApiIntegrationTests extends BaseTrainingApiIntegrationTests {
     @Test
     void end_to_end_flow() {
         // as admin

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ChapterProblemApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ChapterProblemApiIntegrationTests.java
@@ -10,7 +10,7 @@ import judgels.api.chapter.problem.ChapterProblemData;
 import judgels.api.problem.ProblemType;
 import org.junit.jupiter.api.Test;
 
-class ChapterProblemApiIntegrationTests extends BaseJerahmeelApiIntegrationTests {
+class ChapterProblemApiIntegrationTests extends BaseTrainingApiIntegrationTests {
     @Test
     void end_to_end_flow() {
         // as admin

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestAnnouncementApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestAnnouncementApiIntegrationTests.java
@@ -17,7 +17,7 @@ import judgels.contest.ContestAnnouncementClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestAnnouncementApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestAnnouncementApiIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestAnnouncementClient announcementClient = createClient(ContestAnnouncementClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestAnnouncementApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestAnnouncementApiPermissionIntegrationTests.java
@@ -12,7 +12,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestAnnouncementApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestAnnouncementApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestAnnouncementClient announcementClient = createClient(ContestAnnouncementClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestApiIntegrationTests.java
@@ -30,7 +30,7 @@ import org.hibernate.dialect.H2Dialect;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class ContestApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestApiIntegrationTests extends BaseContestApiIntegrationTests {
     @BeforeAll
     static void beforeAll() {
         Configuration config = new Configuration();

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestApiPermissionIntegrationTests.java
@@ -11,7 +11,7 @@ import judgels.api.contest.ContestUpdateData;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
-class ContestApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @Test

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestClarificationApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestClarificationApiIntegrationTests.java
@@ -20,7 +20,7 @@ import judgels.contest.ContestClarificationClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestClarificationApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestClarificationApiIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestClarificationClient clarificationClient = createClient(ContestClarificationClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestClarificationApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestClarificationApiPermissionIntegrationTests.java
@@ -19,7 +19,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestClarificationApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestClarificationApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestClarificationClient clarificationClient = createClient(ContestClarificationClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestContestantApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestContestantApiIntegrationTests.java
@@ -25,7 +25,7 @@ import judgels.api.contest.supervisor.SupervisorManagementPermission;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestContestantApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestContestantApiIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestContestantApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestContestantApiPermissionIntegrationTests.java
@@ -12,7 +12,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestContestantApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestContestantApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestEditorialApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestEditorialApiIntegrationTests.java
@@ -10,7 +10,7 @@ import judgels.contest.ContestEditorialClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ContestEditorialApiIntegrationTests extends BaseUrielApiIntegrationTests {
+public class ContestEditorialApiIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestEditorialClient editorialClient = createClient(ContestEditorialClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestEditorialApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestEditorialApiPermissionIntegrationTests.java
@@ -10,7 +10,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestEditorialApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestEditorialApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestEditorialClient editorialClient = createClient(ContestEditorialClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestFileApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestFileApiIntegrationTests.java
@@ -16,7 +16,7 @@ import judgels.contest.ContestFileClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestFileApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestFileApiIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestFileClient fileClient = createClient(ContestFileClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestFileApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestFileApiPermissionIntegrationTests.java
@@ -11,7 +11,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestFileApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestFileApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestFileClient fileClient = createClient(ContestFileClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestItemSubmissionApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestItemSubmissionApiIntegrationTests.java
@@ -18,7 +18,7 @@ import judgels.contest.ContestItemSubmissionClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestItemSubmissionApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestItemSubmissionApiIntegrationTests extends BaseContestApiIntegrationTests {
     private static final String PROBLEM_3_ALIAS = "B";
     private final ContestItemSubmissionClient submissionClient = createClient(ContestItemSubmissionClient.class);
 

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestLogApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestLogApiIntegrationTests.java
@@ -19,7 +19,7 @@ import judgels.contest.ContestLogClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestLogApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestLogApiIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestLogClient logClient = createClient(ContestLogClient.class);
     private final ContestClarificationClient clarificationClient = createClient(ContestClarificationClient.class);
 

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestLogApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestLogApiPermissionIntegrationTests.java
@@ -8,7 +8,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestLogApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestLogApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestLogClient logClient = createClient(ContestLogClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestManagerApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestManagerApiIntegrationTests.java
@@ -10,7 +10,7 @@ import judgels.api.contest.manager.ContestManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestManagerApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestManagerApiIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestManagerApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestManagerApiPermissionIntegrationTests.java
@@ -6,7 +6,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestManagerApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestManagerApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestModuleApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestModuleApiIntegrationTests.java
@@ -12,7 +12,7 @@ import judgels.api.contest.module.VirtualModuleConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestModuleApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestModuleApiIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestModuleApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestModuleApiPermissionIntegrationTests.java
@@ -9,7 +9,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestModuleApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestModuleApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestProblemApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestProblemApiIntegrationTests.java
@@ -32,7 +32,7 @@ import judgels.grading.api.LanguageRestriction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestProblemApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestProblemApiIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestProblemApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestProblemApiPermissionIntegrationTests.java
@@ -13,7 +13,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestProblemApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestProblemApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestScoreboardApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestScoreboardApiIntegrationTests.java
@@ -23,7 +23,7 @@ import judgels.contest.ContestScoreboardClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestScoreboardApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestScoreboardApiIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestScoreboardClient scoreboardClient = createClient(ContestScoreboardClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestScoreboardApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestScoreboardApiPermissionIntegrationTests.java
@@ -10,7 +10,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestScoreboardApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestScoreboardApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestScoreboardClient scoreboardClient = createClient(ContestScoreboardClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestSubmissionApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestSubmissionApiIntegrationTests.java
@@ -20,7 +20,7 @@ import judgels.contest.ContestSubmissionClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestSubmissionApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestSubmissionApiIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestSubmissionClient submissionClient = createClient(ContestSubmissionClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestSubmissionApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestSubmissionApiPermissionIntegrationTests.java
@@ -18,7 +18,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestSubmissionApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestSubmissionApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestSubmissionClient submissionClient = createClient(ContestSubmissionClient.class);
 
     private Contest contest;

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestSupervisorApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestSupervisorApiIntegrationTests.java
@@ -11,7 +11,7 @@ import judgels.api.contest.supervisor.ContestSupervisorUpsertData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestSupervisorApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestSupervisorApiIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestSupervisorApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestSupervisorApiPermissionIntegrationTests.java
@@ -7,7 +7,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestSupervisorApiPermissionIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestSupervisorApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
     private Contest contest;
 
     @BeforeEach

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestWebApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestWebApiIntegrationTests.java
@@ -32,7 +32,7 @@ import judgels.contest.ContestWebClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ContestWebApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestWebApiIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestWebClient webClient = createClient(ContestWebClient.class);
     private final ContestClarificationClient clarificationClient = createClient(ContestClarificationClient.class);
 

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/CourseApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/CourseApiIntegrationTests.java
@@ -8,7 +8,7 @@ import judgels.api.course.CourseCreateData;
 import judgels.api.course.CourseUpdateData;
 import org.junit.jupiter.api.Test;
 
-class CourseApiIntegrationTests extends BaseJerahmeelApiIntegrationTests {
+class CourseApiIntegrationTests extends BaseTrainingApiIntegrationTests {
     @Test
     void end_to_end_flow() {
         // as admin

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/CourseChapterClientIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/CourseChapterClientIntegrationTests.java
@@ -17,7 +17,7 @@ import judgels.api.course.chapter.CourseChapterUserProgressesResponse;
 import judgels.api.problem.ProblemType;
 import org.junit.jupiter.api.Test;
 
-class CourseChapterClientIntegrationTests extends BaseJerahmeelApiIntegrationTests {
+class CourseChapterClientIntegrationTests extends BaseTrainingApiIntegrationTests {
     @Test
     void end_to_end_flow() {
         // as admin

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ProblemSetApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ProblemSetApiIntegrationTests.java
@@ -17,7 +17,7 @@ import judgels.problemset.ProblemSetClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ProblemSetApiIntegrationTests extends BaseJerahmeelApiIntegrationTests {
+class ProblemSetApiIntegrationTests extends BaseTrainingApiIntegrationTests {
     @BeforeEach
     void before() {
         contest1 = createContest(CONTEST_1_SLUG);

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ProblemSetProblemApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ProblemSetProblemApiIntegrationTests.java
@@ -13,7 +13,7 @@ import judgels.api.problemset.problem.ProblemSetProblemData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ProblemSetProblemApiIntegrationTests extends BaseJerahmeelApiIntegrationTests {
+class ProblemSetProblemApiIntegrationTests extends BaseTrainingApiIntegrationTests {
     @BeforeEach
     void before() {
         contest1 = createContest(CONTEST_1_SLUG);

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/contrib/api/ContestRatingApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/contrib/api/ContestRatingApiIntegrationTests.java
@@ -6,7 +6,7 @@ import static org.hibernate.cfg.AvailableSettings.DRIVER;
 import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
 import static org.hibernate.cfg.AvailableSettings.URL;
 
-import judgels.api.BaseUrielApiIntegrationTests;
+import judgels.api.BaseContestApiIntegrationTests;
 import judgels.contrib.contest.ContestRatingClient;
 import org.h2.Driver;
 import org.hibernate.Session;
@@ -17,7 +17,7 @@ import org.hibernate.dialect.H2Dialect;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class ContestRatingApiIntegrationTests extends BaseUrielApiIntegrationTests {
+class ContestRatingApiIntegrationTests extends BaseContestApiIntegrationTests {
     private final ContestRatingClient ratingClient = createClient(ContestRatingClient.class);
 
     @BeforeAll

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/session/SessionCleanerIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/session/SessionCleanerIntegrationTests.java
@@ -3,17 +3,17 @@ package judgels.session;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import judgels.jophiel.BaseJophielIntegrationTests;
-import judgels.jophiel.JophielIntegrationTestComponent;
 import judgels.persistence.SessionModel;
 import judgels.persistence.TestClock;
 import judgels.persistence.hibernate.WithHibernateSession;
+import judgels.user.BaseUserIntegrationTests;
+import judgels.user.UserIntegrationTestComponent;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @WithHibernateSession(models = {SessionModel.class})
-public class SessionCleanerIntegrationTests extends BaseJophielIntegrationTests {
+public class SessionCleanerIntegrationTests extends BaseUserIntegrationTests {
     private TestClock clock;
     private SessionStore store;
     private SessionCleaner cleaner;
@@ -21,7 +21,7 @@ public class SessionCleanerIntegrationTests extends BaseJophielIntegrationTests 
     @BeforeEach
     void setUpSession(SessionFactory sessionFactory) {
         clock = new TestClock();
-        JophielIntegrationTestComponent component = createComponent(sessionFactory, clock);
+        UserIntegrationTestComponent component = createComponent(sessionFactory, clock);
         store = component.sessionStore();
         cleaner = new SessionCleaner(clock, store);
     }

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/user/BaseUserIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/user/BaseUserIntegrationTests.java
@@ -1,4 +1,4 @@
-package judgels.jophiel;
+package judgels.user;
 
 import java.time.Clock;
 import judgels.persistence.TestActorProvider;
@@ -7,13 +7,13 @@ import judgels.service.hibernate.JudgelsHibernateModule;
 import judgels.service.persistence.JudgelsPersistenceModule;
 import org.hibernate.SessionFactory;
 
-public abstract class BaseJophielIntegrationTests {
-    protected static JophielIntegrationTestComponent createComponent(SessionFactory sessionFactory) {
+public abstract class BaseUserIntegrationTests {
+    protected static UserIntegrationTestComponent createComponent(SessionFactory sessionFactory) {
         return createComponent(sessionFactory, new TestClock());
     }
 
-    protected static JophielIntegrationTestComponent createComponent(SessionFactory sessionFactory, Clock clock) {
-        return DaggerJophielIntegrationTestComponent.builder()
+    protected static UserIntegrationTestComponent createComponent(SessionFactory sessionFactory, Clock clock) {
+        return DaggerUserIntegrationTestComponent.builder()
                 .judgelsHibernateModule(new JudgelsHibernateModule(sessionFactory))
                 .judgelsPersistenceModule(new JudgelsPersistenceModule(clock, new TestActorProvider()))
                 .build();

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/user/UserIntegrationTestComponent.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/user/UserIntegrationTestComponent.java
@@ -1,4 +1,4 @@
-package judgels.jophiel;
+package judgels.user;
 
 import dagger.Component;
 import jakarta.inject.Singleton;
@@ -8,7 +8,6 @@ import judgels.service.hibernate.JudgelsHibernateModule;
 import judgels.service.hibernate.JudgelsServerHibernateDaoModule;
 import judgels.service.persistence.JudgelsPersistenceModule;
 import judgels.session.SessionStore;
-import judgels.user.UserStore;
 import judgels.user.account.UserResetPasswordStore;
 import judgels.user.avatar.UserAvatarIntegrationTestModule;
 
@@ -19,7 +18,7 @@ import judgels.user.avatar.UserAvatarIntegrationTestModule;
         JudgelsPersistenceModule.class,
         UserAvatarIntegrationTestModule.class})
 @Singleton
-public interface JophielIntegrationTestComponent {
+public interface UserIntegrationTestComponent {
     UserStore userStore();
     SessionStore sessionStore();
     SuperadminRoleStore superadminRoleStore();

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/user/account/UserResetPasswordStoreIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/user/account/UserResetPasswordStoreIntegrationTests.java
@@ -3,17 +3,17 @@ package judgels.user.account;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import judgels.jophiel.BaseJophielIntegrationTests;
-import judgels.jophiel.JophielIntegrationTestComponent;
 import judgels.persistence.TestClock;
 import judgels.persistence.UserResetPasswordModel;
 import judgels.persistence.hibernate.WithHibernateSession;
+import judgels.user.BaseUserIntegrationTests;
+import judgels.user.UserIntegrationTestComponent;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @WithHibernateSession(models = {UserResetPasswordModel.class})
-public class UserResetPasswordStoreIntegrationTests extends BaseJophielIntegrationTests {
+public class UserResetPasswordStoreIntegrationTests extends BaseUserIntegrationTests {
     private static final String USER_JID = "userJid";
 
     private TestClock clock;
@@ -23,7 +23,7 @@ public class UserResetPasswordStoreIntegrationTests extends BaseJophielIntegrati
     void setUpSession(SessionFactory sessionFactory) {
         clock = new TestClock();
 
-        JophielIntegrationTestComponent component = createComponent(sessionFactory, clock);
+        UserIntegrationTestComponent component = createComponent(sessionFactory, clock);
 
         store = component.userResetPasswordStore();
     }

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/user/superadmin/SuperadminCreatorIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/user/superadmin/SuperadminCreatorIntegrationTests.java
@@ -4,18 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import judgels.api.user.User;
-import judgels.jophiel.BaseJophielIntegrationTests;
-import judgels.jophiel.JophielIntegrationTestComponent;
 import judgels.persistence.UserModel;
 import judgels.persistence.hibernate.WithHibernateSession;
 import judgels.role.SuperadminRoleStore;
+import judgels.user.BaseUserIntegrationTests;
+import judgels.user.UserIntegrationTestComponent;
 import judgels.user.UserStore;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @WithHibernateSession(models = {UserModel.class})
-public class SuperadminCreatorIntegrationTests extends BaseJophielIntegrationTests {
+public class SuperadminCreatorIntegrationTests extends BaseUserIntegrationTests {
     private static final SuperadminCreatorConfiguration CONFIG = new SuperadminCreatorConfiguration.Builder()
             .initialPassword("superpass")
             .build();
@@ -26,7 +26,7 @@ public class SuperadminCreatorIntegrationTests extends BaseJophielIntegrationTes
 
     @BeforeEach
     void setUpSession(SessionFactory sessionFactory) {
-        JophielIntegrationTestComponent component = createComponent(sessionFactory);
+        UserIntegrationTestComponent component = createComponent(sessionFactory);
         userStore = component.userStore();
         superadminRoleStore = component.superadminRoleStore();
         superadminCreator = new SuperadminCreator(userStore, superadminRoleStore, Optional.of(CONFIG));


### PR DESCRIPTION
## Summary
- Renames the four archangel-named base classes left in the integTest tree, matching the `BaseTrainingIntegrationTests` rename from #921 and eliminating the `judgels.jophiel` test package entirely.
- Renames:
  - `judgels.api.BaseJerahmeelApiIntegrationTests` → `judgels.api.BaseTrainingApiIntegrationTests`
  - `judgels.api.BaseUrielApiIntegrationTests` → `judgels.api.BaseContestApiIntegrationTests`
  - `judgels.jophiel.BaseJophielIntegrationTests` → `judgels.user.BaseUserIntegrationTests`
  - `judgels.jophiel.JophielIntegrationTestComponent` → `judgels.user.UserIntegrationTestComponent`
- Also renames the two static `@BeforeAll` helpers: `setUpJerahmeel` → `setUpTraining`, `setUpUriel` → `setUpContest`.
- Files moved via `git mv` (history preserved). The SQL literal `delete from uriel_contest` stays unchanged because the DB table name is unchanged (table renames deferred per #921).
- Updates the 37 subclasses extending the renamed bases and the 3 callers of the former `JophielIntegrationTestComponent` (`SuperadminCreator`, `UserResetPasswordStore`, `SessionCleaner`), including import-order adjustments for checkstyle.

## Test plan
- [x] `./gradlew :judgels-server-app:checkstyleIntegTest` passes
- [x] `./gradlew :judgels-server-app:compileIntegTestJava` passes
- [x] `./gradlew :judgels-server-app:integTest`: 114/120 pass. The 6 `ContestSubmissionApi*` failures reproduce on `master` and are unrelated to this rename.
- [x] `judgels-server-app/src/integTest/java/judgels/jophiel/` directory no longer exists
- [x] No stale references: `grep -r 'BaseJerahmeelApiIntegrationTests\|BaseUrielApiIntegrationTests\|BaseJophielIntegrationTests\|JophielIntegrationTestComponent\|setUpJerahmeel\|setUpUriel' judgels-backends/` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)