### PR TITLE
Add integration tests for previously untested API endpoints

### DIFF
--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestHistoryApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestHistoryApiIntegrationTests.java
@@ -1,0 +1,92 @@
+package judgels.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.cfg.AvailableSettings.DIALECT;
+import static org.hibernate.cfg.AvailableSettings.DRIVER;
+import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
+import static org.hibernate.cfg.AvailableSettings.URL;
+
+import java.time.Instant;
+import judgels.api.contest.Contest;
+import judgels.api.contest.history.ContestHistoryResponse;
+import judgels.api.contest.module.ContestModuleType;
+import judgels.api.user.rating.UserRating;
+import judgels.contest.ContestHistoryClient;
+import org.h2.Driver;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.dialect.H2Dialect;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import tlx.api.user.rating.UserRatingUpdateData;
+import tlx.user.UserRatingClient;
+
+class ContestHistoryApiIntegrationTests extends BaseContestApiIntegrationTests {
+    private final ContestHistoryClient historyClient = createClient(ContestHistoryClient.class);
+    private final UserRatingClient userRatingClient = createClient(UserRatingClient.class);
+
+    @BeforeAll
+    static void beforeAll() {
+        Session session = openSession();
+        Transaction txn = session.beginTransaction();
+        session.createNativeQuery("CREATE ALIAS IF NOT EXISTS UNIX_TIMESTAMP FOR \"judgels.persistence.h2.H2SqlFunctions.unixTimestamp\"").executeUpdate();
+        session.createNativeQuery("CREATE ALIAS IF NOT EXISTS FROM_UNIXTIME FOR \"judgels.persistence.h2.H2SqlFunctions.fromUnixTime\"").executeUpdate();
+        txn.commit();
+        session.close();
+    }
+
+    @Test
+    void get_public_history() {
+        assertNotFound(() -> historyClient.getPublicHistory("nonexistent"));
+
+        ContestHistoryResponse empty = historyClient.getPublicHistory(CONTESTANT);
+        assertThat(empty.getData()).isEmpty();
+        assertThat(empty.getContestsMap()).isEmpty();
+
+        Contest contest = buildContest()
+                .modules(ContestModuleType.REGISTRATION)
+                .contestants(CONTESTANT)
+                .ended()
+                .build();
+        setFinalRank(contest.getJid(), contestant.getJid(), 3);
+
+        userRatingClient.updateRatings(adminToken, new UserRatingUpdateData.Builder()
+                .time(Instant.ofEpochSecond(100))
+                .eventJid(contest.getJid())
+                .putRatingsMap(contestant.getJid(), UserRating.of(1500, 1400))
+                .build());
+
+        ContestHistoryResponse history = historyClient.getPublicHistory(CONTESTANT);
+        assertThat(history.getData()).hasSize(1);
+        assertThat(history.getData().get(0).getContestJid()).isEqualTo(contest.getJid());
+        assertThat(history.getData().get(0).getRank()).isEqualTo(3);
+        assertThat(history.getData().get(0).getRating()).contains(UserRating.of(1500, 1400));
+        assertThat(history.getContestsMap()).containsKey(contest.getJid());
+        assertThat(history.getContestsMap().get(contest.getJid()).getSlug()).isEqualTo(contest.getSlug());
+    }
+
+    private static void setFinalRank(String contestJid, String userJid, int rank) {
+        Session session = openSession();
+        Transaction txn = session.beginTransaction();
+        session.createNativeQuery(
+                "update uriel_contest_contestant set finalRank = :rank "
+                        + "where contestJid = :contestJid and userJid = :userJid")
+                .setParameter("rank", rank)
+                .setParameter("contestJid", contestJid)
+                .setParameter("userJid", userJid)
+                .executeUpdate();
+        txn.commit();
+        session.close();
+    }
+
+    private static Session openSession() {
+        Configuration config = new Configuration();
+        config.setProperty(DIALECT, H2Dialect.class.getName());
+        config.setProperty(DRIVER, Driver.class.getName());
+        config.setProperty(URL, "jdbc:h2:mem:test");
+        config.setProperty(GENERATE_STATISTICS, "false");
+
+        return config.buildSessionFactory().openSession();
+    }
+}

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ProblemTagApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ProblemTagApiIntegrationTests.java
@@ -1,0 +1,39 @@
+package judgels.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import judgels.BaseJudgelsApiIntegrationTests;
+import judgels.api.problem.ProblemTagCategory;
+import judgels.api.problem.ProblemTagOption;
+import judgels.api.problem.ProblemTagsResponse;
+import judgels.problem.ProblemTagClient;
+import org.junit.jupiter.api.Test;
+
+class ProblemTagApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
+    private final ProblemTagClient problemTagClient = createClient(ProblemTagClient.class);
+
+    @Test
+    void get_problem_tags() {
+        ProblemTagsResponse response = problemTagClient.getProblemTags();
+
+        List<ProblemTagCategory> data = response.getData();
+        assertThat(data).extracting(ProblemTagCategory::getTitle)
+                .containsExactly("Statement", "Editorial", "Tag", "Type", "Scoring");
+
+        ProblemTagCategory topicCategory = findCategory(data, "Tag");
+        assertThat(topicCategory.getOptions()).isEmpty();
+
+        ProblemTagCategory typeCategory = findCategory(data, "Type");
+        assertThat(typeCategory.getOptions()).extracting(ProblemTagOption::getValue)
+                .containsExactly("engine-batch", "engine-interactive", "engine-output-only", "engine-functional");
+        assertThat(typeCategory.getOptions()).allMatch(option -> option.getCount() == 0);
+    }
+
+    private static ProblemTagCategory findCategory(List<ProblemTagCategory> data, String title) {
+        return data.stream()
+                .filter(category -> category.getTitle().equals(title))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/SettingApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/SettingApiIntegrationTests.java
@@ -1,0 +1,42 @@
+package judgels.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import judgels.BaseJudgelsApiIntegrationTests;
+import judgels.api.setting.AppSettings;
+import judgels.api.setting.HomeSettings;
+import judgels.api.setting.SettingUpdateData;
+import judgels.api.setting.Settings;
+import judgels.setting.SettingClient;
+import org.junit.jupiter.api.Test;
+
+class SettingApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
+    private final SettingClient settingClient = createClient(SettingClient.class);
+
+    @Test
+    void get_and_update_settings() {
+        Settings settings = settingClient.getSettings(adminToken);
+        assertThat(settings.getApp().getName()).isEqualTo(AppSettings.DEFAULT_NAME);
+        assertThat(settings.getApp().getSlogan()).isEqualTo(AppSettings.DEFAULT_SLOGAN);
+        assertThat(settings.getApp().getAnnouncement()).isEmpty();
+        assertThat(settings.getHome().getBanner()).isEqualTo(HomeSettings.DEFAULT_BANNER);
+
+        Settings updated = settingClient.updateSettings(adminToken, new SettingUpdateData.Builder()
+                .app(new AppSettings.Builder()
+                        .name("My Judge")
+                        .slogan("Train hard")
+                        .announcement("Maintenance tonight")
+                        .build())
+                .home(new HomeSettings.Builder()
+                        .banner("<h1>Hello</h1>")
+                        .build())
+                .build());
+
+        assertThat(updated.getApp().getName()).isEqualTo("My Judge");
+        assertThat(updated.getApp().getSlogan()).isEqualTo("Train hard");
+        assertThat(updated.getApp().getAnnouncement()).contains("Maintenance tonight");
+        assertThat(updated.getHome().getBanner()).isEqualTo("<h1>Hello</h1>");
+
+        assertThat(settingClient.getSettings(adminToken)).isEqualTo(updated);
+    }
+}

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/SettingApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/SettingApiPermissionIntegrationTests.java
@@ -1,0 +1,31 @@
+package judgels.api;
+
+import judgels.BaseJudgelsApiIntegrationTests;
+import judgels.api.setting.SettingUpdateData;
+import judgels.setting.SettingClient;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+
+class SettingApiPermissionIntegrationTests extends BaseJudgelsApiIntegrationTests {
+    private final SettingClient settingClient = createClient(SettingClient.class);
+
+    @Test
+    void get_settings() {
+        assertPermitted(getSettings(adminToken));
+        assertForbidden(getSettings(userToken));
+    }
+
+    @Test
+    void update_settings() {
+        assertPermitted(updateSettings(adminToken));
+        assertForbidden(updateSettings(userToken));
+    }
+
+    private ThrowingCallable getSettings(String token) {
+        return () -> settingClient.getSettings(token);
+    }
+
+    private ThrowingCallable updateSettings(String token) {
+        return () -> settingClient.updateSettings(token, new SettingUpdateData.Builder().build());
+    }
+}

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserAvatarApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserAvatarApiIntegrationTests.java
@@ -1,0 +1,29 @@
+package judgels.api;
+
+import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.form.FormData;
+import judgels.BaseJudgelsApiIntegrationTests;
+import judgels.api.user.User;
+import judgels.user.UserAvatarClient;
+import org.junit.jupiter.api.Test;
+
+class UserAvatarApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
+    private final UserAvatarClient avatarClient = createClient(UserAvatarClient.class);
+
+    @Test
+    void update_and_delete_avatar() {
+        User andi = createUser("andi");
+        String andiToken = getToken(andi);
+
+        assertThat(avatarClient.avatarExists(andi.getJid())).isFalse();
+
+        avatarClient.updateAvatar(andiToken, andi.getJid(),
+                new FormData(MULTIPART_FORM_DATA, "avatar.png", new byte[]{1, 2, 3}));
+        assertThat(avatarClient.avatarExists(andi.getJid())).isTrue();
+
+        avatarClient.deleteAvatar(andiToken, andi.getJid());
+        assertThat(avatarClient.avatarExists(andi.getJid())).isFalse();
+    }
+}

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserAvatarApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserAvatarApiPermissionIntegrationTests.java
@@ -1,0 +1,43 @@
+package judgels.api;
+
+import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
+
+import feign.form.FormData;
+import judgels.BaseJudgelsApiIntegrationTests;
+import judgels.api.user.User;
+import judgels.user.UserAvatarClient;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+
+class UserAvatarApiPermissionIntegrationTests extends BaseJudgelsApiIntegrationTests {
+    private final UserAvatarClient avatarClient = createClient(UserAvatarClient.class);
+
+    @Test
+    void update_avatar() {
+        User andi = createUser("andi");
+        String andiToken = getToken(andi);
+
+        assertPermitted(updateAvatar(andiToken, andi.getJid()));
+        assertPermitted(updateAvatar(adminToken, andi.getJid()));
+        assertForbidden(updateAvatar(userToken, andi.getJid()));
+    }
+
+    @Test
+    void delete_avatar() {
+        User budi = createUser("budi");
+        String budiToken = getToken(budi);
+
+        assertPermitted(deleteAvatar(budiToken, budi.getJid()));
+        assertPermitted(deleteAvatar(adminToken, budi.getJid()));
+        assertForbidden(deleteAvatar(userToken, budi.getJid()));
+    }
+
+    private ThrowingCallable updateAvatar(String token, String userJid) {
+        return () -> avatarClient.updateAvatar(token, userJid,
+                new FormData(MULTIPART_FORM_DATA, "avatar.png", new byte[]{1, 2, 3}));
+    }
+
+    private ThrowingCallable deleteAvatar(String token, String userJid) {
+        return () -> avatarClient.deleteAvatar(token, userJid);
+    }
+}

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserWebApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/UserWebApiIntegrationTests.java
@@ -1,0 +1,49 @@
+package judgels.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import judgels.BaseJudgelsApiIntegrationTests;
+import judgels.api.setting.AppSettings;
+import judgels.api.setting.HomeSettings;
+import judgels.api.setting.SettingUpdateData;
+import judgels.api.user.web.UserWebConfig;
+import judgels.setting.SettingClient;
+import judgels.user.UserWebClient;
+import org.junit.jupiter.api.Test;
+
+class UserWebApiIntegrationTests extends BaseJudgelsApiIntegrationTests {
+    private final UserWebClient userWebClient = createClient(UserWebClient.class);
+    private final SettingClient settingClient = createClient(SettingClient.class);
+
+    @Test
+    void get_web_config() {
+        UserWebConfig anonymousConfig = userWebClient.getPublicWebConfig();
+        assertThat(anonymousConfig.getAppName()).isEqualTo(AppSettings.DEFAULT_NAME);
+        assertThat(anonymousConfig.getAppSlogan()).isEqualTo(AppSettings.DEFAULT_SLOGAN);
+        assertThat(anonymousConfig.getHomeBanner()).isEqualTo(HomeSettings.DEFAULT_BANNER);
+        assertThat(anonymousConfig.getRole().getAccount()).isEmpty();
+        assertThat(anonymousConfig.getProfile()).isEmpty();
+
+        UserWebConfig adminConfig = userWebClient.getWebConfig(adminToken);
+        assertThat(adminConfig.getRole().getAccount()).contains("ADMIN");
+        assertThat(adminConfig.getProfile()).isPresent();
+        assertThat(adminConfig.getProfile().get().getUsername()).isEqualTo("admin");
+
+        settingClient.updateSettings(adminToken, new SettingUpdateData.Builder()
+                .app(new AppSettings.Builder()
+                        .name("Updated")
+                        .slogan("Updated slogan")
+                        .announcement("Hi")
+                        .build())
+                .home(new HomeSettings.Builder()
+                        .banner("<h1>Updated</h1>")
+                        .build())
+                .build());
+
+        UserWebConfig updatedConfig = userWebClient.getPublicWebConfig();
+        assertThat(updatedConfig.getAppName()).isEqualTo("Updated");
+        assertThat(updatedConfig.getAppSlogan()).isEqualTo("Updated slogan");
+        assertThat(updatedConfig.getAppAnnouncement()).contains("Hi");
+        assertThat(updatedConfig.getHomeBanner()).isEqualTo("<h1>Updated</h1>");
+    }
+}

