### PR TITLE
Initialize app settings on startup

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
@@ -124,6 +124,7 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
                 .build();
 
         component.superadminCreator().ensureSuperadminExists();
+        component.settingCreator().initializeSettings();
 
         env.jersey().register(component.sessionResource());
         env.jersey().register(component.userResource());

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerComponent.java
@@ -18,6 +18,7 @@ import judgels.submission.programming.GradingResponsePoller;
         judgels.user.avatar.UserAvatarModule.class,
         judgels.user.web.WebModule.class,
         judgels.session.SessionModule.class,
+        judgels.setting.SettingModule.class,
 
         judgels.messaging.rabbitmq.RabbitMQModule.class,
         judgels.grading.GradingModule.class,
@@ -72,6 +73,7 @@ public interface JudgelsServerComponent {
     judgels.contest.scoreboard.ContestScoreboardPoller contestScoreboardPoller();
 
     judgels.setting.SettingResource settingResource();
+    judgels.setting.SettingCreator settingCreator();
 
     judgels.session.SessionCleaner sessionCleaner();
     GradingResponsePoller problemGradingResponsePoller();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/setting/SettingCreator.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/setting/SettingCreator.java
@@ -1,0 +1,27 @@
+package judgels.setting;
+
+import io.dropwizard.hibernate.UnitOfWork;
+import judgels.api.setting.AppSettings;
+import judgels.api.setting.AppSettingsUpdateData;
+
+public class SettingCreator {
+    private final SettingStore settingStore;
+
+    public SettingCreator(SettingStore settingStore) {
+        this.settingStore = settingStore;
+    }
+
+    @UnitOfWork
+    public void initializeSettings() {
+        AppSettings app = settingStore.getSettings().getApp();
+
+        AppSettingsUpdateData.Builder data = new AppSettingsUpdateData.Builder();
+        if (app.getName().isEmpty()) {
+            data.name("Judgels");
+        }
+        if (app.getSlogan().isEmpty()) {
+            data.slogan("Programming Contest System");
+        }
+        settingStore.updateAppSettings(data.build());
+    }
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/setting/SettingModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/setting/SettingModule.java
@@ -1,0 +1,20 @@
+package judgels.setting;
+
+import dagger.Module;
+import dagger.Provides;
+import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
+import jakarta.inject.Singleton;
+
+@Module
+public class SettingModule {
+    @Provides
+    @Singleton
+    SettingCreator settingCreator(
+            UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
+            SettingStore settingStore) {
+        return unitOfWorkAwareProxyFactory.create(
+                SettingCreator.class,
+                new Class<?>[]{SettingStore.class},
+                new Object[]{settingStore});
+    }
+}

--- a/judgels-client/src/modules/webConfig.js
+++ b/judgels-client/src/modules/webConfig.js
@@ -6,9 +6,9 @@ function getUserWebConfig() {
 }
 
 export function getAppName() {
-  return getUserWebConfig()?.appName || 'Judgels';
+  return getUserWebConfig()?.appName;
 }
 
 export function getAppSlogan() {
-  return getUserWebConfig()?.appSlogan || 'Programming Contest System';
+  return getUserWebConfig()?.appSlogan;
 }


### PR DESCRIPTION
## Summary
- Add `SettingCreator` with `initializeSettings()` (mirrors `SuperadminCreator`), wired via a new `SettingModule` and invoked on server startup right after `ensureSuperadminExists()`.
- It seeds the app name (`Judgels`) and slogan (`Programming Contest System`) only when those settings are empty, so an admin's customizations survive restarts.
- Drop the corresponding hardcoded fallbacks from `judgels-client`'s `webConfig.js`, since the backend now always provides these values.

## Notes
- Existing deployments pick up the defaults on their next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)