### PR TITLE
Refactor: extract TlxServerComponent as Dagger subcomponent

### DIFF
--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/training/TrainingIntegrationTestComponent.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/training/TrainingIntegrationTestComponent.java
@@ -1,7 +1,6 @@
 package judgels.training;
 
 import dagger.Component;
-import jakarta.inject.Singleton;
 import judgels.archive.ArchiveStore;
 import judgels.chapter.ChapterStore;
 import judgels.chapter.problem.ChapterProblemStore;
@@ -15,6 +14,7 @@ import judgels.service.persistence.hibernate.JudgelsHibernateModule;
 import judgels.service.persistence.hibernate.JudgelsServerHibernateDaoModule;
 import judgels.stats.StatsStore;
 import judgels.training.submission.bundle.TrainingItemSubmissionModule;
+import tlx.TlxScope;
 
 @Component(modules = {
         JudgelsModule.class,
@@ -22,7 +22,7 @@ import judgels.training.submission.bundle.TrainingItemSubmissionModule;
         JudgelsPersistenceModule.class,
         JudgelsServerHibernateDaoModule.class,
         TrainingItemSubmissionModule.class})
-@Singleton
+@TlxScope
 public interface TrainingIntegrationTestComponent {
     CourseStore courseStore();
     CourseChapterStore courseChapterStore();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
@@ -19,10 +19,12 @@ import judgels.service.persistence.hibernate.JudgelsHibernateModule;
 import judgels.session.SessionModule;
 import judgels.training.TrainingConfiguration;
 import judgels.training.submission.bundle.TrainingItemSubmissionModule;
+import judgels.training.submission.programming.TrainingSubmissionModule;
 import judgels.user.account.UserResetPasswordModule;
 import judgels.user.superadmin.SuperadminModule;
 import judgels.user.web.WebModule;
 import org.eclipse.jetty.server.session.SessionHandler;
+import tlx.TlxServerComponent;
 import tlx.auth.AuthModule;
 import tlx.contest.rating.ContestRatingModule;
 import tlx.contest.rating.TlxContestRatingProvider;
@@ -58,7 +60,11 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
         JudgelsApp.initialize(config.getJudgelsConfig().getAppConfig());
 
         runMichael(config, env);
-        runJudgelsServer(config, env);
+        JudgelsServerComponent serverComponent = runJudgelsServer(config, env);
+
+        if (JudgelsApp.isTLX()) {
+            runTlxServer(serverComponent, config, env);
+        }
     }
 
     private void runMichael(JudgelsServerApplicationConfiguration config, Environment env) {
@@ -104,9 +110,8 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
         env.jersey().register(component.lessonVersionResource());
     }
 