--- a/judgels-backends/judgels-server-feign/src/main/java/judgels/contest/ContestHistoryClient.java
+++ b/judgels-backends/judgels-server-feign/src/main/java/judgels/contest/ContestHistoryClient.java
@@ -1,0 +1,10 @@
+package judgels.contest;
+
+import feign.Param;
+import feign.RequestLine;
+import judgels.api.contest.history.ContestHistoryResponse;
+
+public interface ContestHistoryClient {
+    @RequestLine("GET /api/v2/contest-history/public?username={username}")
+    ContestHistoryResponse getPublicHistory(@Param("username") String username);
+}

--- a/judgels-backends/judgels-server-feign/src/main/java/judgels/problem/ProblemTagClient.java
+++ b/judgels-backends/judgels-server-feign/src/main/java/judgels/problem/ProblemTagClient.java
@@ -1,0 +1,9 @@
+package judgels.problem;
+
+import feign.RequestLine;
+import judgels.api.problem.ProblemTagsResponse;
+
+public interface ProblemTagClient {
+    @RequestLine("GET /api/v2/problems/tags")
+    ProblemTagsResponse getProblemTags();
+}

--- a/judgels-backends/judgels-server-feign/src/main/java/judgels/setting/SettingClient.java
+++ b/judgels-backends/judgels-server-feign/src/main/java/judgels/setting/SettingClient.java
@@ -1,0 +1,17 @@
+package judgels.setting;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import judgels.api.setting.SettingUpdateData;
+import judgels.api.setting.Settings;
+
+public interface SettingClient {
+    @RequestLine("GET /api/v2/settings")
+    @Headers("Authorization: Bearer {token}")
+    Settings getSettings(@Param("token") String token);
+
+    @RequestLine("PUT /api/v2/settings")
+    @Headers({"Authorization: Bearer {token}", "Content-Type: application/json"})
+    Settings updateSettings(@Param("token") String token, SettingUpdateData data);
+}

