### PR TITLE
Lighten table heading font weight to 600

### DIFF
--- a/judgels-client/src/components/forms/FormTable/FormTable.scss
+++ b/judgels-client/src/components/forms/FormTable/FormTable.scss
@@ -1,5 +1,5 @@
 .form-table__title {
-  font-weight: bold;
+  font-weight: 600;
 }
 
 .form-table__value {

--- a/judgels-client/src/components/forms/FormTableInput/FormTableInput.scss
+++ b/judgels-client/src/components/forms/FormTableInput/FormTableInput.scss
@@ -14,7 +14,7 @@
 }
 
 .form-table-input__label {
-  font-weight: bold;
+  font-weight: 600;
 }
 
 .form-table-input__label-helper {

--- a/judgels-client/src/routes/home/profiles/single/summary/BasicProfilePanel/BasicProfilePanel.scss
+++ b/judgels-client/src/routes/home/profiles/single/summary/BasicProfilePanel/BasicProfilePanel.scss
@@ -52,7 +52,7 @@
 }
 
 .basic-profile-card__details-keys {
-  font-weight: bold;
+  font-weight: 600;
   width: 100px;
 }
 


### PR DESCRIPTION
## Summary
- Use `600` instead of `bold` (700) for table key/heading columns, for a calmer look (especially in dark mode).
- Affects `FormTable` view-mode keys, `FormTableInput` edit-mode labels, and the basic profile details keys.

## Changes
- `FormTable.scss` — `.form-table__title`
- `FormTableInput.scss` — `.form-table-input__label`
- `BasicProfilePanel.scss` — `.basic-profile-card__details-keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)