-    private void runJudgelsServer(JudgelsServerApplicationConfiguration config, Environment env) {
+    private JudgelsServerComponent runJudgelsServer(JudgelsServerApplicationConfiguration config, Environment env) {
         JudgelsServerConfiguration judgelsConfig = config.getJudgelsConfig();
-        TrainingConfiguration trainingConfig = config.getTrainingConfig();
 
         var componentBuilder = DaggerJudgelsServerComponent.builder()
                 .judgelsServerModule(new JudgelsServerModule(judgelsConfig))
@@ -119,26 +124,10 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
                 .superadminModule(new SuperadminModule(judgelsConfig.getSuperadminCreatorConfig()))
                 .userResetPasswordModule(new UserResetPasswordModule(judgelsConfig.getUserResetPasswordConfig()))
                 .sessionModule(new SessionModule(judgelsConfig.getSessionConfig()))
-                .webModule(new WebModule(judgelsConfig.getWebConfig()))
-                .trainingSubmissionModule(new judgels.training.submission.programming.TrainingSubmissionModule(trainingConfig.getStatsConfig()))
-                .trainingItemSubmissionModule(new TrainingItemSubmissionModule(trainingConfig.getStatsConfig()));
+                .webModule(new WebModule(judgelsConfig.getWebConfig()));
 
         if (JudgelsApp.isTLX()) {
-            componentBuilder
-                    .recaptchaModule(new RecaptchaModule(judgelsConfig.getRecaptchaConfig()))
-                    .userRegistrationModule(new UserRegistrationModule(
-                            judgelsConfig.getUserRegistrationConfig(),
-                            UserRegistrationWebConfig.fromServerConfig(judgelsConfig)))
-                    .contestRatingModule(new ContestRatingModule(new TlxContestRatingProvider()));
-
-            if (trainingConfig.getSubmissionConfig().isPresent()) {
-                if (trainingConfig.getAwsConfig().isPresent() && trainingConfig.getSubmissionConfig().get().getFs() instanceof AwsFsConfiguration) {
-                    AwsConfiguration awsConfig = trainingConfig.getAwsConfig().get();
-                    AwsFsConfiguration submissionFsConfig = (AwsFsConfiguration) trainingConfig.getSubmissionConfig().get().getFs();
-                    AwsFileSystem submissionFs = new AwsFileSystem(awsConfig, submissionFsConfig);
-                    componentBuilder.trainingSubmissionModule(new judgels.training.submission.programming.TrainingSubmissionModule(trainingConfig.getStatsConfig(), submissionFs));
-                }
-            }
+            componentBuilder.contestRatingModule(new ContestRatingModule(new TlxContestRatingProvider()));
         }
 
         JudgelsServerComponent component = componentBuilder.build();
@@ -163,12 +152,6 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
                 "session-cleaner",
                 component.sessionCleaner(),
                 Duration.ofDays(1));
-
-        if (JudgelsApp.isTLX()) {
-            env.jersey().register(component.sessionWithGoogleResource());
-            env.jersey().register(component.userAccountWithRegistrationResource());
-            env.jersey().register(component.userRegistrationWebResource());
-        }
 
         // Problems
         env.jersey().register(component.baseProblemResource());
@@ -197,12 +180,6 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
         env.jersey().register(component.contestBundleSubmissionResource());
         env.jersey().register(component.contestSupervisorResource());
 
-        if (JudgelsApp.isTLX()) {
-            env.jersey().register(component.contestRatingResource());
-            env.jersey().register(component.contestRatingAdminResource());
-            env.jersey().register(component.userRatingAdminResource());
-        }
-
         component.scheduler().scheduleWithFixedDelay(
                 "contest-scoreboard-poller",
                 component.contestScoreboardPoller(),
@@ -219,9 +196,44 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
 
         env.admin().addTask(component.dumpContestTask());
 
-        if (JudgelsApp.isTLX()) {
-            env.admin().addTask(component.tlxReplaceProblemTask());
+        return component;
+    }
+
+    private void runTlxServer(
+            JudgelsServerComponent serverComponent,
+            JudgelsServerApplicationConfiguration config,
+            Environment env) {
+
+        JudgelsServerConfiguration judgelsConfig = config.getJudgelsConfig();
+        TrainingConfiguration trainingConfig = config.getTrainingConfig();
+
+        TrainingSubmissionModule trainingSubmissionModule =
+                new TrainingSubmissionModule(trainingConfig.getStatsConfig());
+        if (trainingConfig.getSubmissionConfig().isPresent()
+                && trainingConfig.getAwsConfig().isPresent()
+                && trainingConfig.getSubmissionConfig().get().getFs() instanceof AwsFsConfiguration) {
+            AwsConfiguration awsConfig = trainingConfig.getAwsConfig().get();
+            AwsFsConfiguration submissionFsConfig = (AwsFsConfiguration) trainingConfig.getSubmissionConfig().get().getFs();
+            AwsFileSystem submissionFs = new AwsFileSystem(awsConfig, submissionFsConfig);
+            trainingSubmissionModule = new TrainingSubmissionModule(trainingConfig.getStatsConfig(), submissionFs);
         }
+
+        TlxServerComponent component = serverComponent.tlxServerComponentFactory().create(
+                new RecaptchaModule(judgelsConfig.getRecaptchaConfig()),
+                new UserRegistrationModule(UserRegistrationWebConfig.fromServerConfig(judgelsConfig)),
+                trainingSubmissionModule,
+                new TrainingItemSubmissionModule(trainingConfig.getStatsConfig()));
+
+        // Users
+        env.jersey().register(component.sessionWithGoogleResource());
+        env.jersey().register(component.userAccountWithRegistrationResource());
+        env.jersey().register(component.userRegistrationWebResource());
+
+        // Contests
+        env.jersey().register(component.contestRatingResource());
+        env.jersey().register(component.contestRatingAdminResource());
+        env.jersey().register(component.userRatingAdminResource());
+        env.admin().addTask(component.tlxReplaceProblemTask());
 
         // Training
         env.jersey().register(component.archiveResource());
@@ -253,11 +265,8 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
 
         env.admin().addTask(component.refreshContestStatsTask());
         env.admin().addTask(component.refreshProblemSetStatsTask());
-
-        if (JudgelsApp.isTLX()) {
-            env.admin().addTask(component.tlxDeleteProblemTask());
-            env.admin().addTask(component.tlxMoveProblemToChapterTask());
-            env.admin().addTask(component.tlxMoveProblemToProblemSetTask());
-        }
+        env.admin().addTask(component.tlxDeleteProblemTask());
+        env.admin().addTask(component.tlxMoveProblemToChapterTask());
+        env.admin().addTask(component.tlxMoveProblemToProblemSetTask());
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
@@ -5,7 +5,6 @@ import jakarta.inject.Singleton;
 import judgels.contest.submission.programming.ContestGradingResponsePoller;
 import judgels.service.JudgelsScheduler;
 import judgels.submission.programming.GradingResponsePoller;
-import judgels.training.submission.programming.TrainingGradingResponsePoller;
 
 @Component(modules = {
         // Judgels service
@@ -31,8 +30,6 @@ import judgels.training.submission.programming.TrainingGradingResponsePoller;
         judgels.session.SessionModule.class,
         judgels.user.web.WebModule.class,
         tlx.auth.AuthModule.class,
-        tlx.recaptcha.RecaptchaModule.class,
-        tlx.user.registration.UserRegistrationModule.class,
 
         // Problem features
         judgels.submission.SubmissionModule.class,
@@ -45,13 +42,8 @@ import judgels.training.submission.programming.TrainingGradingResponsePoller;
         judgels.contest.scoreboard.ContestScoreboardUpdaterModule.class,
         tlx.contest.rating.ContestRatingModule.class,
 
-        // Training features
-        judgels.training.submission.programming.TrainingSubmissionModule.class,
-        judgels.training.submission.bundle.TrainingItemSubmissionModule.class,
-
         // Tasks
-        judgels.tasks.JudgelsServerTaskModule.class,
-        tlx.tasks.TlxTaskModule.class})
+        judgels.tasks.JudgelsServerTaskModule.class})
 @Singleton
 public interface JudgelsServerComponent {
     // Users
@@ -69,9 +61,6 @@ public interface JudgelsServerComponent {
     judgels.user.search.UserSearchResource userSearchResource();
     judgels.user.web.UserWebResource userWebResource();
     judgels.session.SessionCleaner sessionCleaner();
-    tlx.session.SessionWithGoogleResource sessionWithGoogleResource();
-    tlx.user.account.UserAccountWithRegistrationResource userAccountWithRegistrationResource();
-    tlx.user.registration.web.UserRegistrationWebResource userRegistrationWebResource();
 
     // Problems
     judgels.problem.base.ProblemResource baseProblemResource();
@@ -100,40 +89,8 @@ public interface JudgelsServerComponent {
     judgels.contest.log.ContestLogPoller contestLogPoller();
     judgels.contest.scoreboard.ContestScoreboardPoller contestScoreboardPoller();
     judgels.tasks.DumpContestTask dumpContestTask();
-    tlx.contest.rating.ContestRatingResource contestRatingResource();
-    tlx.admin.contest.rating.ContestRatingAdminResource contestRatingAdminResource();
-    judgels.admin.user.rating.UserRatingAdminResource userRatingAdminResource();
-    tlx.tasks.ReplaceProblemTask tlxReplaceProblemTask();
-
-    // Training
-    tlx.archive.ArchiveResource archiveResource();
-    tlx.admin.archive.ArchiveAdminResource archiveAdminResource();
-    tlx.curriculum.CurriculumResource curriculumResource();
-    tlx.course.CourseResource courseResource();
-    tlx.admin.course.CourseAdminResource courseAdminResource();
-    tlx.chapter.ChapterResource chapterResource();
-    tlx.admin.chapter.ChapterAdminResource chapterAdminResource();
-    tlx.course.chapter.CourseChapterResource courseChapterResource();
-    tlx.admin.course.chapter.CourseChapterAdminResource courseChapterAdminResource();
-    tlx.chapter.lesson.ChapterLessonResource chapterLessonResource();
-    tlx.admin.chapter.lesson.ChapterLessonAdminResource chapterLessonAdminResource();
-    tlx.chapter.problem.ChapterProblemResource chapterProblemResource();
-    tlx.admin.chapter.problem.ChapterProblemAdminResource chapterProblemAdminResource();
-    tlx.problem.ProblemResource problemResource();
-    tlx.problem.ProblemTagResource problemTagResource();
-    tlx.problemset.ProblemSetResource problemSetResource();
-    tlx.admin.problemset.ProblemSetAdminResource problemSetAdminResource();
-    tlx.problemset.problem.ProblemSetProblemResource problemSetProblemResource();
-    tlx.admin.problemset.problem.ProblemSetProblemAdminResource problemSetProblemAdminResource();
-    tlx.submission.bundle.ItemSubmissionResource itemSubmissionResource();
-    tlx.submission.programming.SubmissionResource submissionResource();
-    tlx.stats.UserStatsResource userStatsResource();
-    @TrainingGradingResponsePoller GradingResponsePoller trainingGradingResponsePoller();
-    tlx.tasks.RefreshContestStatsTask refreshContestStatsTask();
-    tlx.tasks.RefreshProblemSetStatsTask refreshProblemSetStatsTask();
-    tlx.tasks.DeleteProblemTask tlxDeleteProblemTask();
-    tlx.tasks.MoveProblemToChapterTask tlxMoveProblemToChapterTask();
-    tlx.tasks.MoveProblemToProblemSetTask tlxMoveProblemToProblemSetTask();
 
     JudgelsScheduler scheduler();
+
+    tlx.TlxServerComponent.Factory tlxServerComponentFactory();
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerModule.java
@@ -3,8 +3,10 @@ package judgels;
 import dagger.Module;
 import dagger.Provides;
 import java.nio.file.Path;
+import java.util.Optional;
 import judgels.app.JudgelsAppConfiguration;
 import judgels.service.JudgelsBaseDataDir;
+import tlx.user.registration.UserRegistrationConfiguration;
 
 @Module
 public class JudgelsServerModule {
@@ -23,5 +25,10 @@ public class JudgelsServerModule {
     @Provides
     JudgelsAppConfiguration appConfig() {
         return config.getAppConfig();
+    }
+
+    @Provides
+    Optional<UserRegistrationConfiguration> userRegistrationConfig() {
+        return config.getUserRegistrationConfig();
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/training/submission/bundle/TrainingItemSubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/training/submission/bundle/TrainingItemSubmissionModule.java
@@ -3,7 +3,6 @@ package judgels.training.submission.bundle;
 import dagger.Module;
 import dagger.Provides;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
-import jakarta.inject.Singleton;
 import judgels.persistence.dao.BundleItemSubmissionDao;
 import judgels.problem.ProblemService;
 import judgels.stats.StatsConfiguration;
@@ -14,6 +13,7 @@ import judgels.submission.bundle.ItemSubmissionRegradeProcessor;
 import judgels.submission.bundle.ItemSubmissionRegrader;
 import judgels.submission.bundle.ItemSubmissionStore;
 import judgels.submission.bundle.NoOpItemSubmissionConsumer;
+import tlx.TlxScope;
 
 @Module
 public class TrainingItemSubmissionModule {
@@ -24,20 +24,20 @@ public class TrainingItemSubmissionModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     ItemSubmissionConsumer itemSubmissionConsumer(StatsProcessor statsProcessor) {
         return statsConfig.getEnabled() ? statsProcessor : new NoOpItemSubmissionConsumer();
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingItemSubmissionStore
     static ItemSubmissionStore itemSubmissionStore(BundleItemSubmissionDao submissionDao) {
         return new BaseItemSubmissionStore<>(submissionDao);
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingItemSubmissionRegradeProcessor
     static ItemSubmissionRegradeProcessor itemSubmissionRegradeProcessor(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
@@ -61,7 +61,7 @@ public class TrainingItemSubmissionModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingItemSubmissionRegrader
     static ItemSubmissionRegrader itemSubmissionRegrader(
             @TrainingItemSubmissionStore ItemSubmissionStore itemSubmissionStore,

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/training/submission/programming/TrainingSubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/training/submission/programming/TrainingSubmissionModule.java
@@ -5,7 +5,6 @@ import dagger.Module;
 import dagger.Provides;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -30,6 +29,7 @@ import judgels.submission.programming.SubmissionRegrader;
 import judgels.submission.programming.SubmissionSourceBuilder;
 import judgels.submission.programming.SubmissionStore;
 import org.hibernate.SessionFactory;
+import tlx.TlxScope;
 
 @Module
 public class TrainingSubmissionModule {
@@ -47,14 +47,14 @@ public class TrainingSubmissionModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingSubmissionFs
     FileSystem submissionFs(@JudgelsBaseDataDir Path baseDataDir) {
         return fs.orElse(new LocalFileSystem(baseDataDir.resolve("submissions")));
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingSubmissionStore
     static SubmissionStore trainingSubmissionStore(
             TrainingProgrammingSubmissionDao submissionDao,
@@ -65,14 +65,14 @@ public class TrainingSubmissionModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingSubmissionSourceBuilder
     static SubmissionSourceBuilder submissionSourceBuilder(@TrainingSubmissionFs FileSystem submissionFs) {
         return new SubmissionSourceBuilder(submissionFs);
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingSubmissionClient
     static SubmissionClient submissionClient(
             SessionFactory sessionFactory,
@@ -92,7 +92,7 @@ public class TrainingSubmissionModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingSubmissionRegrader
     static SubmissionRegrader submissionRegrader(
             JudgelsScheduler scheduler,
@@ -108,7 +108,7 @@ public class TrainingSubmissionModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingGradingResponsePoller
     static GradingResponsePoller gradingResponsePoller(
             JudgelsScheduler scheduler,
@@ -125,7 +125,7 @@ public class TrainingSubmissionModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     @TrainingGradingResponseProcessor
     GradingResponseProcessor gradingResponseProcessor(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/TlxScope.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/TlxScope.java
@@ -1,0 +1,9 @@
+package tlx;
+
+import jakarta.inject.Scope;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TlxScope {}

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/TlxServerComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/TlxServerComponent.java
@@ -1,0 +1,69 @@
+package tlx;
+
+import dagger.Subcomponent;
+import judgels.submission.programming.GradingResponsePoller;
+import judgels.training.submission.bundle.TrainingItemSubmissionModule;
+import judgels.training.submission.programming.TrainingGradingResponsePoller;
+import judgels.training.submission.programming.TrainingSubmissionModule;
+import tlx.recaptcha.RecaptchaModule;
+import tlx.tasks.TlxTaskModule;
+import tlx.user.registration.UserRegistrationModule;
+
+@Subcomponent(modules = {
+        RecaptchaModule.class,
+        UserRegistrationModule.class,
+        TrainingSubmissionModule.class,
+        TrainingItemSubmissionModule.class,
+        TlxTaskModule.class})
+@TlxScope
+public interface TlxServerComponent {
+    @Subcomponent.Factory
+    interface Factory {
+        TlxServerComponent create(
+                RecaptchaModule recaptchaModule,
+                UserRegistrationModule userRegistrationModule,
+                TrainingSubmissionModule trainingSubmissionModule,
+                TrainingItemSubmissionModule trainingItemSubmissionModule);
+    }
+
+    // Users
+    tlx.session.SessionWithGoogleResource sessionWithGoogleResource();
+    tlx.user.account.UserAccountWithRegistrationResource userAccountWithRegistrationResource();
+    tlx.user.registration.web.UserRegistrationWebResource userRegistrationWebResource();
+
+    // Contests
+    tlx.contest.rating.ContestRatingResource contestRatingResource();
+    tlx.admin.contest.rating.ContestRatingAdminResource contestRatingAdminResource();
+    judgels.admin.user.rating.UserRatingAdminResource userRatingAdminResource();
+    tlx.tasks.ReplaceProblemTask tlxReplaceProblemTask();
+
+    // Training
+    tlx.archive.ArchiveResource archiveResource();
+    tlx.admin.archive.ArchiveAdminResource archiveAdminResource();
+    tlx.curriculum.CurriculumResource curriculumResource();
+    tlx.course.CourseResource courseResource();
+    tlx.admin.course.CourseAdminResource courseAdminResource();
+    tlx.chapter.ChapterResource chapterResource();
+    tlx.admin.chapter.ChapterAdminResource chapterAdminResource();
+    tlx.course.chapter.CourseChapterResource courseChapterResource();
+    tlx.admin.course.chapter.CourseChapterAdminResource courseChapterAdminResource();
+    tlx.chapter.lesson.ChapterLessonResource chapterLessonResource();
+    tlx.admin.chapter.lesson.ChapterLessonAdminResource chapterLessonAdminResource();
+    tlx.chapter.problem.ChapterProblemResource chapterProblemResource();
+    tlx.admin.chapter.problem.ChapterProblemAdminResource chapterProblemAdminResource();
+    tlx.problem.ProblemResource problemResource();
+    tlx.problem.ProblemTagResource problemTagResource();
+    tlx.problemset.ProblemSetResource problemSetResource();
+    tlx.admin.problemset.ProblemSetAdminResource problemSetAdminResource();
+    tlx.problemset.problem.ProblemSetProblemResource problemSetProblemResource();
+    tlx.admin.problemset.problem.ProblemSetProblemAdminResource problemSetProblemAdminResource();
+    tlx.submission.bundle.ItemSubmissionResource itemSubmissionResource();
+    tlx.submission.programming.SubmissionResource submissionResource();
+    tlx.stats.UserStatsResource userStatsResource();
+    @TrainingGradingResponsePoller GradingResponsePoller trainingGradingResponsePoller();
+    tlx.tasks.RefreshContestStatsTask refreshContestStatsTask();
+    tlx.tasks.RefreshProblemSetStatsTask refreshProblemSetStatsTask();
+    tlx.tasks.DeleteProblemTask tlxDeleteProblemTask();
+    tlx.tasks.MoveProblemToChapterTask tlxMoveProblemToChapterTask();
+    tlx.tasks.MoveProblemToProblemSetTask tlxMoveProblemToProblemSetTask();
+}

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/recaptcha/RecaptchaModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/recaptcha/RecaptchaModule.java
@@ -2,8 +2,8 @@ package tlx.recaptcha;
 
 import dagger.Module;
 import dagger.Provides;
-import jakarta.inject.Singleton;
 import java.util.Optional;
+import tlx.TlxScope;
 
 @Module
 public class RecaptchaModule {
@@ -18,7 +18,7 @@ public class RecaptchaModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     Optional<RecaptchaVerifier> recaptchaVerifier() {
         return config.map(c -> new RecaptchaVerifier(c.getSecretKey()));
     }

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/tasks/TlxTaskModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/tasks/TlxTaskModule.java
@@ -3,7 +3,6 @@ package tlx.tasks;
 import dagger.Module;
 import dagger.Provides;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
-import jakarta.inject.Singleton;
 import judgels.contest.submission.programming.ContestSubmissionStore;
 import judgels.persistence.dao.BundleItemSubmissionDao;
 import judgels.persistence.dao.ChapterDao;
@@ -21,13 +20,14 @@ import judgels.persistence.dao.TrainingProgrammingSubmissionDao;
 import judgels.submission.programming.SubmissionStore;
 import judgels.training.submission.programming.StatsProcessor;
 import judgels.training.submission.programming.TrainingSubmissionStore;
+import tlx.TlxScope;
 
 @Module
 public class TlxTaskModule {
     private TlxTaskModule() {}
 
     @Provides
-    @Singleton
+    @TlxScope
     static ReplaceProblemTask replaceProblemTask(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             ProblemDao problemDao,
@@ -53,7 +53,7 @@ public class TlxTaskModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     static DeleteProblemTask deleteProblemTask(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             ProblemDao problemDao,
@@ -85,7 +85,7 @@ public class TlxTaskModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     static MoveProblemToChapterTask moveProblemToChapterTask(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             ProblemDao problemDao,
@@ -111,7 +111,7 @@ public class TlxTaskModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     static MoveProblemToProblemSetTask moveProblemToProblemSetTask(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             ProblemDao problemDao,
@@ -137,7 +137,7 @@ public class TlxTaskModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     static RefreshContestStatsTask refreshContestStatsTask(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             @ContestSubmissionStore SubmissionStore submissionStore,
@@ -154,7 +154,7 @@ public class TlxTaskModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     static RefreshProblemSetStatsTask refreshProblemSetStatsTask(
             UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
             @TrainingSubmissionStore SubmissionStore submissionStore,

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/user/registration/UserRegistrationModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/user/registration/UserRegistrationModule.java
@@ -2,36 +2,25 @@ package tlx.user.registration;
 
 import dagger.Module;
 import dagger.Provides;
-import jakarta.inject.Singleton;
 import java.util.Optional;
 import judgels.mailer.Mailer;
 import judgels.user.UserStore;
 import judgels.user.info.UserInfoStore;
+import tlx.TlxScope;
 import tlx.auth.google.GoogleAuth;
 import tlx.recaptcha.RecaptchaVerifier;
 import tlx.user.registration.web.UserRegistrationWebConfig;
 
 @Module
 public class UserRegistrationModule {
-    private final Optional<UserRegistrationConfiguration> config;
     private final Optional<UserRegistrationWebConfig> webConfig;
 
     public UserRegistrationModule() {
-        this.config = Optional.empty();
         this.webConfig = Optional.empty();
     }
 
-    public UserRegistrationModule(
-            Optional<UserRegistrationConfiguration> config,
-            Optional<UserRegistrationWebConfig> webConfig) {
-
-        this.config = config;
+    public UserRegistrationModule(Optional<UserRegistrationWebConfig> webConfig) {
         this.webConfig = webConfig;
-    }
-
-    @Provides
-    Optional<UserRegistrationConfiguration> userRegistrationConfig() {
-        return config;
     }
 
     @Provides
@@ -40,8 +29,9 @@ public class UserRegistrationModule {
     }
 
     @Provides
-    @Singleton
+    @TlxScope
     Optional<UserRegisterer> userRegisterer(
+            Optional<UserRegistrationConfiguration> config,
             UserStore userStore,
             UserInfoStore userInfoStore,
             UserRegistrationEmailStore userRegistrationEmailStore,


### PR DESCRIPTION
## Summary

- New `tlx.TlxServerComponent` is a Dagger `@Subcomponent` (`@TlxScope`) of `JudgelsServerComponent`. It owns the TLX-only modules (`RecaptchaModule`, `UserRegistrationModule`, `TrainingSubmissionModule`, `TrainingItemSubmissionModule`, `TlxTaskModule`) and all the resources/tasks that were previously gated by `JudgelsApp.isTLX()` inside `runJudgelsServer`, plus the entire training stack.
- `JudgelsServerApplication.run()` becomes `runMichael` → `runJudgelsServer` → `if (isTLX()) runTlxServer(serverComponent, ...)`. The five `isTLX()` blocks inside `runJudgelsServer` collapse, and the AWS submission-FS override moves into `runTlxServer`.
- Two TLX-aware spots remain in the parent because non-TLX code injects across the seam:
  - `JudgelsServerModule` now provides `Optional<UserRegistrationConfiguration>` (used by `SessionResource`).
  - `ContestRatingModule` stays in `JudgelsServerComponent`; one `isTLX()` check in `runJudgelsServer` installs the `TlxContestRatingProvider` override, because `ContestContestantRoleChecker` injects `ContestRatingProvider`.

## Test plan

- [x] `./gradlew :judgels-server-app:compileJava :judgels-server-app:compileTestJava :judgels-server-app:compileIntegTestJava` passes
- [x] `./gradlew :judgels-server-app:checkstyleMain :judgels-server-app:checkstyleTest :judgels-server-app:checkstyleIntegTest` passes
- [ ] Smoke-test a TLX deployment (login with Google, registration, contest rating, training endpoints, refresh-stats tasks)
- [ ] Smoke-test a non-TLX deployment (no TLX endpoints registered, contest rating provider falls back to `JudgelsContestRatingProvider`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)