### PR TITLE
Wire app name/slogan to DB-persisted settings

### DIFF
--- a/deployment/v3-ubuntu-24.04/ansible/conf/judgels-client.js.j2
+++ b/deployment/v3-ubuntu-24.04/ansible/conf/judgels-client.js.j2
@@ -1,7 +1,5 @@
 window.conf = {
   mode: '{{ app_mode | default('JUDGELS', true) }}',
-  name: '{{ app_name }}',
-  slogan: '{{ app_slogan }}',
   apiUrl: 'https://{{ nginx_domain_judgels_server_api }}/v2',
   welcomeBanner: {
     title: '{{ app_title }}',

--- a/deployment/v3-ubuntu-24.04/ansible/env-example/vars.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/env-example/vars.yml
@@ -1,6 +1,4 @@
 app_version: latest
-app_name: Judgels
-app_slogan: Programming Contest System
 app_title: <h1>Welcome to Judgels</h1>
 app_description: <h2>This is a programming contest system.</h2>
 app_footer: © Ikatan Alumni TOKI

--- a/judgels-backends/judgels-server-api/src/main/java/judgels/api/user/web/UserWebConfig.java
+++ b/judgels-backends/judgels-server-api/src/main/java/judgels/api/user/web/UserWebConfig.java
@@ -10,6 +10,8 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(as = ImmutableUserWebConfig.class)
 public interface UserWebConfig {
+    String getAppName();
+    String getAppSlogan();
     UserRole getRole();
     Optional<Profile> getProfile();
     List<String> getAnnouncements();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/user/web/UserWebResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/user/web/UserWebResource.java
@@ -10,11 +10,13 @@ import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import java.util.Optional;
+import judgels.api.setting.AppSettings;
 import judgels.api.user.role.UserRole;
 import judgels.api.user.web.UserWebConfig;
 import judgels.profile.ProfileStore;
 import judgels.service.actor.ActorChecker;
 import judgels.service.api.actor.AuthHeader;
+import judgels.setting.SettingStore;
 import judgels.user.role.UserRoleStore;
 
 @Path("/api/v2/user-web")
@@ -23,6 +25,7 @@ public class UserWebResource {
     @Inject protected UserRoleStore roleStore;
     @Inject protected ProfileStore profileStore;
     @Inject protected WebConfiguration webConfig;
+    @Inject protected SettingStore settingStore;
 
     @Inject public UserWebResource() {}
 
@@ -31,7 +34,10 @@ public class UserWebResource {
     @Produces(APPLICATION_JSON)
     @UnitOfWork(readOnly = true)
     public UserWebConfig getWebConfig(@HeaderParam(AUTHORIZATION) Optional<AuthHeader> authHeader) {
+        AppSettings app = settingStore.getSettings().getApp();
         UserWebConfig.Builder config = new UserWebConfig.Builder()
+                .appName(app.getName())
+                .appSlogan(app.getSlogan())
                 .announcements(webConfig.getAnnouncements());
 
         if (!authHeader.isPresent()) {

--- a/judgels-client/src/components/Header/Header.jsx
+++ b/judgels-client/src/components/Header/Header.jsx
@@ -3,7 +3,7 @@ import { Link } from '@tanstack/react-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import logo from '../../assets/images/logo-header.png';
-import { APP_CONFIG } from '../../conf';
+import { getAppName, getAppSlogan } from '../../modules/webConfig';
 import DarkModeWidget from '../DarkModeWidget/DarkModeWidget';
 import Menubar from '../Menubar/Menubar';
 import UserWidget from '../UserWidget/UserWidget';
@@ -41,8 +41,8 @@ export default function Header({ items, homeRoute }) {
             <img src={logo} alt="header" className="header__logo" />
           </Link>
           <div className="header__text">
-            <div className="header__title">{APP_CONFIG.name}</div>
-            <div className="header__subtitle">{APP_CONFIG.slogan}</div>
+            <div className="header__title">{getAppName()}</div>
+            <div className="header__subtitle">{getAppSlogan()}</div>
           </div>
         </div>
 

--- a/judgels-client/src/modules/notification/notification.js
+++ b/judgels-client/src/modules/notification/notification.js
@@ -1,11 +1,11 @@
 import logo from '../../assets/images/logo-header.png';
-import { APP_CONFIG } from '../../conf';
+import { getAppName } from '../webConfig';
 
 export function showDesktopNotification(title, tag, message) {
   if (!('Notification' in window)) {
     return;
   }
-  new Notification(title, { body: `${APP_CONFIG.name}: ${message}`, icon: logo, tag: tag });
+  new Notification(title, { body: `${getAppName()}: ${message}`, icon: logo, tag: tag });
 }
 
 export function askDesktopNotificationPermission() {

--- a/judgels-client/src/modules/queries/setting.js
+++ b/judgels-client/src/modules/queries/setting.js
@@ -3,6 +3,7 @@ import { queryOptions } from '@tanstack/react-query';
 import { settingAPI } from '../api/setting';
 import { queryClient } from '../queryClient';
 import { getToken } from '../session';
+import { userWebConfigQueryOptions } from './userWeb';
 
 export const settingsQueryOptions = () =>
   queryOptions({
@@ -14,5 +15,6 @@ export const updateAppSettingsMutationOptions = () => ({
   mutationFn: data => settingAPI.updateAppSettings(getToken(), data),
   onSuccess: () => {
     queryClient.invalidateQueries(settingsQueryOptions());
+    queryClient.invalidateQueries(userWebConfigQueryOptions());
   },
 });

--- a/judgels-client/src/modules/webConfig.js
+++ b/judgels-client/src/modules/webConfig.js
@@ -1,0 +1,14 @@
+import { userWebConfigQueryOptions } from './queries/userWeb';
+import { queryClient } from './queryClient';
+
+function getUserWebConfig() {
+  return queryClient.getQueryData(userWebConfigQueryOptions().queryKey);
+}
+
+export function getAppName() {
+  return getUserWebConfig()?.appName || 'Judgels';
+}
+
+export function getAppSlogan() {
+  return getUserWebConfig()?.appSlogan || 'Programming Contest System';
+}

--- a/judgels-client/src/utils/title.js
+++ b/judgels-client/src/utils/title.js
@@ -1,5 +1,6 @@
-import { APP_CONFIG } from '../conf';
+import { getAppName } from '../modules/webConfig';
 
 export function createDocumentTitle(title) {
-  return title ? `${title} | ${APP_CONFIG.name}` : APP_CONFIG.name;
+  const appName = getAppName();
+  return title ? `${title} | ${appName}` : appName;
 }


### PR DESCRIPTION
Follow-up to #951 (DB-persisted app settings). Wires the live consumers in the frontend to read the app name and slogan from the DB instead of static config.

## Backend
- `UserWebConfig` now carries flattened `appName` / `appSlogan`.
- `UserWebResource` populates them from `SettingStore` (the endpoint already allows anonymous access), so the header/title work for all users — including logged-out — with no extra request.

## Frontend
- New `modules/webConfig.js` exposes `getAppName()` / `getAppSlogan()`, reading from the bootstrap `user-web-config` cache, falling back to `Judgels` / `Programming Contest System` when the DB value is empty.
- Header title/subtitle, `document.title`, and desktop notifications now read from it.
- The superadmin app-settings edit invalidates `user-web-config` so the header/title update live.

## Deployment
- Drop the now-unused `app_name` / `app_slogan` vars from ansible v3.

## Notes
- The DB starts with empty name/slogan (no migration seed); the fallbacks cover that until a superadmin sets them.
- Scoped the ansible cleanup to v3 only; v2 deployments and the local dev conf still carry the (now unused) vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)