### PR TITLE
Refactor: move TLX registration check out of generic SessionResource

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/session/JudgelsSessionLoginValidator.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/session/JudgelsSessionLoginValidator.java
@@ -1,0 +1,8 @@
+package judgels.session;
+
+import judgels.api.user.User;
+
+public class JudgelsSessionLoginValidator implements SessionLoginValidator {
+    @Override
+    public void validate(User user) {}
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/session/SessionLoginValidator.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/session/SessionLoginValidator.java
@@ -1,0 +1,7 @@
+package judgels.session;
+
+import judgels.api.user.User;
+
+public interface SessionLoginValidator {
+    void validate(User user);
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/session/SessionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/session/SessionModule.java
@@ -5,6 +5,11 @@ import dagger.Provides;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import jakarta.inject.Singleton;
 import java.time.Clock;
+import java.util.Optional;
+import judgels.app.JudgelsApp;
+import tlx.session.TlxSessionLoginValidator;
+import tlx.user.registration.UserRegistrationConfiguration;
+import tlx.user.registration.UserRegistrationEmailStore;
 
 @Module
 public class SessionModule {
@@ -17,6 +22,15 @@ public class SessionModule {
     @Provides
     SessionConfiguration sessionConfig() {
         return this.config;
+    }
+
+    @Provides
+    SessionLoginValidator sessionLoginValidator(
+            Optional<UserRegistrationConfiguration> userRegistrationConfig,
+            UserRegistrationEmailStore userRegistrationEmailStore) {
+        return JudgelsApp.isTLX()
+                ? new TlxSessionLoginValidator(userRegistrationConfig, userRegistrationEmailStore)
+                : new JudgelsSessionLoginValidator();
     }
 
     @Provides

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/session/SessionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/session/SessionResource.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import java.util.Optional;
 import judgels.api.session.Credentials;
 import judgels.api.session.Session;
 import judgels.api.session.SessionErrors;
@@ -20,17 +19,13 @@ import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.user.UserRoleChecker;
 import judgels.user.UserStore;
-import tlx.api.session.SessionWithRegistrationErrors;
-import tlx.user.registration.UserRegistrationConfiguration;
-import tlx.user.registration.UserRegistrationEmailStore;
 
 @Path("/api/v2/session")
 public class SessionResource {
     @Inject protected ActorChecker actorChecker;
     @Inject protected UserRoleChecker roleChecker;
     @Inject protected UserStore userStore;
-    @Inject protected Optional<UserRegistrationConfiguration> userRegistrationConfig;
-    @Inject protected UserRegistrationEmailStore userRegistrationEmailStore;
+    @Inject protected SessionLoginValidator loginValidator;
     @Inject protected SessionStore sessionStore;
     @Inject protected SessionConfiguration sessionConfiguration;
 
@@ -47,11 +42,7 @@ public class SessionResource {
                     userStore.getUserByEmailAndPassword(credentials.getUsernameOrEmail(), credentials.getPassword())
                     .orElseThrow(ForbiddenException::new));
 
-        if (userRegistrationConfig.isPresent()) {
-            if (!userRegistrationEmailStore.isUserActivated(user.getJid())) {
-                throw SessionWithRegistrationErrors.userNotActivated(user.getEmail());
-            }
-        }
+        loginValidator.validate(user);
 
         if (!roleChecker.canAdminister(user.getJid())) {
             int maxConcurrentSessionsPerUser = sessionConfiguration.getMaxConcurrentSessionsPerUser();

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/session/TlxSessionLoginValidator.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/session/TlxSessionLoginValidator.java
@@ -1,0 +1,29 @@
+package tlx.session;
+
+import java.util.Optional;
+import judgels.api.user.User;
+import judgels.session.SessionLoginValidator;
+import tlx.api.session.SessionWithRegistrationErrors;
+import tlx.user.registration.UserRegistrationConfiguration;
+import tlx.user.registration.UserRegistrationEmailStore;
+
+public class TlxSessionLoginValidator implements SessionLoginValidator {
+    private final Optional<UserRegistrationConfiguration> userRegistrationConfig;
+    private final UserRegistrationEmailStore userRegistrationEmailStore;
+
+    public TlxSessionLoginValidator(
+            Optional<UserRegistrationConfiguration> userRegistrationConfig,
+            UserRegistrationEmailStore userRegistrationEmailStore) {
+        this.userRegistrationConfig = userRegistrationConfig;
+        this.userRegistrationEmailStore = userRegistrationEmailStore;
+    }
+
+    @Override
+    public void validate(User user) {
+        if (userRegistrationConfig.isPresent()) {
+            if (!userRegistrationEmailStore.isUserActivated(user.getJid())) {
+                throw SessionWithRegistrationErrors.userNotActivated(user.getEmail());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Generic `judgels.session.SessionResource` imported three `tlx.*` classes and embedded the TLX-only email-activation check directly in its login path — a TLX-boundary leak flagged in #930.
- Extract a generic `SessionLoginValidator` hook: no-op `JudgelsSessionLoginValidator` default + `TlxSessionLoginValidator` (owns the activation check and all `tlx.*` imports).
- The `isTLX()` switch is localized to `SessionModule`, mirroring the `ContestRatingProvider` convention (#931). `SessionResource` is now fully generic.

Behavior is preserved: FREE edition gets the no-op validator; TLX edition keeps the exact prior activation gate.

## Test plan
- [x] `./gradlew :judgels-server-app:compileJava :judgels-server-app:checkstyleMain` passes (Dagger binding resolves)
- [x] `SessionResource.java` has no remaining `tlx.` references
- [ ] Session login integration test (unactivated user under TLX) still blocks login

🤖 Generated with [Claude Code](https://claude.com/claude-code)