### PR TITLE
Show training role only in TLX mode

### DIFF
--- a/judgels-client/src/routes/admin/roles/RoleEditDialog/RoleEditDialog.jsx
+++ b/judgels-client/src/routes/admin/roles/RoleEditDialog/RoleEditDialog.jsx
@@ -6,6 +6,7 @@ import { Field, Form } from 'react-final-form';
 
 import { FormTextArea } from '../../../../components/forms/FormTextArea/FormTextArea';
 import { Required } from '../../../../components/forms/validations';
+import { isTLX } from '../../../../conf';
 import { setUserRolesMutationOptions } from '../../../../modules/queries/userRole';
 
 import * as toastActions from '../../../../modules/toast/toastActions';
@@ -20,7 +21,11 @@ function buildCsvFromData(response) {
     const profile = profilesMap[entry.userJid];
     const username = profile ? profile.username : entry.userJid;
     const { role } = entry;
-    return [username, role.account || '', role.problem || '', role.contest || '', role.training || ''].join(',');
+    const cols = [username, role.account || '', role.problem || '', role.contest || ''];
+    if (isTLX()) {
+      cols.push(role.training || '');
+    }
+    return cols.join(',');
   });
 
   return lines.join('\n');
@@ -49,7 +54,7 @@ function parseCsvToRoleMap(csv) {
     if (contest) {
       role.contest = contest;
     }
-    if (training) {
+    if (isTLX() && training) {
       role.training = training;
     }
     map[username] = role;
@@ -107,7 +112,11 @@ export function RoleEditDialog({ currentData }) {
                 />
                 <Collapse isOpen={isInstructionOpen}>
                   <h5>Row format</h5>
-                  <pre>{'<username>,<account role>,<problem role>,<contest role>,<training role>'}</pre>
+                  <pre>
+                    {isTLX()
+                      ? '<username>,<account role>,<problem role>,<contest role>,<training role>'
+                      : '<username>,<account role>,<problem role>,<contest role>'}
+                  </pre>
                   <br />
                   <ul>
                     <li>
@@ -119,9 +128,11 @@ export function RoleEditDialog({ currentData }) {
                     <li>
                       <code>contest role</code>: contest management role
                     </li>
-                    <li>
-                      <code>training role</code>: training management role
-                    </li>
+                    {isTLX() && (
+                      <li>
+                        <code>training role</code>: training management role
+                      </li>
+                    )}
                   </ul>
                   <br />
                   <p>
@@ -129,7 +140,9 @@ export function RoleEditDialog({ currentData }) {
                   </p>
                   <hr />
                   <h5>Example</h5>
-                  <pre>{`andi,ADMIN,ADMIN,ADMIN,ADMIN\nbudi,,ADMIN,,`}</pre>
+                  <pre>
+                    {isTLX() ? `andi,ADMIN,ADMIN,ADMIN,ADMIN\nbudi,,ADMIN,,` : `andi,ADMIN,ADMIN,ADMIN\nbudi,,ADMIN,`}
+                  </pre>
                   <hr />
                 </Collapse>
 

--- a/judgels-client/src/routes/admin/roles/RolesPage/RolesPage.jsx
+++ b/judgels-client/src/routes/admin/roles/RolesPage/RolesPage.jsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ActionButtons } from '../../../../components/ActionButtons/ActionButtons';
 import { ContentCard } from '../../../../components/ContentCard/ContentCard';
 import { LoadingState } from '../../../../components/LoadingState/LoadingState';
+import { isTLX } from '../../../../conf';
 import { userRolesQueryOptions } from '../../../../modules/queries/userRole';
 import { RoleEditDialog } from '../RoleEditDialog/RoleEditDialog';
 
@@ -35,7 +36,7 @@ export default function RolesPage() {
           <td>{role.account || '-'}</td>
           <td>{role.problem || '-'}</td>
           <td>{role.contest || '-'}</td>
-          <td>{role.training || '-'}</td>
+          {isTLX() && <td>{role.training || '-'}</td>}
         </tr>
       );
     });
@@ -48,7 +49,7 @@ export default function RolesPage() {
             <th>Account</th>
             <th>Problem</th>
             <th>Contest</th>
-            <th>Training</th>
+            {isTLX() && <th>Training</th>}
           </tr>
         </thead>
         <tbody>{rows}</tbody>


### PR DESCRIPTION
## Summary

In the admin roles page and the edit-roles dialog, the **training** role column / CSV field is now only shown when the deployment is in TLX mode, matching the rest of the admin UI which already gates training behind `isTLX()`.

- `RolesPage`: the `Training` column header and cells render only when `isTLX()`.
- `RoleEditDialog`: the CSV `buildCsvFromData` / `parseCsvToRoleMap` and the instructions (row format, bullet, example) include the training role only when `isTLX()`.

For non-TLX deployments, training is irrelevant, so the rows become `<username>,<account>,<problem>,<contest>`.

## Test plan
- Client role tests pass (4/4) — test env runs in TLX mode, so the training column stays asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)