### PR TITLE
Fix: give each subsystem its own grading response queue

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/submission/programming/ContestSubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/submission/programming/ContestSubmissionModule.java
@@ -94,7 +94,7 @@ public class ContestSubmissionModule {
                 sessionFactory,
                 submissionStore,
                 gradingRequestQueueName,
-                gradingResponseQueueName,
+                gradingResponseQueueName + "-contest",
                 messageClient,
                 mapper);
     }
@@ -134,7 +134,7 @@ public class ContestSubmissionModule {
         ExecutorService executorService = scheduler.createExecutorService("contest-grading-response-processor-%d", 10);
         return new GradingResponsePoller(
                 messageListener,
-                gradingResponseQueueName,
+                gradingResponseQueueName + "-contest",
                 (ThreadPoolExecutor) executorService,
                 processor);
     }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/submission/SubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/submission/SubmissionModule.java
@@ -70,7 +70,7 @@ public class SubmissionModule {
                 sessionFactory,
                 submissionStore,
                 gradingRequestQueueName,
-                gradingResponseQueueName,
+                gradingResponseQueueName + "-problem",
                 messageClient,
                 mapper);
     }
@@ -101,7 +101,7 @@ public class SubmissionModule {
         ExecutorService executorService = scheduler.createExecutorService("problem-grading-response-processor-%d", 10);
         return new GradingResponsePoller(
                 messageListener,
-                gradingResponseQueueName,
+                gradingResponseQueueName + "-problem",
                 (ThreadPoolExecutor) executorService,
                 processor);
     }

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/training/submission/programming/TrainingSubmissionModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/training/submission/programming/TrainingSubmissionModule.java
@@ -86,7 +86,7 @@ public class TrainingSubmissionModule {
                 sessionFactory,
                 submissionStore,
                 gradingRequestQueueName,
-                gradingResponseQueueName,
+                gradingResponseQueueName + "-training",
                 messageClient,
                 mapper);
     }
@@ -119,7 +119,7 @@ public class TrainingSubmissionModule {
         ExecutorService executorService = scheduler.createExecutorService("training-grading-response-processor-%d", 10);
         return new GradingResponsePoller(
                 messageListener,
-                gradingResponseQueueName,
+                gradingResponseQueueName + "-training",
                 (ThreadPoolExecutor) executorService,
                 processor);
     }


### PR DESCRIPTION
## Problem

The v2 consolidation (#910 and the surrounding de-archangel work) merged the formerly separate **Sandalphon / Uriel / Jerahmeel** apps into one process, sharing a single `gradingResponseQueueName` (`judgels-grading-response`).

As a result, all three grading response pollers — problem, contest, training — consume the **same** RabbitMQ queue as **competing consumers**. RabbitMQ delivers each response to exactly one of them, and the payload carries no submission-type discriminator. Each poller only resolves grading JIDs in its own table (`sandalphon_*` / `uriel_*` / `jerahmeel_*`), so when the "wrong" poller picks up a response:

- `updateGrading` returns empty → `GradingResponseProcessor` logs `Failed to find grading jid` and returns normally
- the message is **acked and dropped** (never requeued)

→ roughly **2 out of 3 grading responses are silently lost**, leaving submissions stuck `PENDING`.

In the old multi-process world this worked because each app ran as its own JVM with its own config, hence a distinct response queue. The single global config collapsed those into one queue. (Not yet deployed, so caught before it bit production.)

## Fix

Give each subsystem its own response queue by suffixing the configured name with `-problem` / `-contest` / `-training`. Each `SubmissionClient` stamps its requests with its own reply-to queue, and each poller listens on the matching queue, so the grader routes every response back to the correct poller.

```
request  (shared):  judgels-grading-request
responses:          judgels-grading-response-problem
                    judgels-grading-response-contest
                    judgels-grading-response-training
```

`getGradingResponseQueueName()` is now effectively a **prefix**; the suffix is hardcoded next to each `new SubmissionClient(...)` / `new GradingResponsePoller(...)` so the client/poller pair can't drift apart. The shared request queue and the grader are untouched. New queues auto-declare on first use.

## Test plan

- [x] `:judgels-server-app:compileJava`
- [x] `:judgels-server-app:checkstyleMain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)