### PR TITLE
Refactor: merge judgels.admin.* packages into non-admin counterparts

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
@@ -51,13 +51,13 @@ public interface JudgelsServerComponent {
     judgels.session.SessionResource sessionResource();
     judgels.user.superadmin.SuperadminCreator superadminCreator();
     judgels.user.UserResource userResource();
-    judgels.admin.user.UserAdminResource userAdminResource();
+    judgels.user.UserAdminResource userAdminResource();
     judgels.user.account.UserAccountResource userAccountResource();
     judgels.user.avatar.UserAvatarResource userAvatarResource();
     judgels.user.info.UserInfoResource userProfileResource();
-    judgels.admin.user.info.UserInfoAdminResource userInfoAdminResource();
+    judgels.user.info.UserInfoAdminResource userInfoAdminResource();
     judgels.user.rating.UserRatingResource userRatingResource();
-    judgels.admin.user.role.UserRoleAdminResource userRoleAdminResource();
+    judgels.user.role.UserRoleAdminResource userRoleAdminResource();
     judgels.user.search.UserSearchResource userSearchResource();
     judgels.user.web.UserWebResource userWebResource();
     judgels.session.SessionCleaner sessionCleaner();
@@ -70,7 +70,7 @@ public interface JudgelsServerComponent {
 
     // Contests
     judgels.contest.ContestResource contestResource();
-    judgels.admin.contest.ContestAdminResource contestAdminResource();
+    judgels.contest.ContestAdminResource contestAdminResource();
     judgels.contest.web.ContestWebResource contestWebResource();
     judgels.contest.announcement.ContestAnnouncementResource contestAnnouncementResource();
     judgels.contest.clarification.ContestClarificationResource contestClarificationResource();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/ContestAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/ContestAdminResource.java
@@ -1,8 +1,7 @@
-package judgels.admin.contest;
+package judgels.contest;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import judgels.contest.ContestResource;
 
 @Path("/api/v2/admin/contests")
 public class ContestAdminResource extends ContestResource {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/user/UserAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/user/UserAdminResource.java
@@ -1,4 +1,4 @@
-package judgels.admin.user;
+package judgels.user;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -31,9 +31,6 @@ import judgels.persistence.api.Page;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.session.SessionStore;
-import judgels.user.UserCreator;
-import judgels.user.UserRoleChecker;
-import judgels.user.UserStore;
 
 @Path("/api/v2/admin/users")
 public class UserAdminResource {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/user/info/UserInfoAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/user/info/UserInfoAdminResource.java
@@ -1,4 +1,4 @@
-package judgels.admin.user.info;
+package judgels.user.info;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -20,7 +20,6 @@ import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.user.UserRoleChecker;
 import judgels.user.UserStore;
-import judgels.user.info.UserInfoStore;
 
 @Path("/api/v2/admin/users/{userJid}/info")
 public class UserInfoAdminResource {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/user/role/UserRoleAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/user/role/UserRoleAdminResource.java
@@ -1,4 +1,4 @@
-package judgels.admin.user.role;
+package judgels.user.role;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -25,7 +25,6 @@ import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import judgels.user.UserRoleChecker;
 import judgels.user.UserStore;
-import judgels.user.role.UserRoleStore;
 
 @Path("/api/v2/admin/user-roles")
 public class UserRoleAdminResource {


### PR DESCRIPTION
## Summary
- Move the four `*AdminResource` classes out of the `judgels.admin` package tree into their corresponding domain packages:
  - `judgels.admin.contest.ContestAdminResource` → `judgels.contest.ContestAdminResource`
  - `judgels.admin.user.UserAdminResource` → `judgels.user.UserAdminResource`
  - `judgels.admin.user.info.UserInfoAdminResource` → `judgels.user.info.UserInfoAdminResource`
  - `judgels.admin.user.role.UserRoleAdminResource` → `judgels.user.role.UserRoleAdminResource`
- Drop the now-redundant same-package imports and update the references in `JudgelsServerComponent`.

## Test plan
- [x] `./gradlew :judgels-server-app:compileJava :judgels-server-app:checkstyleMain` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)