### PR TITLE
Show a simple 404 page for not found pages

### DIFF
--- a/judgels-client/src/components/NotFoundPage/NotFoundPage.jsx
+++ b/judgels-client/src/components/NotFoundPage/NotFoundPage.jsx
@@ -1,0 +1,11 @@
+import { NonIdealState } from '@blueprintjs/core';
+
+import { FullPageLayout } from '../FullPageLayout/FullPageLayout';
+
+export function NotFoundPage() {
+  return (
+    <FullPageLayout>
+      <NonIdealState description="The page you are looking for does not exist." />
+    </FullPageLayout>
+  );
+}

--- a/judgels-client/src/routes/router.jsx
+++ b/judgels-client/src/routes/router.jsx
@@ -2,7 +2,9 @@ import { createRootRoute, createRoute, createRouter } from '@tanstack/react-rout
 import { parse, stringify } from 'query-string';
 
 import { LoadingState } from '../components/LoadingState/LoadingState';
+import { NotFoundPage } from '../components/NotFoundPage/NotFoundPage';
 import { APP_CONFIG } from '../conf';
+import { NotFoundError } from '../modules/api/error';
 import { userWebConfigQueryOptions } from '../modules/queries/userWeb';
 import { queryClient } from '../modules/queryClient';
 import App from './App';
@@ -42,7 +44,10 @@ const appChildren = [
 
 const routeTree = rootRoute.addChildren([appRoute.addChildren(appChildren)]);
 
-function DefaultErrorComponent() {
+function DefaultErrorComponent({ error }) {
+  if (error instanceof NotFoundError) {
+    return <NotFoundPage />;
+  }
   return (
     <div style={{ padding: 20, textAlign: 'center' }}>
       <p>Something went wrong.</p>
@@ -57,6 +62,7 @@ export const router = createRouter({
   scrollRestoration: true,
   defaultPendingComponent: () => <LoadingState large />,
   defaultErrorComponent: DefaultErrorComponent,
+  defaultNotFoundComponent: NotFoundPage,
   parseSearch: searchStr => parse(searchStr),
   stringifySearch: searchObj => {
     const str = stringify(searchObj);


### PR DESCRIPTION
## Summary

Opening a URL for a non-existent resource (e.g. `/profiles/sdfdsf`) previously showed the generic "Something went wrong" error. This renders a simple 404 page instead.

- Added a `NotFoundPage` component using Blueprint's `NonIdealState`.
- The default error component now renders `NotFoundPage` when the error is a `NotFoundError`.
- Wired `defaultNotFoundComponent` so unmatched routes also show the 404 page.

Other genuine/transient errors still fall through to the "Something went wrong" + Refresh fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)