### PR TITLE
Unify stacked ContentCardLink lists into a single rounded list

### DIFF
--- a/judgels-client/src/components/ContentCardLink/ContentCardLink.scss
+++ b/judgels-client/src/components/ContentCardLink/ContentCardLink.scss
@@ -5,6 +5,20 @@
   display: block;
   padding: 0;
   overflow: auto;
+  border-radius: 2px;
+}
+
+// Render a contiguous run of cards as a single unified list: only round the
+// top of the first card and the bottom of the last card in the run. Cards
+// separated by other elements (e.g. an <hr>) start a new run.
+.content-card-link + .content-card-link {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.content-card-link:has(+ .content-card-link) {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .content-card-link:hover {


### PR DESCRIPTION
## Problem

On pages like `/contests/:slug/problems`, each problem row is rendered as a standalone Blueprint card (`bp6-card`, via `ContentCardLink`) with rounded corners. Stacked directly on top of each other, every card kept all four rounded corners, so the curves pinched inward at each boundary — leaving little notches and making the stack read as a pile of separate pills rather than one clean list.

## Fix

In `ContentCardLink.scss`, a contiguous run of cards now renders as a single unified list:

- Only the **first** card keeps its rounded **top** corners.
- Only the **last** card keeps its rounded **bottom** corners.
- Inner corners are squared so rows sit flush; the existing box-shadow rings overlap into a single clean divider line.

Adjacency selectors (`+` and `:has(+ ...)`) are used instead of `:first-child`/`:last-child` so that a run broken by another element — e.g. the `<hr>` between Open and Closed problems — starts a new rounded group.

This is global to `ContentCardLink`, so all stacked card lists (contest problems, problemsets, chapters, courses, contests, home widget) get the consistent unified-list look. All usages are vertical stacks of `display: block` cards, so none are adversely affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)