### PR TITLE
Refactor: merge tlx.admin.* packages into non-admin counterparts

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/tlx/TlxServerComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/TlxServerComponent.java
@@ -33,30 +33,30 @@ public interface TlxServerComponent {
 
     // Contests
     tlx.contest.rating.ContestRatingResource contestRatingResource();
-    tlx.admin.contest.rating.ContestRatingAdminResource contestRatingAdminResource();
-    tlx.admin.user.rating.UserRatingAdminResource userRatingAdminResource();
+    tlx.contest.rating.ContestRatingAdminResource contestRatingAdminResource();
+    tlx.user.rating.UserRatingAdminResource userRatingAdminResource();
     tlx.tasks.ReplaceProblemTask tlxReplaceProblemTask();
 
     // Training
     tlx.archive.ArchiveResource archiveResource();
-    tlx.admin.archive.ArchiveAdminResource archiveAdminResource();
+    tlx.archive.ArchiveAdminResource archiveAdminResource();
     tlx.curriculum.CurriculumResource curriculumResource();
     tlx.course.CourseResource courseResource();
-    tlx.admin.course.CourseAdminResource courseAdminResource();
+    tlx.course.CourseAdminResource courseAdminResource();
     tlx.chapter.ChapterResource chapterResource();
-    tlx.admin.chapter.ChapterAdminResource chapterAdminResource();
+    tlx.chapter.ChapterAdminResource chapterAdminResource();
     tlx.course.chapter.CourseChapterResource courseChapterResource();
-    tlx.admin.course.chapter.CourseChapterAdminResource courseChapterAdminResource();
+    tlx.course.chapter.CourseChapterAdminResource courseChapterAdminResource();
     tlx.chapter.lesson.ChapterLessonResource chapterLessonResource();
-    tlx.admin.chapter.lesson.ChapterLessonAdminResource chapterLessonAdminResource();
+    tlx.chapter.lesson.ChapterLessonAdminResource chapterLessonAdminResource();
     tlx.chapter.problem.ChapterProblemResource chapterProblemResource();
-    tlx.admin.chapter.problem.ChapterProblemAdminResource chapterProblemAdminResource();
+    tlx.chapter.problem.ChapterProblemAdminResource chapterProblemAdminResource();
     tlx.problem.ProblemResource problemResource();
     tlx.problem.ProblemTagResource problemTagResource();
     tlx.problemset.ProblemSetResource problemSetResource();
-    tlx.admin.problemset.ProblemSetAdminResource problemSetAdminResource();
+    tlx.problemset.ProblemSetAdminResource problemSetAdminResource();
     tlx.problemset.problem.ProblemSetProblemResource problemSetProblemResource();
-    tlx.admin.problemset.problem.ProblemSetProblemAdminResource problemSetProblemAdminResource();
+    tlx.problemset.problem.ProblemSetProblemAdminResource problemSetProblemAdminResource();
     tlx.submission.bundle.ItemSubmissionResource itemSubmissionResource();
     tlx.submission.programming.SubmissionResource submissionResource();
     tlx.stats.UserStatsResource userStatsResource();

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/archive/ArchiveAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/archive/ArchiveAdminResource.java
@@ -1,8 +1,7 @@
-package tlx.admin.archive;
+package tlx.archive;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import tlx.archive.ArchiveResource;
 
 @Path("/api/v2/admin/archives")
 public class ArchiveAdminResource extends ArchiveResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/chapter/ChapterAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/chapter/ChapterAdminResource.java
@@ -1,8 +1,7 @@
-package tlx.admin.chapter;
+package tlx.chapter;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import tlx.chapter.ChapterResource;
 
 @Path("/api/v2/admin/chapters")
 public class ChapterAdminResource extends ChapterResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/chapter/lesson/ChapterLessonAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/chapter/lesson/ChapterLessonAdminResource.java
@@ -1,8 +1,7 @@
-package tlx.admin.chapter.lesson;
+package tlx.chapter.lesson;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import tlx.chapter.lesson.ChapterLessonResource;
 
 @Path("/api/v2/admin/chapters/{chapterJid}/lessons")
 public class ChapterLessonAdminResource extends ChapterLessonResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/chapter/problem/ChapterProblemAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/chapter/problem/ChapterProblemAdminResource.java
@@ -1,8 +1,7 @@
-package tlx.admin.chapter.problem;
+package tlx.chapter.problem;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import tlx.chapter.problem.ChapterProblemResource;
 
 @Path("/api/v2/admin/chapters/{chapterJid}/problems")
 public class ChapterProblemAdminResource extends ChapterProblemResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/contest/rating/ContestRatingAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/contest/rating/ContestRatingAdminResource.java
@@ -1,8 +1,7 @@
-package tlx.admin.contest.rating;
+package tlx.contest.rating;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import tlx.contest.rating.ContestRatingResource;
 
 @Path("/api/v2/admin/contest-rating")
 public class ContestRatingAdminResource extends ContestRatingResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/course/CourseAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/course/CourseAdminResource.java
@@ -1,8 +1,7 @@
-package tlx.admin.course;
+package tlx.course;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import tlx.course.CourseResource;
 
 @Path("/api/v2/admin/courses")
 public class CourseAdminResource extends CourseResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/course/chapter/CourseChapterAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/course/chapter/CourseChapterAdminResource.java
@@ -1,8 +1,7 @@
-package tlx.admin.course.chapter;
+package tlx.course.chapter;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import tlx.course.chapter.CourseChapterResource;
 
 @Path("/api/v2/admin/courses/{courseJid}/chapters")
 public class CourseChapterAdminResource extends CourseChapterResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/problemset/ProblemSetAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/problemset/ProblemSetAdminResource.java
@@ -1,8 +1,7 @@
-package tlx.admin.problemset;
+package tlx.problemset;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import tlx.problemset.ProblemSetResource;
 
 @Path("/api/v2/admin/problemsets")
 public class ProblemSetAdminResource extends ProblemSetResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/problemset/problem/ProblemSetProblemAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/problemset/problem/ProblemSetProblemAdminResource.java
@@ -1,8 +1,7 @@
-package tlx.admin.problemset.problem;
+package tlx.problemset.problem;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;
-import tlx.problemset.problem.ProblemSetProblemResource;
 
 @Path("/api/v2/admin/problemsets/{problemSetJid}/problems")
 public class ProblemSetProblemAdminResource extends ProblemSetProblemResource {

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/user/rating/UserRatingAdminResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/user/rating/UserRatingAdminResource.java
@@ -1,4 +1,4 @@
-package tlx.admin.user.rating;
+package tlx.user.rating;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Path;


### PR DESCRIPTION
## Summary
- Move the ten `*AdminResource` classes out of the `tlx.admin` package tree into their corresponding domain packages:
  - `tlx.admin.archive.ArchiveAdminResource` → `tlx.archive.ArchiveAdminResource`
  - `tlx.admin.chapter.ChapterAdminResource` → `tlx.chapter.ChapterAdminResource`
  - `tlx.admin.chapter.lesson.ChapterLessonAdminResource` → `tlx.chapter.lesson.ChapterLessonAdminResource`
  - `tlx.admin.chapter.problem.ChapterProblemAdminResource` → `tlx.chapter.problem.ChapterProblemAdminResource`
  - `tlx.admin.contest.rating.ContestRatingAdminResource` → `tlx.contest.rating.ContestRatingAdminResource`
  - `tlx.admin.course.CourseAdminResource` → `tlx.course.CourseAdminResource`
  - `tlx.admin.course.chapter.CourseChapterAdminResource` → `tlx.course.chapter.CourseChapterAdminResource`
  - `tlx.admin.problemset.ProblemSetAdminResource` → `tlx.problemset.ProblemSetAdminResource`
  - `tlx.admin.problemset.problem.ProblemSetProblemAdminResource` → `tlx.problemset.problem.ProblemSetProblemAdminResource`
  - `tlx.admin.user.rating.UserRatingAdminResource` → `tlx.user.rating.UserRatingAdminResource`
- Drop the now-redundant same-package imports and update the references in `TlxServerComponent`.

Follow-up to #933, which did the same for `judgels.admin.*`.

## Test plan
- [x] `./gradlew :judgels-server-app:compileJava :judgels-server-app:checkstyleMain` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)