### PR TITLE
Make RabbitMQ optional on the server

### DIFF
--- a/judgels-backends/judgels-commons/judgels-messaging/src/main/java/judgels/messaging/MessageClient.java
+++ b/judgels-backends/judgels-commons/judgels-messaging/src/main/java/judgels/messaging/MessageClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.MessageProperties;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import judgels.messaging.api.Message;
 import judgels.messaging.rabbitmq.RabbitMQ;
@@ -15,14 +16,19 @@ public class MessageClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageClient.class);
 
     private final ObjectMapper objectMapper;
-    private final RabbitMQ rabbitMQ;
+    private final Optional<RabbitMQ> rabbitMQ;
 
-    public MessageClient(ObjectMapper objectMapper, RabbitMQ rabbitMQ) {
+    public MessageClient(ObjectMapper objectMapper, Optional<RabbitMQ> rabbitMQ) {
         this.objectMapper = objectMapper;
         this.rabbitMQ = rabbitMQ;
     }
 
     public void sendMessage(String sourceQueueName, String targetQueueName, String type, String content) {
+        if (rabbitMQ.isEmpty()) {
+            LOGGER.info("RabbitMQ is not configured; skipping sending message");
+            return;
+        }
+
         Message message = new Message.Builder()
                 .sourceQueueName(sourceQueueName)
                 .type(type)
@@ -38,7 +44,7 @@ public class MessageClient {
 
         Channel channel = null;
         try {
-            channel = rabbitMQ.getConnection().createChannel();
+            channel = rabbitMQ.get().getConnection().createChannel();
             channel.queueDeclare(targetQueueName, true, false, false, null);
             channel.basicPublish("", targetQueueName, MessageProperties.PERSISTENT_BASIC, queueMessage.getBytes());
         } catch (IOException | TimeoutException e) {

--- a/judgels-backends/judgels-commons/judgels-messaging/src/main/java/judgels/messaging/rabbitmq/RabbitMQModule.java
+++ b/judgels-backends/judgels-commons/judgels-messaging/src/main/java/judgels/messaging/rabbitmq/RabbitMQModule.java
@@ -11,13 +11,16 @@ import judgels.messaging.MessageListener;
 @Module
 public class RabbitMQModule {
     private final RabbitMQConfiguration config;
+    private final boolean enabled;
 
     public RabbitMQModule(RabbitMQConfiguration config) {
         this.config = config;
+        this.enabled = true;
     }
 
     public RabbitMQModule(Optional<RabbitMQConfiguration> config) {
         this.config = config.orElse(RabbitMQConfiguration.DEFAULT);
+        this.enabled = config.isPresent();
     }
 
     @Provides
@@ -29,7 +32,7 @@ public class RabbitMQModule {
     @Provides
     @Singleton
     MessageClient messageClient(ObjectMapper objectMapper, RabbitMQ rabbitMQ) {
-        return new MessageClient(objectMapper, rabbitMQ);
+        return new MessageClient(objectMapper, enabled ? Optional.of(rabbitMQ) : Optional.empty());
     }
 
     @Provides

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/BaseJudgelsApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/BaseJudgelsApiIntegrationTests.java
@@ -40,6 +40,7 @@ import judgels.api.user.role.UserRole;
 import judgels.app.BaseJudgelsAppIntegrationTests;
 import judgels.app.JudgelsAppConfiguration;
 import judgels.grading.JudgelsServerGradingConfiguration;
+import judgels.messaging.rabbitmq.RabbitMQConfiguration;
 import judgels.service.feign.FeignClients;
 import judgels.session.SessionClient;
 import judgels.user.UserClient;
@@ -100,7 +101,7 @@ public abstract class BaseJudgelsApiIntegrationTests extends BaseJudgelsAppInteg
                 .gradingResponseQueueName("grading-response")
                 .build();
 
-        JudgelsServerConfiguration judgelsConfig = new JudgelsServerConfiguration.Builder()
+        JudgelsServerConfiguration.Builder judgelsConfigBuilder = new JudgelsServerConfiguration.Builder()
                 .baseDataDir(baseDataDir.toAbsolutePath())
                 .appConfig(judgelsAppConfig)
                 .gradingConfig(gradingConfig)
@@ -115,8 +116,13 @@ public abstract class BaseJudgelsApiIntegrationTests extends BaseJudgelsAppInteg
                 .userRegistrationConfig(UserRegistrationConfiguration.DEFAULT)
                 .userResetPasswordConfig(UserResetPasswordConfiguration.DEFAULT)
                 .superadminCreatorConfig(SuperadminCreatorConfiguration.DEFAULT)
-                .webConfig(WebConfiguration.DEFAULT)
-                .build();
+                .webConfig(WebConfiguration.DEFAULT);
+
+        if (System.getenv("CI") != null) {
+            judgelsConfigBuilder.rabbitMQConfig(RabbitMQConfiguration.DEFAULT);
+        }
+
+        JudgelsServerConfiguration judgelsConfig = judgelsConfigBuilder.build();
 
         TrainingConfiguration trainingConfig = new TrainingConfiguration.Builder()
                 .statsConfig(StatsConfiguration.DEFAULT)


### PR DESCRIPTION
## Summary

Makes RabbitMQ optional for the **server** app. The config (`rabbitMQConfig`) was already `Optional` and the grading-response pollers were already gated on its presence, but the **producer** side (`MessageClient.sendMessage`) always tried to connect to a broker. As a result, creating a submission on a server without a broker configured failed with a 500 (`Connection refused`) when the grading request was sent on transaction commit.

## Changes

- `MessageClient` now holds an `Optional<RabbitMQ>` and no-ops (logs and returns) when it's absent, instead of taking a raw `RabbitMQ`. Single source of truth for whether messaging is enabled.
- `RabbitMQModule` passes `Optional.of(rabbitMQ)` only when a config is present; the grader app uses the direct-config constructor so it's always present (unaffected).
- Integration tests no longer require a running RabbitMQ broker locally. In CI a RabbitMQ service container is available, so the tests set `rabbitMQConfig` there to keep exercising the real grading-request path.

## Behavior

- **Server, no `rabbitMQConfig`** (incl. local integ tests): submissions are created/stored normally; grading requests are skipped (logged at INFO).
- **Server, `rabbitMQConfig` present**: unchanged — sends as before, pollers run.
- **Grader**: unchanged — broker always required.

## Testing

- `ContestSubmissionApiIntegrationTests` + `ContestSubmissionApiPermissionIntegrationTests` pass locally **without** a broker.
- Same tests pass with `CI=1` against a real RabbitMQ broker (real send path).
- Checkstyle clean on the messaging module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)