### PR TITLE
Refactor: move judgels.difficulty (ProblemDifficultyStore) into tlx

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/tlx/difficulty/ProblemDifficultyStore.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/difficulty/ProblemDifficultyStore.java
@@ -1,4 +1,4 @@
-package judgels.difficulty;
+package tlx.difficulty;
 
 import jakarta.inject.Inject;
 import java.util.Collection;

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/problem/ProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/problem/ProblemResource.java
@@ -14,13 +14,13 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import java.util.Optional;
 import java.util.Set;
-import judgels.difficulty.ProblemDifficultyStore;
 import judgels.persistence.api.Page;
 import judgels.problem.ProblemService;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
 import tlx.api.problem.ProblemSetProblemInfo;
 import tlx.api.problem.ProblemsResponse;
+import tlx.difficulty.ProblemDifficultyStore;
 import tlx.stats.StatsStore;
 
 @Path("/api/v2/problems")

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/problemset/problem/ProblemSetProblemResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/problemset/problem/ProblemSetProblemResource.java
@@ -38,7 +38,6 @@ import judgels.api.problem.ProblemTopStats;
 import judgels.api.problem.ProblemType;
 import judgels.api.profile.Profile;
 import judgels.contest.ContestStore;
-import judgels.difficulty.ProblemDifficultyStore;
 import judgels.problem.ProblemService;
 import judgels.problemset.ProblemSetStore;
 import judgels.problemset.problem.ProblemSetProblemStore;
@@ -53,6 +52,7 @@ import tlx.api.problemset.problem.ProblemSetProblem;
 import tlx.api.problemset.problem.ProblemSetProblemData;
 import tlx.api.problemset.problem.ProblemSetProblemWorksheet;
 import tlx.api.problemset.problem.ProblemSetProblemsResponse;
+import tlx.difficulty.ProblemDifficultyStore;
 import tlx.stats.StatsStore;
 
 @Path("/api/v2/problemsets/{problemSetJid}/problems")


### PR DESCRIPTION
Continues the TLX extraction. Moves the TLX-specific `ProblemDifficultyStore` out of `judgels.difficulty` into `tlx`:

- `judgels.difficulty.ProblemDifficultyStore` → `tlx.difficulty.ProblemDifficultyStore` (empties `judgels.difficulty`)

Importers (`ProblemResource`, `ProblemSetProblemResource`) updated and imports re-sorted.

> Stacked on top of #938. Base will retarget to `master` once #938 merges.

## Verification
- `:judgels-server-api:compileJava` + `:judgels-server-app:compileJava` + `compileTestJava` + `compileIntegTestJava` pass
- checkstyle (server-api main, server-app main/test/integTest) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)