--- a/judgels-backends/judgels-server-feign/src/main/java/judgels/user/UserAvatarClient.java
+++ b/judgels-backends/judgels-server-feign/src/main/java/judgels/user/UserAvatarClient.java
@@ -1,0 +1,19 @@
+package judgels.user;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import feign.form.FormData;
+
+public interface UserAvatarClient {
+    @RequestLine("GET /api/v2/users/{userJid}/avatar/exists")
+    boolean avatarExists(@Param("userJid") String userJid);
+
+    @RequestLine("POST /api/v2/users/{userJid}/avatar")
+    @Headers({"Authorization: Bearer {token}", "Content-Type: multipart/form-data"})
+    void updateAvatar(@Param("token") String token, @Param("userJid") String userJid, @Param("file") FormData file);
+
+    @RequestLine("DELETE /api/v2/users/{userJid}/avatar")
+    @Headers("Authorization: Bearer {token}")
+    void deleteAvatar(@Param("token") String token, @Param("userJid") String userJid);
+}

--- a/judgels-backends/judgels-server-feign/src/main/java/judgels/user/UserWebClient.java
+++ b/judgels-backends/judgels-server-feign/src/main/java/judgels/user/UserWebClient.java
@@ -1,0 +1,15 @@
+package judgels.user;
+
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import judgels.api.user.web.UserWebConfig;
+
+public interface UserWebClient {
+    @RequestLine("GET /api/v2/user-web/config")
+    UserWebConfig getPublicWebConfig();
+
+    @RequestLine("GET /api/v2/user-web/config")
+    @Headers("Authorization: Bearer {token}")
+    UserWebConfig getWebConfig(@Param("token") String token);
+}


