### PR TITLE
Fix missing source text on problemset/chapter submission pages

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/tlx/submission/programming/SubmissionResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/submission/programming/SubmissionResource.java
@@ -218,8 +218,10 @@ public class SubmissionResource {
                     .reasonNotAllowedToViewSource(reasonNotAllowedToViewSource.get())
                     .build();
         } else {
+            SubmissionSource source = submissionSourceBuilder.fromPastSubmission(submission.getJid(), true);
             submissionWithSource = new SubmissionWithSource.Builder()
                     .submission(submission)
+                    .source(source)
                     .build();
         }
 


### PR DESCRIPTION
## Problem

When an admin (or anyone allowed to view a submission's source) opens the **Submissions** tab and clicks a submission, they only see the source rendered as an **image** instead of selectable source code text.

## Root cause

Regression from #901 (`589b50423`), which split `getSubmissionWithSourceById` in `tlx/submission/programming/SubmissionResource.java` into allowed / not-allowed branches. The allowed branch forgot to carry over the `.source(source)` call, so the response always had `source == null`.

The frontend (`SubmissionPage.jsx`) treats `source == null` with no deny reason as "allowed but no source" and falls back to fetching the rendered source **image** — for everyone, admins included. It went unnoticed because the image looks nearly identical to the real source view (just non-selectable).

## Fix

Restore building and attaching the source on the allowed branch, matching the working `ContestSubmissionResource`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)