### PR TITLE
De-archangel: move EmailTemplate to judgels.mailer

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contrib/user/registration/UserRegistrationConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contrib/user/registration/UserRegistrationConfiguration.java
@@ -1,7 +1,7 @@
 package judgels.contrib.user.registration;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import judgels.jophiel.EmailTemplate;
+import judgels.mailer.EmailTemplate;
 import org.immutables.value.Value;
 
 @Value.Immutable

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contrib/user/registration/UserRegistrationEmailMailer.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contrib/user/registration/UserRegistrationEmailMailer.java
@@ -1,7 +1,7 @@
 package judgels.contrib.user.registration;
 
 import judgels.api.user.User;
-import judgels.jophiel.EmailTemplate;
+import judgels.mailer.EmailTemplate;
 import judgels.mailer.Mailer;
 
 public class UserRegistrationEmailMailer {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/mailer/EmailTemplate.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/mailer/EmailTemplate.java
@@ -1,4 +1,4 @@
-package judgels.jophiel;
+package judgels.mailer;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/user/account/UserResetPasswordConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/user/account/UserResetPasswordConfiguration.java
@@ -1,7 +1,7 @@
 package judgels.user.account;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import judgels.jophiel.EmailTemplate;
+import judgels.mailer.EmailTemplate;
 import org.immutables.value.Value;
 
 @Value.Immutable

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/user/account/UserResetPasswordMailer.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/user/account/UserResetPasswordMailer.java
@@ -1,7 +1,7 @@
 package judgels.user.account;
 
 import judgels.api.user.User;
-import judgels.jophiel.EmailTemplate;
+import judgels.mailer.EmailTemplate;
 import judgels.mailer.Mailer;
 
 public class UserResetPasswordMailer {


### PR DESCRIPTION
## Summary
- Moves the last remaining file in `judgels.jophiel` (main source) to its natural home next to `Mailer` / `MailerConfiguration` / `MailerModule`.
- After this PR, `judgels-server-app/src/main/java/judgels/jophiel/` is gone and the `judgels.jophiel` main-source package is fully eliminated.
- Rename: `judgels.jophiel.EmailTemplate` → `judgels.mailer.EmailTemplate`. File moved via `git mv` (history preserved). Immutables-generated `ImmutableEmailTemplate` regenerates under the new package automatically.
- 4 import sites updated: `UserResetPasswordConfiguration`, `UserResetPasswordMailer`, `UserRegistrationConfiguration`, `UserRegistrationEmailMailer`.

## Test plan
- [x] `./gradlew :judgels-server-app:checkstyleMain :judgels-server-app:checkstyleTest :judgels-server-app:checkstyleIntegTest` pass
- [x] `./gradlew :judgels-server-app:compileJava :judgels-server-app:compileTestJava :judgels-server-app:compileIntegTestJava` pass
- [x] `./gradlew :judgels-server-app:test` passes
- [x] `grep -rn 'judgels\.jophiel' judgels-server-app/src/` returns nothing
- [x] `judgels-server-app/src/main/java/judgels/jophiel/` directory no longer exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)