### PR DESCRIPTION
## Summary

Adds endpoint integration tests for the remaining judgels (non-TLX, non-`michael`) API endpoints that previously had no coverage:

| Endpoint | Feign client | Test(s) |
|---|---|---|
| `GET/PUT /api/v2/settings` | `SettingClient` | `SettingApiIntegrationTests`, `SettingApiPermissionIntegrationTests` |
| `GET /api/v2/user-web/config` | `UserWebClient` | `UserWebApiIntegrationTests` |
| `GET /api/v2/problems/tags` | `ProblemTagClient` | `ProblemTagApiIntegrationTests` |
| `GET /api/v2/contest-history/public` | `ContestHistoryClient` | `ContestHistoryApiIntegrationTests` |
| `GET/POST/DELETE /api/v2/users/{userJid}/avatar` | `UserAvatarClient` | `UserAvatarApiIntegrationTests`, `UserAvatarApiPermissionIntegrationTests` |

Each test follows the existing `*ApiIntegrationTests` conventions (extends `BaseJudgelsApiIntegrationTests` / `BaseContestApiIntegrationTests`, uses `createClient(...)`, `adminToken`/`userToken`, AssertJ + builders; permission tests use `assertPermitted`/`assertForbidden`).

Out of scope: `ProblemResource` and `LessonResource` render endpoints (media-file rendering requires `michael` problem/lesson creation + binary fixtures).

## Test plan

- `./judgels-backends/gradlew -p judgels-backends/judgels-server-feign compileJava checkstyleMain`
- `./judgels-backends/gradlew -p judgels-backends/judgels-server-app checkstyleIntegTest integTest --tests 'judgels.api.SettingApiIntegrationTests' --tests 'judgels.api.SettingApiPermissionIntegrationTests' --tests 'judgels.api.UserWebApiIntegrationTests' --tests 'judgels.api.ProblemTagApiIntegrationTests' --tests 'judgels.api.ContestHistoryApiIntegrationTests' --tests 'judgels.api.UserAvatarApiIntegrationTests' --tests 'judgels.api.UserAvatarApiPermissionIntegrationTests'`

All new tests pass and checkstyle is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)