### PR TITLE
BREAKING: Add nested admin menus and rename user roles

### DIFF
--- a/judgels-backends/judgels-server-api/src/main/java/judgels/api/user/role/UserRole.java
+++ b/judgels-backends/judgels-server-api/src/main/java/judgels/api/user/role/UserRole.java
@@ -7,10 +7,10 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(as = ImmutableUserRole.class)
 public interface UserRole {
-    Optional<String> getJophiel();
-    Optional<String> getSandalphon();
-    Optional<String> getUriel();
-    Optional<String> getJerahmeel();
+    Optional<String> getAccount();
+    Optional<String> getProblem();
+    Optional<String> getContest();
+    Optional<String> getTraining();
 
     class Builder extends ImmutableUserRole.Builder {}
 }

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/BaseJudgelsApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/BaseJudgelsApiIntegrationTests.java
@@ -151,10 +151,10 @@ public abstract class BaseJudgelsApiIntegrationTests extends BaseJudgelsAppInteg
         admin = createUser("admin");
         adminToken = getToken(admin);
         createClient(UserRoleClient.class).setUserRoles(superadminToken, Map.of("admin", new UserRole.Builder()
-                .jophiel("ADMIN")
-                .sandalphon("ADMIN")
-                .uriel("ADMIN")
-                .jerahmeel("ADMIN")
+                .account("ADMIN")
+                .problem("ADMIN")
+                .contest("ADMIN")
+                .training("ADMIN")
                 .build()));
 
         user = createUser("user");

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserRoleApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserRoleApiIntegrationTests.java
@@ -22,45 +22,45 @@ public class UserRoleApiIntegrationTests extends BaseJudgelsApiIntegrationTests 
         assertThat(userRoleClient.getUserRoles(adminToken).getData()).containsOnly(
                 new UserWithRole.Builder()
                         .userJid(admin.getJid())
-                        .role(new UserRole.Builder().jophiel("ADMIN").sandalphon("ADMIN").uriel("ADMIN").jerahmeel("ADMIN").build())
+                        .role(new UserRole.Builder().account("ADMIN").problem("ADMIN").contest("ADMIN").training("ADMIN").build())
                         .build());
 
         userRoleClient.setUserRoles(adminToken, Map.of(
-                "admin", new UserRole.Builder().jophiel("ADMIN").sandalphon("ADMIN").uriel("ADMIN").jerahmeel("ADMIN").build(),
-                "andi", new UserRole.Builder().uriel("ADMIN").build(),
-                "budi", new UserRole.Builder().uriel("ADMIN").jerahmeel("ADMIN").build()));
+                "admin", new UserRole.Builder().account("ADMIN").problem("ADMIN").contest("ADMIN").training("ADMIN").build(),
+                "andi", new UserRole.Builder().contest("ADMIN").build(),
+                "budi", new UserRole.Builder().contest("ADMIN").training("ADMIN").build()));
 
         assertThat(userRoleClient.getUserRoles(adminToken).getData()).containsOnly(
                 new UserWithRole.Builder()
                         .userJid(admin.getJid())
-                        .role(new UserRole.Builder().jophiel("ADMIN").sandalphon("ADMIN").uriel("ADMIN").jerahmeel("ADMIN").build())
+                        .role(new UserRole.Builder().account("ADMIN").problem("ADMIN").contest("ADMIN").training("ADMIN").build())
                         .build(),
                 new UserWithRole.Builder()
                         .userJid(andi.getJid())
-                        .role(new UserRole.Builder().uriel("ADMIN").build())
+                        .role(new UserRole.Builder().contest("ADMIN").build())
                         .build(),
                 new UserWithRole.Builder()
                         .userJid(budi.getJid())
-                        .role(new UserRole.Builder().uriel("ADMIN").jerahmeel("ADMIN").build())
+                        .role(new UserRole.Builder().contest("ADMIN").training("ADMIN").build())
                         .build());
 
         userRoleClient.setUserRoles(adminToken, Map.of(
-                "admin", new UserRole.Builder().jophiel("ADMIN").sandalphon("ADMIN").uriel("ADMIN").jerahmeel("ADMIN").build(),
-                "budi", new UserRole.Builder().sandalphon("ADMIN").build(),
-                "caca", new UserRole.Builder().jophiel("ADMIN").build()));
+                "admin", new UserRole.Builder().account("ADMIN").problem("ADMIN").contest("ADMIN").training("ADMIN").build(),
+                "budi", new UserRole.Builder().problem("ADMIN").build(),
+                "caca", new UserRole.Builder().account("ADMIN").build()));
 
         assertThat(userRoleClient.getUserRoles(adminToken).getData()).containsOnly(
                 new UserWithRole.Builder()
                         .userJid(admin.getJid())
-                        .role(new UserRole.Builder().jophiel("ADMIN").sandalphon("ADMIN").uriel("ADMIN").jerahmeel("ADMIN").build())
+                        .role(new UserRole.Builder().account("ADMIN").problem("ADMIN").contest("ADMIN").training("ADMIN").build())
                         .build(),
                 new UserWithRole.Builder()
                         .userJid(budi.getJid())
-                        .role(new UserRole.Builder().sandalphon("ADMIN").build())
+                        .role(new UserRole.Builder().problem("ADMIN").build())
                         .build(),
                 new UserWithRole.Builder()
                         .userJid(caca.getJid())
-                        .role(new UserRole.Builder().jophiel("ADMIN").build())
+                        .role(new UserRole.Builder().account("ADMIN").build())
                         .build());
     }
 }

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserRoleApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserRoleApiPermissionIntegrationTests.java
@@ -20,6 +20,6 @@ public class UserRoleApiPermissionIntegrationTests extends BaseJudgelsApiIntegra
     private ThrowingCallable getSetRoles(String token) {
         return callAll(
                 () -> userRoleClient.getUserRoles(token),
-                () -> userRoleClient.setUserRoles(token, Map.of("admin", new UserRole.Builder().jophiel("ADMIN").build())));
+                () -> userRoleClient.setUserRoles(token, Map.of("admin", new UserRole.Builder().account("ADMIN").build())));
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/michael/account/role/RoleResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/michael/account/role/RoleResource.java
@@ -120,10 +120,10 @@ public class RoleResource extends BaseAccountResource {
         for (UserWithRole userWithRole : userWithRoles) {
             List<String> row = new ArrayList<>();
             row.add(profilesMap.get(userWithRole.getUserJid()).getUsername());
-            row.add(userWithRole.getRole().getJophiel().orElse(""));
-            row.add(userWithRole.getRole().getSandalphon().orElse(""));
-            row.add(userWithRole.getRole().getUriel().orElse(""));
-            row.add(userWithRole.getRole().getJerahmeel().orElse(""));
+            row.add(userWithRole.getRole().getAccount().orElse(""));
+            row.add(userWithRole.getRole().getProblem().orElse(""));
+            row.add(userWithRole.getRole().getContest().orElse(""));
+            row.add(userWithRole.getRole().getTraining().orElse(""));
             rows.add(String.join(",", row));
         }
         return String.join("\r\n", rows);
@@ -159,37 +159,37 @@ public class RoleResource extends BaseAccountResource {
 
             UserRole.Builder role = new UserRole.Builder();
 
-            String jophiel = tokens[1].trim();
-            if (!jophiel.isEmpty()) {
-                if (jophiel.equals("ADMIN")) {
-                    role.jophiel(jophiel);
+            String account = tokens[1].trim();
+            if (!account.isEmpty()) {
+                if (account.equals("ADMIN")) {
+                    role.account(account);
                 } else {
                     return Optional.empty();
                 }
             }
 
-            String sandalphon = tokens[2].trim();
-            if (!sandalphon.isEmpty()) {
-                if (sandalphon.equals("ADMIN")) {
-                    role.sandalphon(sandalphon);
+            String problem = tokens[2].trim();
+            if (!problem.isEmpty()) {
+                if (problem.equals("ADMIN")) {
+                    role.problem(problem);
                 } else {
                     return Optional.empty();
                 }
             }
 
-            String uriel = tokens[3].trim();
-            if (!uriel.isEmpty()) {
-                if (uriel.equals("ADMIN")) {
-                    role.uriel(uriel);
+            String contest = tokens[3].trim();
+            if (!contest.isEmpty()) {
+                if (contest.equals("ADMIN")) {
+                    role.contest(contest);
                 } else {
                     return Optional.empty();
                 }
             }
 
-            String jerahmeel = tokens[4].trim();
-            if (!jerahmeel.isEmpty()) {
-                if (jerahmeel.equals("ADMIN")) {
-                    role.jerahmeel(jerahmeel);
+            String training = tokens[4].trim();
+            if (!training.isEmpty()) {
+                if (training.equals("ADMIN")) {
+                    role.training(training);
                 } else {
                     return Optional.empty();
                 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/role/ContestAdminRoleChecker.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/role/ContestAdminRoleChecker.java
@@ -17,6 +17,6 @@ public class ContestAdminRoleChecker {
 
     public boolean isAdmin(String userJid) {
         UserRole role = userRoleStore.getRole(userJid);
-        return role.getUriel().orElse("").equals(ContestAdminRole.ADMIN.name());
+        return role.getContest().orElse("").equals(ContestAdminRole.ADMIN.name());
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/role/ProblemAdminRoleChecker.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/role/ProblemAdminRoleChecker.java
@@ -15,12 +15,12 @@ public class ProblemAdminRoleChecker {
     }
 
     public boolean isAdmin(Actor actor) {
-        return actor.getRole().getSandalphon().orElse("").equals(ProblemAdminRole.ADMIN.name());
+        return actor.getRole().getProblem().orElse("").equals(ProblemAdminRole.ADMIN.name());
     }
 
     public boolean isAdmin(String userJid) {
         UserRole role = userRoleStore.getRole(userJid);
-        return role.getSandalphon().orElse("").equals(ProblemAdminRole.ADMIN.name());
+        return role.getProblem().orElse("").equals(ProblemAdminRole.ADMIN.name());
     }
 
     public boolean isWriter(Actor actor) {

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/user/UserRoleChecker.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/user/UserRoleChecker.java
@@ -15,16 +15,16 @@ public class UserRoleChecker {
 
     public boolean canAdminister(String actorJid) {
         UserRole role = userRoleStore.getRole(actorJid);
-        String jophielRole = role.getJophiel().orElse("");
-        return jophielRole.equals(UserAdminRole.SUPERADMIN.name())
-                || jophielRole.equals(UserAdminRole.ADMIN.name());
+        String accountRole = role.getAccount().orElse("");
+        return accountRole.equals(UserAdminRole.SUPERADMIN.name())
+                || accountRole.equals(UserAdminRole.ADMIN.name());
     }
 
     public boolean canManage(String actorJid, String userJid) {
         UserRole role = userRoleStore.getRole(actorJid);
-        String jophielRole = role.getJophiel().orElse("");
-        return jophielRole.equals(UserAdminRole.SUPERADMIN.name())
-                || jophielRole.equals(UserAdminRole.ADMIN.name())
+        String accountRole = role.getAccount().orElse("");
+        return accountRole.equals(UserAdminRole.SUPERADMIN.name())
+                || accountRole.equals(UserAdminRole.ADMIN.name())
                 || actorJid.equals(userJid);
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/user/role/UserRoleStore.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/user/role/UserRoleStore.java
@@ -38,10 +38,10 @@ public class UserRoleStore {
                 userRoleDao.delete(model);
             } else {
                 UserRole role = userRolesMap.get(model.userJid);
-                if (role.getJophiel().isEmpty()
-                        && role.getSandalphon().isEmpty()
-                        && role.getUriel().isEmpty()
-                        && role.getJerahmeel().isEmpty()) {
+                if (role.getAccount().isEmpty()
+                        && role.getProblem().isEmpty()
+                        && role.getContest().isEmpty()
+                        && role.getTraining().isEmpty()) {
                     userRoleDao.delete(model);
                 }
             }
@@ -49,10 +49,10 @@ public class UserRoleStore {
 
         for (var entry : userRolesMap.entrySet()) {
             UserRole role = entry.getValue();
-            if (role.getJophiel().isEmpty()
-                    && role.getSandalphon().isEmpty()
-                    && role.getUriel().isEmpty()
-                    && role.getJerahmeel().isEmpty()) {
+            if (role.getAccount().isEmpty()
+                    && role.getProblem().isEmpty()
+                    && role.getContest().isEmpty()
+                    && role.getTraining().isEmpty()) {
                 continue;
             }
             upsertRole(entry.getKey(), entry.getValue());
@@ -77,10 +77,10 @@ public class UserRoleStore {
         UserRole.Builder role = new UserRole.Builder();
 
         if (superadminRoleStore.isSuperadmin(userJid)) {
-            role.jophiel(UserAdminRole.SUPERADMIN.name());
-            role.sandalphon("ADMIN");
-            role.uriel("ADMIN");
-            role.jerahmeel("ADMIN");
+            role.account(UserAdminRole.SUPERADMIN.name());
+            role.problem("ADMIN");
+            role.contest("ADMIN");
+            role.training("ADMIN");
         } else {
             Optional<UserRoleModel> maybeModel = userRoleDao.selectByUserJid(userJid);
             if (maybeModel.isPresent()) {
@@ -94,24 +94,24 @@ public class UserRoleStore {
     private UserRole fromModel(UserRoleModel model) {
         UserRole.Builder role = new UserRole.Builder();
         if (model.jophiel != null) {
-            role.jophiel(model.jophiel);
+            role.account(model.jophiel);
         }
         if (model.sandalphon != null) {
-            role.sandalphon(model.sandalphon);
+            role.problem(model.sandalphon);
         }
         if (model.uriel != null) {
-            role.uriel(model.uriel);
+            role.contest(model.uriel);
         }
         if (model.jerahmeel != null) {
-            role.jerahmeel(model.jerahmeel);
+            role.training(model.jerahmeel);
         }
         return role.build();
     }
 
     private void toModel(UserRole role, UserRoleModel model) {
-        model.jophiel = role.getJophiel().orElse(null);
-        model.sandalphon = role.getSandalphon().orElse(null);
-        model.uriel = role.getUriel().orElse(null);
-        model.jerahmeel = role.getJerahmeel().orElse(null);
+        model.jophiel = role.getAccount().orElse(null);
+        model.sandalphon = role.getProblem().orElse(null);
+        model.uriel = role.getContest().orElse(null);
+        model.jerahmeel = role.getTraining().orElse(null);
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/role/TrainingAdminRoleChecker.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/role/TrainingAdminRoleChecker.java
@@ -15,6 +15,6 @@ public class TrainingAdminRoleChecker {
 
     public boolean isAdmin(String userJid) {
         UserRole role = userRoleStore.getRole(userJid);
-        return role.getJerahmeel().orElse("").equals(TrainingAdminRole.ADMIN.name());
+        return role.getTraining().orElse("").equals(TrainingAdminRole.ADMIN.name());
     }
 }

--- a/judgels-client/src/components/ContentWithSidebar/ContentWithSidebar.jsx
+++ b/judgels-client/src/components/ContentWithSidebar/ContentWithSidebar.jsx
@@ -49,6 +49,7 @@ export default function ContentWithSidebar({
         path: item.path,
         titleIcon: item.titleIcon,
         title: item.title,
+        children: item.children && item.children.filter(child => !child.disabled),
       }));
     const sidebarWidget = renderSidebarWidget();
 
@@ -91,7 +92,9 @@ export default function ContentWithSidebar({
 
   const renderSidebarWidget = () => {
     const activeItemPath = getActiveItemPath();
-    const activeItem = items.find(item => item.path === activeItemPath);
+    const activeItem = items
+      .flatMap(item => (item.children ? item.children : [item]))
+      .find(item => item.path === activeItemPath);
 
     if (!activeItem || !activeItem.widgetComponent) {
       return null;

--- a/judgels-client/src/components/Sidebar/Sidebar.jsx
+++ b/judgels-client/src/components/Sidebar/Sidebar.jsx
@@ -13,7 +13,7 @@ export class Sidebar extends PureComponent {
   render() {
     const { title, action, activeItemPath, items, widget, onResolveItemUrl } = this.props;
 
-    const tabs = items.map(item => {
+    const renderTab = item => {
       const ItemIcon = widget ? ChevronDown : ChevronRight;
 
       const icon = item.path === activeItemPath && <ItemIcon className="card-sidebar__arrow" />;
@@ -28,6 +28,18 @@ export class Sidebar extends PureComponent {
           {icon}
         </Tab>
       );
+    };
+
+    const tabs = items.flatMap(item => {
+      if (item.children) {
+        return [
+          <div key={item.title} className="card-sidebar__group">
+            {item.title}
+          </div>,
+          ...item.children.map(renderTab),
+        ];
+      }
+      return [renderTab(item)];
     });
 
     const tabsContainer = (

--- a/judgels-client/src/components/Sidebar/Sidebar.scss
+++ b/judgels-client/src/components/Sidebar/Sidebar.scss
@@ -75,6 +75,25 @@
   }
 }
 
+.card-sidebar__group {
+  padding: 0 20px;
+  margin-top: 16px;
+  line-height: 30px;
+  height: 30px;
+  font-weight: bold;
+  font-size: 12px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+
+  .bp6-light & {
+    color: $secondary-text-color;
+  }
+
+  .bp6-dark & {
+    color: $dark-secondary-text-color;
+  }
+}
+
 .card-sidebar__arrow {
   position: absolute;
   right: 10px;

--- a/judgels-client/src/routes/AppRoutes.jsx
+++ b/judgels-client/src/routes/AppRoutes.jsx
@@ -14,10 +14,10 @@ const appRoutes = [
       path: '/admin',
     },
     visible: role =>
-      role.jophiel === UserAdminRole.Superadmin ||
-      role.jophiel === UserAdminRole.Admin ||
-      role.uriel === ContestAdminRole.Admin ||
-      (isTLX() && role.jerahmeel === TrainingAdminRole.Admin),
+      role.account === UserAdminRole.Superadmin ||
+      role.account === UserAdminRole.Admin ||
+      role.contest === ContestAdminRole.Admin ||
+      (isTLX() && role.training === TrainingAdminRole.Admin),
   },
   {
     id: 'contests',

--- a/judgels-client/src/routes/AppRoutes.test.js
+++ b/judgels-client/src/routes/AppRoutes.test.js
@@ -12,7 +12,7 @@ describe('AppRoutes', () => {
   };
 
   test('Jophiel admin', () => {
-    testAppRoutes({ jophiel: UserAdminRole.Admin }, [
+    testAppRoutes({ account: UserAdminRole.Admin }, [
       'admin',
       'contests',
       'courses',
@@ -23,7 +23,7 @@ describe('AppRoutes', () => {
   });
 
   test('Jophiel superadmin', () => {
-    testAppRoutes({ jophiel: UserAdminRole.Superadmin }, [
+    testAppRoutes({ account: UserAdminRole.Superadmin }, [
       'admin',
       'contests',
       'courses',
@@ -34,7 +34,7 @@ describe('AppRoutes', () => {
   });
 
   test('Uriel admin', () => {
-    testAppRoutes({ uriel: ContestAdminRole.Admin }, [
+    testAppRoutes({ contest: ContestAdminRole.Admin }, [
       'admin',
       'contests',
       'courses',
@@ -45,7 +45,7 @@ describe('AppRoutes', () => {
   });
 
   test('Jerahmeel admin', () => {
-    testAppRoutes({ jerahmeel: TrainingAdminRole.Admin }, [
+    testAppRoutes({ training: TrainingAdminRole.Admin }, [
       'admin',
       'contests',
       'courses',

--- a/judgels-client/src/routes/admin/AdminIndexPage.jsx
+++ b/judgels-client/src/routes/admin/AdminIndexPage.jsx
@@ -12,13 +12,13 @@ export default function AdminIndexPage() {
     data: { role },
   } = useSuspenseQuery(userWebConfigQueryOptions());
 
-  if (role.jophiel === UserAdminRole.Admin || role.jophiel === UserAdminRole.Superadmin) {
+  if (role.account === UserAdminRole.Admin || role.account === UserAdminRole.Superadmin) {
     return <Navigate to="/admin/users" />;
   }
-  if (role.uriel === ContestAdminRole.Admin) {
+  if (role.contest === ContestAdminRole.Admin) {
     return <Navigate to="/admin/contests" />;
   }
-  if (isTLX() && role.jerahmeel === TrainingAdminRole.Admin) {
+  if (isTLX() && role.training === TrainingAdminRole.Admin) {
     return <Navigate to="/admin/courses" />;
   }
   return <Navigate to="/" />;

--- a/judgels-client/src/routes/admin/AdminLayout.jsx
+++ b/judgels-client/src/routes/admin/AdminLayout.jsx
@@ -24,58 +24,69 @@ export default function AdminLayout() {
     data: { role },
   } = useSuspenseQuery(userWebConfigQueryOptions());
 
-  const isJophielAdmin = role.jophiel === UserAdminRole.Admin || role.jophiel === UserAdminRole.Superadmin;
-  const isUrielAdmin = role.uriel === ContestAdminRole.Admin;
-  const isJerahmeelAdmin = isTLX() && role.jerahmeel === TrainingAdminRole.Admin;
+  const isAccountAdmin = role.account === UserAdminRole.Admin || role.account === UserAdminRole.Superadmin;
+  const isContestAdmin = role.contest === ContestAdminRole.Admin;
+  const isTrainingAdmin = isTLX() && role.training === TrainingAdminRole.Admin;
 
   const sidebarItems = [
     {
-      path: 'users',
-      titleIcon: <People />,
-      title: 'Users',
-      visible: isJophielAdmin,
+      title: 'Account',
+      visible: isAccountAdmin,
+      children: [
+        {
+          path: 'users',
+          titleIcon: <People />,
+          title: 'Users',
+        },
+        {
+          path: 'roles',
+          titleIcon: <Shield />,
+          title: 'Roles',
+        },
+        {
+          path: 'ratings',
+          titleIcon: <TimelineLineChart />,
+          title: 'Ratings',
+          visible: isTLX(),
+        },
+      ].filter(child => child.visible !== false),
     },
     {
-      path: 'roles',
-      titleIcon: <Shield />,
-      title: 'Roles',
-      visible: isJophielAdmin,
+      title: 'Contest',
+      visible: isContestAdmin,
+      children: [
+        {
+          path: 'contests',
+          titleIcon: <Console />,
+          title: 'Contests',
+        },
+      ],
     },
     {
-      path: 'ratings',
-      titleIcon: <TimelineLineChart />,
-      title: 'Ratings',
-      visible: isTLX() && isJophielAdmin,
-    },
-    {
-      path: 'contests',
-      titleIcon: <Console />,
-      title: 'Contests',
-      visible: isUrielAdmin,
-    },
-    {
-      path: 'courses',
-      titleIcon: <PredictiveAnalysis />,
-      title: 'Courses',
-      visible: isJerahmeelAdmin,
-    },
-    {
-      path: 'chapters',
-      titleIcon: <Properties />,
-      title: 'Chapters',
-      visible: isJerahmeelAdmin,
-    },
-    {
-      path: 'archives',
-      titleIcon: <Box />,
-      title: 'Archives',
-      visible: isJerahmeelAdmin,
-    },
-    {
-      path: 'problemsets',
-      titleIcon: <PanelStats />,
-      title: 'Problemsets',
-      visible: isJerahmeelAdmin,
+      title: 'Training',
+      visible: isTrainingAdmin,
+      children: [
+        {
+          path: 'courses',
+          titleIcon: <PredictiveAnalysis />,
+          title: 'Courses',
+        },
+        {
+          path: 'chapters',
+          titleIcon: <Properties />,
+          title: 'Chapters',
+        },
+        {
+          path: 'archives',
+          titleIcon: <Box />,
+          title: 'Archives',
+        },
+        {
+          path: 'problemsets',
+          titleIcon: <PanelStats />,
+          title: 'Problemsets',
+        },
+      ],
     },
   ].filter(item => item.visible);
 

--- a/judgels-client/src/routes/admin/roles/RoleEditDialog/RoleEditDialog.jsx
+++ b/judgels-client/src/routes/admin/roles/RoleEditDialog/RoleEditDialog.jsx
@@ -20,7 +20,7 @@ function buildCsvFromData(response) {
     const profile = profilesMap[entry.userJid];
     const username = profile ? profile.username : entry.userJid;
     const { role } = entry;
-    return [username, role.jophiel || '', role.sandalphon || '', role.uriel || '', role.jerahmeel || ''].join(',');
+    return [username, role.account || '', role.problem || '', role.contest || '', role.training || ''].join(',');
   });
 
   return lines.join('\n');
@@ -35,22 +35,22 @@ function parseCsvToRoleMap(csv) {
 
   for (const line of lines) {
     const parts = line.split(',').map(s => s.trim());
-    const [username, jophiel, sandalphon, uriel, jerahmeel] = parts;
+    const [username, account, problem, contest, training] = parts;
     if (!username) {
       continue;
     }
     const role = {};
-    if (jophiel) {
-      role.jophiel = jophiel;
+    if (account) {
+      role.account = account;
     }
-    if (sandalphon) {
-      role.sandalphon = sandalphon;
+    if (problem) {
+      role.problem = problem;
     }
-    if (uriel) {
-      role.uriel = uriel;
+    if (contest) {
+      role.contest = contest;
     }
-    if (jerahmeel) {
-      role.jerahmeel = jerahmeel;
+    if (training) {
+      role.training = training;
     }
     map[username] = role;
   }
@@ -107,20 +107,20 @@ export function RoleEditDialog({ currentData }) {
                 />
                 <Collapse isOpen={isInstructionOpen}>
                   <h5>Row format</h5>
-                  <pre>{'<username>,<jophiel role>,<sandalphon role>,<uriel role>,<jerahmeel role>'}</pre>
+                  <pre>{'<username>,<account role>,<problem role>,<contest role>,<training role>'}</pre>
                   <br />
                   <ul>
                     <li>
-                      <code>jophiel role</code>: user management role
+                      <code>account role</code>: account management role
                     </li>
                     <li>
-                      <code>sandalphon role</code>: problem/lesson management role
+                      <code>problem role</code>: problem management role
                     </li>
                     <li>
-                      <code>uriel role</code>: contest management role
+                      <code>contest role</code>: contest management role
                     </li>
                     <li>
-                      <code>jerahmeel role</code>: training management role
+                      <code>training role</code>: training management role
                     </li>
                   </ul>
                   <br />

--- a/judgels-client/src/routes/admin/roles/RoleEditDialog/RoleEditDialog.test.jsx
+++ b/judgels-client/src/routes/admin/roles/RoleEditDialog/RoleEditDialog.test.jsx
@@ -11,8 +11,8 @@ import { RoleEditDialog } from './RoleEditDialog';
 describe('RoleEditDialog', () => {
   const currentData = {
     data: [
-      { userJid: 'userJid1', role: { jophiel: 'ADMIN', sandalphon: 'ADMIN', uriel: 'ADMIN', jerahmeel: 'ADMIN' } },
-      { userJid: 'userJid2', role: { sandalphon: 'ADMIN' } },
+      { userJid: 'userJid1', role: { account: 'ADMIN', problem: 'ADMIN', contest: 'ADMIN', training: 'ADMIN' } },
+      { userJid: 'userJid2', role: { problem: 'ADMIN' } },
     ],
     profilesMap: {
       userJid1: { username: 'andi' },
@@ -50,8 +50,8 @@ describe('RoleEditDialog', () => {
 
     nockApi()
       .put('/user-roles', {
-        andi: { jophiel: 'ADMIN', sandalphon: 'ADMIN' },
-        caca: { sandalphon: 'ADMIN' },
+        andi: { account: 'ADMIN', problem: 'ADMIN' },
+        caca: { problem: 'ADMIN' },
       })
       .reply(200);
 

--- a/judgels-client/src/routes/admin/roles/RolesPage/RolesPage.jsx
+++ b/judgels-client/src/routes/admin/roles/RolesPage/RolesPage.jsx
@@ -32,10 +32,10 @@ export default function RolesPage() {
       return (
         <tr key={entry.userJid}>
           <td>{username}</td>
-          <td>{role.jophiel || '-'}</td>
-          <td>{role.sandalphon || '-'}</td>
-          <td>{role.uriel || '-'}</td>
-          <td>{role.jerahmeel || '-'}</td>
+          <td>{role.account || '-'}</td>
+          <td>{role.problem || '-'}</td>
+          <td>{role.contest || '-'}</td>
+          <td>{role.training || '-'}</td>
         </tr>
       );
     });
@@ -46,7 +46,7 @@ export default function RolesPage() {
           <tr>
             <th>User</th>
             <th>Account</th>
-            <th>Problem/Lesson</th>
+            <th>Problem</th>
             <th>Contest</th>
             <th>Training</th>
           </tr>

--- a/judgels-client/src/routes/admin/roles/RolesPage/RolesPage.test.jsx
+++ b/judgels-client/src/routes/admin/roles/RolesPage/RolesPage.test.jsx
@@ -13,8 +13,8 @@ describe('RolesPage', () => {
 
   const renderComponent = async ({
     roles = [
-      { userJid: 'userJid1', role: { jophiel: 'ADMIN', sandalphon: 'ADMIN', uriel: 'ADMIN', jerahmeel: 'ADMIN' } },
-      { userJid: 'userJid2', role: { sandalphon: 'ADMIN' } },
+      { userJid: 'userJid1', role: { account: 'ADMIN', problem: 'ADMIN', contest: 'ADMIN', training: 'ADMIN' } },
+      { userJid: 'userJid2', role: { problem: 'ADMIN' } },
     ],
     profilesMap = {
       userJid1: { username: 'andi' },


### PR DESCRIPTION
## Summary

Two related admin-area changes:

### 1. Nested admin sidebar menus
The admin sidebar is now grouped into sections instead of a flat list:
- **Account** → Users, Roles, Ratings
- **Contest** → Contests
- **Training** → Courses, Chapters, Archives, Problemsets

`Sidebar` / `ContentWithSidebar` now support items with `children`, rendering a section header followed by the nested items. Routes stay flat (`/admin/users`, etc.), so active-item highlighting is unchanged.

### 2. Rename user roles
Renamed the `UserRole` API fields from the legacy archangel codenames to domain names:

| old        | new       |
|------------|-----------|
| jophiel    | account   |
| sandalphon | problem   |
| uriel      | contest   |
| jerahmeel  | training  |

All backend callers (role checkers, `RoleResource`, `UserRoleStore`, integration tests) and the client (admin routing, roles page/dialog, tests) are updated to match.

> [!WARNING]
> This changes the JSON contract of `UserRole` and **breaks API compatibility** for any external consumer using the old field names.

The underlying DB columns (`UserRoleModel`) are intentionally left unchanged, so **no data migration is required**.

## Test plan
- Backend: `compileJava` + `checkstyleMain` + `compileIntegTestJava` — all pass.
- Client: affected tests (`AppRoutes`, `RoleEditDialog`, `RolesPage`) — 9/9 pass.
- Verified the nested sidebar visually in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)