### PR TITLE
MIGRATION NEEDED: Add DB-persisted app settings (name, slogan)

### DIFF
--- a/judgels-backends/judgels-server-api/src/main/java/judgels/api/setting/AppSettings.java
+++ b/judgels-backends/judgels-server-api/src/main/java/judgels/api/setting/AppSettings.java
@@ -1,0 +1,13 @@
+package judgels.api.setting;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableAppSettings.class)
+public interface AppSettings {
+    String getName();
+    String getSlogan();
+
+    class Builder extends ImmutableAppSettings.Builder {}
+}

--- a/judgels-backends/judgels-server-api/src/main/java/judgels/api/setting/AppSettingsUpdateData.java
+++ b/judgels-backends/judgels-server-api/src/main/java/judgels/api/setting/AppSettingsUpdateData.java
@@ -1,0 +1,14 @@
+package judgels.api.setting;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableAppSettingsUpdateData.class)
+public interface AppSettingsUpdateData {
+    Optional<String> getName();
+    Optional<String> getSlogan();
+
+    class Builder extends ImmutableAppSettingsUpdateData.Builder {}
+}

--- a/judgels-backends/judgels-server-api/src/main/java/judgels/api/setting/Settings.java
+++ b/judgels-backends/judgels-server-api/src/main/java/judgels/api/setting/Settings.java
@@ -1,0 +1,12 @@
+package judgels.api.setting;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableSettings.class)
+public interface Settings {
+    AppSettings getApp();
+
+    class Builder extends ImmutableSettings.Builder {}
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
@@ -156,6 +156,8 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
         env.jersey().register(component.contestItemSubmissionResource());
         env.jersey().register(component.contestSupervisorResource());
 
+        env.jersey().register(component.settingResource());
+
         component.scheduler().scheduleWithFixedDelay(
                 "session-cleaner",
                 component.sessionCleaner(),

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
@@ -71,6 +71,8 @@ public interface JudgelsServerComponent {
     judgels.contest.log.ContestLogPoller contestLogPoller();
     judgels.contest.scoreboard.ContestScoreboardPoller contestScoreboardPoller();
 
+    judgels.setting.SettingResource settingResource();
+
     judgels.session.SessionCleaner sessionCleaner();
     GradingResponsePoller problemGradingResponsePoller();
     @ContestGradingResponsePoller GradingResponsePoller contestGradingResponsePoller();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerHibernateBundle.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerHibernateBundle.java
@@ -39,6 +39,7 @@ import judgels.persistence.model.ProblemTagModel;
 import judgels.persistence.model.ProgrammingGradingModel;
 import judgels.persistence.model.ProgrammingSubmissionModel;
 import judgels.persistence.model.SessionModel;
+import judgels.persistence.model.SettingModel;
 import judgels.persistence.model.StatsUserModel;
 import judgels.persistence.model.StatsUserProblemModel;
 import judgels.persistence.model.TrainingProgrammingGradingModel;
@@ -55,6 +56,7 @@ public class JudgelsServerHibernateBundle extends HibernateBundle<JudgelsServerA
     public JudgelsServerHibernateBundle() {
         super(
                 SessionModel.class,
+                SettingModel.class,
                 UserModel.class,
                 UserInfoModel.class,
                 UserRatingModel.class,

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/persistence/dao/SettingDao.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/persistence/dao/SettingDao.java
@@ -1,0 +1,9 @@
+package judgels.persistence.dao;
+
+import java.util.Optional;
+import judgels.persistence.Dao;
+import judgels.persistence.model.SettingModel;
+
+public interface SettingDao extends Dao<SettingModel> {
+    Optional<SettingModel> selectByKey(String key);
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/persistence/hibernate/dao/SettingHibernateDao.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/persistence/hibernate/dao/SettingHibernateDao.java
@@ -1,0 +1,21 @@
+package judgels.persistence.hibernate.dao;
+
+import jakarta.inject.Inject;
+import java.util.Optional;
+import judgels.persistence.dao.SettingDao;
+import judgels.persistence.hibernate.HibernateDao;
+import judgels.persistence.hibernate.HibernateDaoData;
+import judgels.persistence.model.SettingModel;
+import judgels.persistence.model.SettingModel_;
+
+public class SettingHibernateDao extends HibernateDao<SettingModel> implements SettingDao {
+    @Inject
+    public SettingHibernateDao(HibernateDaoData data) {
+        super(data);
+    }
+
+    @Override
+    public Optional<SettingModel> selectByKey(String key) {
+        return select().where(columnEq(SettingModel_.settingKey, key)).unique();
+    }
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/persistence/model/SettingModel.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/persistence/model/SettingModel.java
@@ -1,0 +1,15 @@
+package judgels.persistence.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import judgels.persistence.Model;
+
+@SuppressWarnings("checkstyle:visibilitymodifier")
+@Entity(name = "judgels_setting")
+public final class SettingModel extends Model {
+    @Column(nullable = false, unique = true)
+    public String settingKey;
+
+    @Column(columnDefinition = "TEXT")
+    public String settingValue;
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/service/persistence/hibernate/JudgelsServerHibernateDaoModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/service/persistence/hibernate/JudgelsServerHibernateDaoModule.java
@@ -40,6 +40,7 @@ import judgels.persistence.dao.ProblemTagDao;
 import judgels.persistence.dao.ProgrammingGradingDao;
 import judgels.persistence.dao.ProgrammingSubmissionDao;
 import judgels.persistence.dao.SessionDao;
+import judgels.persistence.dao.SettingDao;
 import judgels.persistence.dao.StatsUserDao;
 import judgels.persistence.dao.StatsUserProblemDao;
 import judgels.persistence.dao.TrainingProgrammingGradingDao;
@@ -89,6 +90,7 @@ import judgels.persistence.hibernate.dao.ProblemTagHibernateDao;
 import judgels.persistence.hibernate.dao.ProgrammingGradingHibernateDao;
 import judgels.persistence.hibernate.dao.ProgrammingSubmissionHibernateDao;
 import judgels.persistence.hibernate.dao.SessionHibernateDao;
+import judgels.persistence.hibernate.dao.SettingHibernateDao;
 import judgels.persistence.hibernate.dao.StatsUserHibernateDao;
 import judgels.persistence.hibernate.dao.StatsUserProblemHibernateDao;
 import judgels.persistence.hibernate.dao.TrainingProgrammingGradingHibernateDao;
@@ -328,6 +330,11 @@ public class JudgelsServerHibernateDaoModule {
 
     @Provides
     static BundleItemSubmissionDao bundleItemSubmissionDao(BundleItemSubmissionHibernateDao dao) {
+        return dao;
+    }
+
+    @Provides
+    static SettingDao settingDao(SettingHibernateDao dao) {
         return dao;
     }
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/setting/SettingResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/setting/SettingResource.java
@@ -1,0 +1,55 @@
+package judgels.setting;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static judgels.service.ServiceUtils.checkAllowed;
+
+import io.dropwizard.hibernate.UnitOfWork;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import judgels.api.setting.AppSettingsUpdateData;
+import judgels.api.setting.Settings;
+import judgels.role.SuperadminRoleStore;
+import judgels.service.actor.ActorChecker;
+import judgels.service.api.actor.AuthHeader;
+
+@Path("/api/v2/settings")
+public class SettingResource {
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected SuperadminRoleStore superadminRoleStore;
+    @Inject protected SettingStore store;
+
+    @Inject public SettingResource() {}
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    @UnitOfWork(readOnly = true)
+    public Settings getSettings(@HeaderParam(AUTHORIZATION) AuthHeader authHeader) {
+        String actorJid = actorChecker.check(authHeader);
+        checkAllowed(superadminRoleStore.isSuperadmin(actorJid));
+
+        return store.getSettings();
+    }
+
+    @PUT
+    @Path("/app")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @UnitOfWork
+    public Settings updateAppSettings(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            AppSettingsUpdateData data) {
+
+        String actorJid = actorChecker.check(authHeader);
+        checkAllowed(superadminRoleStore.isSuperadmin(actorJid));
+
+        store.updateAppSettings(data);
+
+        return store.getSettings();
+    }
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/setting/SettingStore.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/setting/SettingStore.java
@@ -1,0 +1,54 @@
+package judgels.setting;
+
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import judgels.api.setting.AppSettings;
+import judgels.api.setting.AppSettingsUpdateData;
+import judgels.api.setting.Settings;
+import judgels.persistence.dao.SettingDao;
+import judgels.persistence.model.SettingModel;
+
+public class SettingStore {
+    private static final String KEY_APP_NAME = "app_name";
+    private static final String KEY_APP_SLOGAN = "app_slogan";
+
+    private final SettingDao settingDao;
+
+    @Inject
+    public SettingStore(SettingDao settingDao) {
+        this.settingDao = settingDao;
+    }
+
+    public Settings getSettings() {
+        Map<String, String> settings = settingDao.select().all().stream()
+                .collect(Collectors.toMap(m -> m.settingKey, m -> m.settingValue));
+
+        return new Settings.Builder()
+                .app(new AppSettings.Builder()
+                        .name(settings.getOrDefault(KEY_APP_NAME, ""))
+                        .slogan(settings.getOrDefault(KEY_APP_SLOGAN, ""))
+                        .build())
+                .build();
+    }
+
+    public void updateAppSettings(AppSettingsUpdateData data) {
+        data.getName().ifPresent(value -> upsertSetting(KEY_APP_NAME, value));
+        data.getSlogan().ifPresent(value -> upsertSetting(KEY_APP_SLOGAN, value));
+    }
+
+    private void upsertSetting(String key, String value) {
+        Optional<SettingModel> maybeModel = settingDao.selectByKey(key);
+        if (maybeModel.isPresent()) {
+            SettingModel model = maybeModel.get();
+            model.settingValue = value;
+            settingDao.update(model);
+        } else {
+            SettingModel model = new SettingModel();
+            model.settingKey = key;
+            model.settingValue = value;
+            settingDao.insert(model);
+        }
+    }
+}

--- a/judgels-backends/judgels-server-app/src/main/resources/migrations.xml
+++ b/judgels-backends/judgels-server-app/src/main/resources/migrations.xml
@@ -7,4 +7,5 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <include file="migrations/000_init.xml"/>
+    <include file="migrations/001_add_judgels_setting.xml"/>
 </databaseChangeLog>

--- a/judgels-backends/judgels-server-app/src/main/resources/migrations/001_add_judgels_setting.xml
+++ b/judgels-backends/judgels-server-app/src/main/resources/migrations/001_add_judgels_setting.xml
@@ -1,0 +1,24 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.8.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet author="ia-toki" id="add-judgels-setting-1">
+        <createTable catalogName="judgels" schemaName="judgels" tableName="judgels_setting">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="settingKey" type="VARCHAR(255)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="settingValue" type="TEXT"/>
+            <column name="createdAt" type="datetime(3)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="createdBy" type="VARCHAR(32)"/>
+            <column name="createdIp" type="VARCHAR(100)"/>
+            <column name="updatedAt" type="datetime(3)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updatedBy" type="VARCHAR(32)"/>
+            <column name="updatedIp" type="VARCHAR(100)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/judgels-client/src/components/ContentWithSidebar/ContentWithSidebar.jsx
+++ b/judgels-client/src/components/ContentWithSidebar/ContentWithSidebar.jsx
@@ -123,13 +123,16 @@ export default function ContentWithSidebar({
   };
 
   const getActiveItemPath = () => {
-    if (location.pathname === basePath) {
-      return '';
-    }
+    const relativePath = location.pathname.slice(basePath.length).replace(/^\//, '');
 
-    const currentPath = location.pathname + '/';
-    const nextSlashPos = currentPath.indexOf('/', basePath.length + 1);
-    return currentPath.substring(basePath.length + 1, nextSlashPos);
+    const itemPaths = items.flatMap(item =>
+      item.children ? item.children.map(child => child.path) : [item.path]
+    );
+    const matchedPath = itemPaths
+      .filter(path => path && (relativePath === path || relativePath.startsWith(path + '/')))
+      .sort((a, b) => b.length - a.length)[0];
+
+    return matchedPath ?? relativePath.split('/')[0];
   };
 
   return (

--- a/judgels-client/src/components/ContentWithSidebar/ContentWithSidebar.jsx
+++ b/judgels-client/src/components/ContentWithSidebar/ContentWithSidebar.jsx
@@ -125,9 +125,7 @@ export default function ContentWithSidebar({
   const getActiveItemPath = () => {
     const relativePath = location.pathname.slice(basePath.length).replace(/^\//, '');
 
-    const itemPaths = items.flatMap(item =>
-      item.children ? item.children.map(child => child.path) : [item.path]
-    );
+    const itemPaths = items.flatMap(item => (item.children ? item.children.map(child => child.path) : [item.path]));
     const matchedPath = itemPaths
       .filter(path => path && (relativePath === path || relativePath.startsWith(path + '/')))
       .sort((a, b) => b.length - a.length)[0];

--- a/judgels-client/src/modules/api/setting.js
+++ b/judgels-client/src/modules/api/setting.js
@@ -1,0 +1,14 @@
+import { APP_CONFIG } from '../../conf';
+import { get, put } from './http';
+
+const baseURL = `${APP_CONFIG.apiUrl}/settings`;
+
+export const settingAPI = {
+  getSettings: token => {
+    return get(baseURL, token);
+  },
+
+  updateAppSettings: (token, data) => {
+    return put(`${baseURL}/app`, token, data);
+  },
+};

--- a/judgels-client/src/modules/queries/setting.js
+++ b/judgels-client/src/modules/queries/setting.js
@@ -1,0 +1,18 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { settingAPI } from '../api/setting';
+import { queryClient } from '../queryClient';
+import { getToken } from '../session';
+
+export const settingsQueryOptions = () =>
+  queryOptions({
+    queryKey: ['settings'],
+    queryFn: () => settingAPI.getSettings(getToken()),
+  });
+
+export const updateAppSettingsMutationOptions = () => ({
+  mutationFn: data => settingAPI.updateAppSettings(getToken(), data),
+  onSuccess: () => {
+    queryClient.invalidateQueries(settingsQueryOptions());
+  },
+});

--- a/judgels-client/src/routes/admin/AdminLayout.jsx
+++ b/judgels-client/src/routes/admin/AdminLayout.jsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Cog,
   Console,
   PanelStats,
   People,
@@ -25,6 +26,7 @@ export default function AdminLayout() {
   } = useSuspenseQuery(userWebConfigQueryOptions());
 
   const isAccountAdmin = role.account === UserAdminRole.Admin || role.account === UserAdminRole.Superadmin;
+  const isSuperadmin = role.account === UserAdminRole.Superadmin;
   const isContestAdmin = role.contest === ContestAdminRole.Admin;
   const isTrainingAdmin = isTLX() && role.training === TrainingAdminRole.Admin;
 
@@ -85,6 +87,17 @@ export default function AdminLayout() {
           path: 'problemsets',
           titleIcon: <PanelStats />,
           title: 'Problemsets',
+        },
+      ],
+    },
+    {
+      title: 'Settings',
+      visible: isSuperadmin,
+      children: [
+        {
+          path: 'settings/app',
+          titleIcon: <Cog />,
+          title: 'App',
         },
       ],
     },

--- a/judgels-client/src/routes/admin/routes.jsx
+++ b/judgels-client/src/routes/admin/routes.jsx
@@ -132,6 +132,12 @@ export const createAdminRoutes = appRoute => {
     },
   });
 
+  const adminSettingsAppRoute = createRoute({
+    getParentRoute: () => adminRoute,
+    path: 'settings/app',
+    component: lazyRouteComponent(retryImport(() => import('./settings/AppSettingsPage/AppSettingsPage'))),
+  });
+
   return adminRoute.addChildren([
     adminIndexRoute,
     adminUsersRoute,
@@ -147,5 +153,6 @@ export const createAdminRoutes = appRoute => {
     adminArchiveRoute,
     adminProblemSetsRoute,
     adminProblemSetRoute,
+    adminSettingsAppRoute,
   ]);
 };

--- a/judgels-client/src/routes/admin/settings/AppSettingsPage/AppSettingsPage.jsx
+++ b/judgels-client/src/routes/admin/settings/AppSettingsPage/AppSettingsPage.jsx
@@ -1,0 +1,93 @@
+import { Button, HTMLTable, Intent } from '@blueprintjs/core';
+import { Edit } from '@blueprintjs/icons';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { Field, Form } from 'react-final-form';
+
+import { ActionButtons } from '../../../../components/ActionButtons/ActionButtons';
+import { ContentCard } from '../../../../components/ContentCard/ContentCard';
+import { LoadingState } from '../../../../components/LoadingState/LoadingState';
+import { FormTable } from '../../../../components/forms/FormTable/FormTable';
+import { FormTableTextInput } from '../../../../components/forms/FormTableTextInput/FormTableTextInput';
+import { settingsQueryOptions, updateAppSettingsMutationOptions } from '../../../../modules/queries/setting';
+
+import * as toastActions from '../../../../modules/toast/toastActions';
+
+export default function AppSettingsPage() {
+  const { data } = useQuery(settingsQueryOptions());
+
+  const updateAppSettingsMutation = useMutation(updateAppSettingsMutationOptions());
+
+  const [isEditing, setIsEditing] = useState(false);
+
+  const renderAction = () => {
+    if (data === undefined || isEditing) {
+      return null;
+    }
+    return (
+      <ActionButtons>
+        <Button intent={Intent.PRIMARY} icon={<Edit />} onClick={() => setIsEditing(true)}>
+          Edit settings
+        </Button>
+      </ActionButtons>
+    );
+  };
+
+  const renderContent = () => {
+    if (data === undefined) {
+      return <LoadingState />;
+    }
+
+    const app = data.app;
+
+    if (isEditing) {
+      const initialValues = {
+        name: app.name,
+        slogan: app.slogan,
+      };
+      return (
+        <Form onSubmit={updateAppSettings} initialValues={initialValues}>
+          {({ handleSubmit, submitting }) => (
+            <form onSubmit={handleSubmit}>
+              <HTMLTable striped>
+                <tbody>
+                  <Field component={FormTableTextInput} name="name" label="App name" />
+                  <Field component={FormTableTextInput} name="slogan" label="App slogan" />
+                </tbody>
+              </HTMLTable>
+
+              <hr />
+              <ActionButtons justifyContent="end">
+                <Button text="Cancel" disabled={submitting} onClick={() => setIsEditing(false)} />
+                <Button type="submit" text="Save" intent={Intent.PRIMARY} loading={submitting} />
+              </ActionButtons>
+            </form>
+          )}
+        </Form>
+      );
+    }
+
+    const rows = [
+      { key: 'name', title: 'App name', value: app.name },
+      { key: 'slogan', title: 'App slogan', value: app.slogan },
+    ];
+    return <FormTable rows={rows} />;
+  };
+
+  const updateAppSettings = values => {
+    updateAppSettingsMutation.mutate(
+      { name: values.name, slogan: values.slogan },
+      {
+        onSuccess: () => toastActions.showSuccessToast('Settings updated.'),
+      }
+    );
+    setIsEditing(false);
+  };
+
+  return (
+    <ContentCard title="App settings">
+      {renderAction()}
+      {renderContent()}
+    </ContentCard>
+  );
+}


### PR DESCRIPTION
## Summary

Persist app-wide settings (**app name** and **slogan**) in the DB so a superadmin can edit them live via a new admin page, instead of editing static config and redeploying.

This iteration is **storage + admin UI only**. Wiring the live consumers (client `Header`/title, michael header) to read from the DB is a deliberate follow-up — the values can now be created/edited and read via the API, but the live surfaces keep their current sources.

## Backend

- New `judgels_setting` table (migration `001_add_judgels_setting.xml`), one row per key (`app_name`, `app_slogan`), with `SettingModel` / `SettingDao` / `SettingHibernateDao`. Entity registered in `JudgelsServerHibernateBundle`.
- Typed API DTOs in `judgels.api.setting`: `Settings` → `AppSettings` (`name`, `slogan`), plus `AppSettingsUpdateData` (all fields optional).
- `SettingStore` converts between the flat key-value rows and the typed DTOs; updates upsert only the keys present.
- `SettingResource` (superadmin-gated): `GET /api/v2/settings` returns `Settings`; `PUT /api/v2/settings/app` takes `AppSettingsUpdateData`.

## Frontend

- New superadmin-only **Settings → App** admin page (`ContentCard` with a view/edit toggle).
- Fixed `ContentWithSidebar` active-item detection to support nested item paths (e.g. `settings/app`), while keeping detail-page and index-item behavior intact.

## Test plan

- Backend: `:judgels-server-app:compileJava` + `:checkstyleMain` pass.
- Frontend: `yarn build` passes; `ContentWithSidebar` tests pass.
- Manual: as Superadmin, Admin → Settings → App, edit name/slogan, save, reload, confirm persisted. Settings group hidden for non-superadmins (incl. plain Admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)