### PR TITLE
Fix TinyMCE editor not reappearing after form remount

### DIFF
--- a/judgels-client/src/components/forms/FormRichTextArea/FormRichTextArea.jsx
+++ b/judgels-client/src/components/forms/FormRichTextArea/FormRichTextArea.jsx
@@ -11,7 +11,7 @@ export function FormRichTextArea({ rows, input, label, meta }) {
   return (
     <FormGroup labelFor={input.name} label={label} intent={getIntent(meta)}>
       <Suspense fallback={null}>
-        <LazyTinyMCETextArea onChange={input.onChange} />
+        <LazyTinyMCETextArea onChange={input.onChange} id={input.name} />
       </Suspense>
       <textarea id={input.name} rows={rows} {...input} className="tinymce" />
       <FormInputValidation meta={meta} />

--- a/judgels-client/src/components/forms/FormRichTextArea/TinyMCETextArea.jsx
+++ b/judgels-client/src/components/forms/FormRichTextArea/TinyMCETextArea.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 let isTinyMCEScriptAdded = false;
 
-function TinyMCETextArea({ onChange }) {
+function TinyMCETextArea({ onChange, id }) {
   const [isLoaded, setIsLoaded] = useState(!!window.tinymce);
 
   useEffect(() => {
@@ -41,7 +41,7 @@ function TinyMCETextArea({ onChange }) {
     }
 
     tinymce.init({
-      selector: '.tinymce',
+      selector: `#${id}`,
       skin_url: '/tinymce/skins/lightgray',
       content_css: '/skins/judgels/content.css',
       branding: false,
@@ -63,7 +63,14 @@ function TinyMCETextArea({ onChange }) {
         });
       },
     });
-  });
+
+    return () => {
+      const editor = tinymce.get(id);
+      if (editor) {
+        editor.remove();
+      }
+    };
+  }, [isLoaded, id]);
 
   return null;
 }

--- a/judgels-client/src/components/forms/FormTableRichTextArea/FormTableRichTextArea.jsx
+++ b/judgels-client/src/components/forms/FormTableRichTextArea/FormTableRichTextArea.jsx
@@ -12,7 +12,7 @@ export function FormTableRichTextArea(props) {
   return (
     <FormTableInput {...props}>
       <Suspense fallback={null}>
-        <LazyTinyMCETextArea onChange={input.onChange} />
+        <LazyTinyMCETextArea onChange={input.onChange} id={input.name} />
       </Suspense>
       <textarea id={input.name} rows={rows} {...input} className="tinymce form-table-rich-textarea" />
     </FormTableInput>


### PR DESCRIPTION
## Problem

In the rich text editor (e.g. Admin → Settings → Home settings → Banner), editing and saving, then editing again, shows only a plain `<textarea>` instead of the TinyMCE editor.

## Root cause

`TinyMCETextArea` called `tinymce.init({ selector: '.tinymce' })` but never tore the editor down on unmount:

1. First Edit → `<textarea id="banner">` rendered, TinyMCE creates an editor with id `banner`.
2. Save/Cancel → the textarea is removed from the DOM, but TinyMCE keeps the `banner` editor in its global registry, now pointing at a detached node.
3. Edit again → a fresh `<textarea id="banner">` renders and `init` runs, but TinyMCE sees an editor named `banner` already exists and silently skips it → bare textarea.

## Fix

- Target the specific element (`selector: #${id}`) instead of the global `.tinymce` class, so each editor manages its own lifecycle.
- Add a cleanup function that calls `editor.remove()` on unmount, clearing the stale instance from TinyMCE's registry.
- Give the effect a proper dependency array `[isLoaded, id]` (previously re-ran on every render).
- Pass `id={input.name}` from `FormRichTextArea` and `FormTableRichTextArea`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)