### PR TITLE
Refactor: reorder server resource registrations and group schedulers

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
@@ -125,9 +125,7 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
 
         component.superadminCreator().ensureSuperadminExists();
 
-        // Users
         env.jersey().register(component.sessionResource());
-        env.jersey().register(component.profileResource());
         env.jersey().register(component.userResource());
         env.jersey().register(component.userAvatarResource());
         env.jersey().register(component.userProfileResource());
@@ -135,19 +133,11 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
         env.jersey().register(component.userRoleResource());
         env.jersey().register(component.userSearchResource());
         env.jersey().register(component.userWebResource());
-
-        component.scheduler().scheduleWithFixedDelay(
-                "session-cleaner",
-                component.sessionCleaner(),
-                Duration.ofDays(1));
+        env.jersey().register(component.profileResource());
 
         env.jersey().register(component.problemResource());
         env.jersey().register(component.problemTagResource());
         env.jersey().register(component.lessonResource());
-
-        if (judgelsConfig.getRabbitMQConfig().isPresent()) {
-            env.lifecycle().manage(component.problemGradingResponsePoller());
-        }
 
         env.jersey().register(component.contestResource());
         env.jersey().register(component.contestWebResource());
@@ -162,9 +152,14 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
         env.jersey().register(component.contestModuleResource());
         env.jersey().register(component.contestProblemResource());
         env.jersey().register(component.contestScoreboardResource());
-        env.jersey().register(component.contestProgrammingSubmissionResource());
-        env.jersey().register(component.contestBundleSubmissionResource());
+        env.jersey().register(component.contestSubmissionResource());
+        env.jersey().register(component.contestItemSubmissionResource());
         env.jersey().register(component.contestSupervisorResource());
+
+        component.scheduler().scheduleWithFixedDelay(
+                "session-cleaner",
+                component.sessionCleaner(),
+                Duration.ofDays(1));
 
         component.scheduler().scheduleWithFixedDelay(
                 "contest-scoreboard-poller",
@@ -177,6 +172,7 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
                 Duration.ofSeconds(3));
 
         if (judgelsConfig.getRabbitMQConfig().isPresent()) {
+            env.lifecycle().manage(component.problemGradingResponsePoller());
             env.lifecycle().manage(component.contestGradingResponsePoller());
         }
 
@@ -215,9 +211,9 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
         env.jersey().register(component.sessionResource());
         env.jersey().register(component.userAccountResource());
         env.jersey().register(component.userRegistrationWebResource());
+        env.jersey().register(component.userRatingResource());
 
         env.jersey().register(component.contestRatingResource());
-        env.jersey().register(component.userRatingResource());
 
         env.jersey().register(component.archiveResource());
         env.jersey().register(component.curriculumResource());

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
@@ -37,7 +37,6 @@ import judgels.submission.programming.GradingResponsePoller;
         tlx.auth.AuthModule.class})
 @Singleton
 public interface JudgelsServerComponent {
-    judgels.profile.ProfileResource profileResource();
     judgels.session.SessionResource sessionResource();
     judgels.user.superadmin.SuperadminCreator superadminCreator();
     judgels.user.UserResource userResource();
@@ -47,12 +46,11 @@ public interface JudgelsServerComponent {
     judgels.user.role.UserRoleResource userRoleResource();
     judgels.user.search.UserSearchResource userSearchResource();
     judgels.user.web.UserWebResource userWebResource();
-    judgels.session.SessionCleaner sessionCleaner();
+    judgels.profile.ProfileResource profileResource();
 
     judgels.problem.base.ProblemResource problemResource();
     judgels.problem.ProblemTagResource problemTagResource();
     judgels.lesson.LessonResource lessonResource();
-    GradingResponsePoller problemGradingResponsePoller();
 
     judgels.contest.ContestResource contestResource();
     judgels.contest.web.ContestWebResource contestWebResource();
@@ -67,11 +65,14 @@ public interface JudgelsServerComponent {
     judgels.contest.module.ContestModuleResource contestModuleResource();
     judgels.contest.problem.ContestProblemResource contestProblemResource();
     judgels.contest.scoreboard.ContestScoreboardResource contestScoreboardResource();
-    judgels.contest.submission.programming.ContestSubmissionResource contestProgrammingSubmissionResource();
-    judgels.contest.submission.bundle.ContestItemSubmissionResource contestBundleSubmissionResource();
+    judgels.contest.submission.programming.ContestSubmissionResource contestSubmissionResource();
+    judgels.contest.submission.bundle.ContestItemSubmissionResource contestItemSubmissionResource();
     judgels.contest.supervisor.ContestSupervisorResource contestSupervisorResource();
     judgels.contest.log.ContestLogPoller contestLogPoller();
     judgels.contest.scoreboard.ContestScoreboardPoller contestScoreboardPoller();
+
+    judgels.session.SessionCleaner sessionCleaner();
+    GradingResponsePoller problemGradingResponsePoller();
     @ContestGradingResponsePoller GradingResponsePoller contestGradingResponsePoller();
 
     judgels.tasks.DumpContestTask dumpContestTask();


### PR DESCRIPTION
Pure reorganization of `JudgelsServerApplication` and `JudgelsServerComponent`, no behavior change:

- Rename `contestProgrammingSubmissionResource()` → `contestSubmissionResource()` and `contestBundleSubmissionResource()` → `contestItemSubmissionResource()`.
- Move `profileResource()` next to the other user resources.
- Group the `session-cleaner` scheduler and `problemGradingResponsePoller` together with the other schedulers/pollers (the poller now lives in the shared RabbitMQ lifecycle block alongside `contestGradingResponsePoller`).
- Move `userRatingResource()` next to the other rating-related registrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)