### PR TITLE
Fill backend permission and frontend page test gaps

### DIFF
--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestItemSubmissionApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestItemSubmissionApiPermissionIntegrationTests.java
@@ -1,0 +1,84 @@
+package judgels.api;
+
+import jakarta.ws.rs.core.Form;
+import judgels.api.contest.Contest;
+import judgels.api.problem.bundle.ItemType;
+import judgels.api.submission.bundle.ItemSubmissionData;
+import judgels.contest.ContestItemSubmissionClient;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ContestItemSubmissionApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
+    private static final String PROBLEM_ALIAS = "B";
+
+    private final ContestItemSubmissionClient submissionClient = createClient(ContestItemSubmissionClient.class);
+
+    private Contest contest;
+    private String itemJid;
+
+    @BeforeEach
+    void before() {
+        contest = buildContestWithRoles()
+                .begun()
+                .problems(PROBLEM_ALIAS, PROBLEM_3_SLUG)
+                .build();
+
+        updateProblemStatement(managerToken, problem3, "Problem 3", "text");
+
+        Form form = new Form();
+        form.param("meta", "1");
+        form.param("statement", "<p>QUESTION 1</p>");
+        form.param("score", "10");
+        itemJid = createBundleProblemItem(managerToken, problem3, ItemType.ESSAY, form);
+    }
+
+    @Test
+    void get_submissions() {
+        assertPermitted(getSubmissions(adminToken));
+        assertPermitted(getSubmissions(managerToken));
+        assertPermitted(getSubmissions(supervisorToken));
+        assertPermitted(getSubmissions(contestantToken));
+        assertForbidden(getSubmissions(userToken));
+    }
+
+    @Test
+    void create_submission() {
+        assertPermitted(submit(adminToken));
+        assertPermitted(submit(managerToken));
+        assertPermitted(submit(supervisorToken));
+        assertPermitted(submit(contestantToken));
+        assertForbidden(submit(userToken))
+                .hasMessageContaining("You are not a contestant");
+    }
+
+    @Test
+    void regrade_submissions() {
+        assertPermitted(regrade(adminToken));
+        assertPermitted(regrade(managerToken));
+        assertForbidden(regrade(supervisorToken));
+        assertForbidden(regrade(contestantToken));
+        assertForbidden(regrade(userToken));
+    }
+
+    private ThrowingCallable getSubmissions(String token) {
+        return () -> submissionClient.getSubmissions(
+                token, contest.getJid(), new ContestItemSubmissionClient.GetSubmissionsParams());
+    }
+
+    private ThrowingCallable submit(String token) {
+        return () -> submissionClient.createItemSubmission(token, new ItemSubmissionData.Builder()
+                .containerJid(contest.getJid())
+                .problemJid(problem3.getJid())
+                .itemJid(itemJid)
+                .answer("hello")
+                .build());
+    }
+
+    private ThrowingCallable regrade(String token) {
+        var params = new ContestItemSubmissionClient.RegradeSubmissionsParams();
+        params.contestJid = contest.getJid();
+        params.problemJid = problem3.getJid();
+        return () -> submissionClient.regradeSubmissions(token, params);
+    }
+}

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestWebApiPermissionIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestWebApiPermissionIntegrationTests.java
@@ -1,0 +1,49 @@
+package judgels.api;
+
+import static judgels.api.contest.module.ContestModuleType.HIDDEN;
+import static judgels.api.contest.module.ContestModuleType.REGISTRATION;
+
+import judgels.api.contest.Contest;
+import judgels.contest.ContestWebClient;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+
+class ContestWebApiPermissionIntegrationTests extends BaseContestApiIntegrationTests {
+    private final ContestWebClient webClient = createClient(ContestWebClient.class);
+
+    private Contest contest;
+
+    @Test
+    void get_web_config() {
+        contest = createContestWithRoles();
+
+        assertPermitted(getWebConfig(adminToken));
+        assertPermitted(getWebConfig(managerToken));
+        assertPermitted(getWebConfig(supervisorToken));
+        assertPermitted(getWebConfig(contestantToken));
+        assertForbidden(getWebConfig(userToken));
+        assertForbidden(getWebConfig(""));
+
+        enableModule(contest, REGISTRATION);
+
+        assertPermitted(getWebConfig(adminToken));
+        assertPermitted(getWebConfig(managerToken));
+        assertPermitted(getWebConfig(supervisorToken));
+        assertPermitted(getWebConfig(contestantToken));
+        assertPermitted(getWebConfig(userToken));
+        assertPermitted(getWebConfig(""));
+
+        enableModule(contest, HIDDEN);
+
+        assertPermitted(getWebConfig(adminToken));
+        assertPermitted(getWebConfig(managerToken));
+        assertForbidden(getWebConfig(supervisorToken));
+        assertForbidden(getWebConfig(contestantToken));
+        assertForbidden(getWebConfig(userToken));
+        assertForbidden(getWebConfig(""));
+    }
+
+    private ThrowingCallable getWebConfig(String token) {
+        return () -> webClient.getWebConfig(token, contest.getJid());
+    }
+}

--- a/judgels-client/src/routes/account/account/changeAvatar/ChangeAvatarPage/ChangeAvatarPage.test.jsx
+++ b/judgels-client/src/routes/account/account/changeAvatar/ChangeAvatarPage/ChangeAvatarPage.test.jsx
@@ -1,0 +1,44 @@
+import { act, render, screen } from '@testing-library/react';
+import nock from 'nock';
+
+import { setSession } from '../../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../../test/RouterWrapper';
+import { nockApi } from '../../../../../utils/nock';
+import ChangeAvatarPage from './ChangeAvatarPage';
+
+describe('ChangeAvatarPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'JIDUSER1' });
+  });
+
+  const renderComponent = async avatarExists => {
+    nockApi().get('/users/JIDUSER1/avatar/exists').reply(200, avatarExists);
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter>
+            <ChangeAvatarPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders upload form with current avatar', async () => {
+    await renderComponent(true);
+
+    expect(await screen.findByText('Current avatar')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /remove avatar/i })).toBeInTheDocument();
+    expect(screen.getByText('Upload new avatar')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /upload/i })).toBeInTheDocument();
+  });
+
+  test('renders upload form without current avatar', async () => {
+    await renderComponent(false);
+
+    expect(await screen.findByText('Upload new avatar')).toBeInTheDocument();
+    expect(screen.queryByText('Current avatar')).not.toBeInTheDocument();
+  });
+});

--- a/judgels-client/src/routes/account/account/info/InfoPage/InfoPage.test.jsx
+++ b/judgels-client/src/routes/account/account/info/InfoPage/InfoPage.test.jsx
@@ -1,0 +1,73 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+
+import { setSession } from '../../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../../test/RouterWrapper';
+import { nockApi } from '../../../../../utils/nock';
+import InfoPage from './InfoPage';
+
+describe('InfoPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'JIDUSER1' });
+  });
+
+  const renderComponent = async () => {
+    nockApi().get('/users/JIDUSER1').reply(200, {
+      jid: 'JIDUSER1',
+      username: 'andi',
+      email: 'andi@domain.com',
+    });
+
+    nockApi().get('/users/JIDUSER1/info').reply(200, {
+      name: 'Andi',
+      gender: 'MALE',
+      country: 'ID',
+      homeAddress: 'Address',
+      shirtSize: 'M',
+      institutionName: 'MIT',
+      institutionCountry: 'US',
+      institutionProvince: 'MA',
+      institutionCity: 'Cambridge',
+    });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter>
+            <InfoPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('details', async () => {
+    await renderComponent();
+
+    await waitFor(() => expect(document.querySelector('[data-key="name"]').textContent).toEqual('Andi'));
+    expect(document.querySelector('[data-key="country"]').textContent).toEqual('Indonesia');
+    expect(document.querySelector('[data-key="institutionName"]').textContent).toEqual('MIT');
+  });
+
+  test('info form', async () => {
+    await renderComponent();
+
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: /edit/i }));
+
+    const name = screen.getByDisplayValue('Andi');
+    await user.clear(name);
+    await user.type(name, 'New Andi');
+
+    nockApi()
+      .put('/users/JIDUSER1/info', body => body.name === 'New Andi')
+      .reply(200, {});
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(nock.isDone()).toBe(true));
+  });
+});

--- a/judgels-client/src/routes/problems/problems/ProblemsPage/ProblemsPage.test.jsx
+++ b/judgels-client/src/routes/problems/problems/ProblemsPage/ProblemsPage.test.jsx
@@ -1,0 +1,43 @@
+import { act, render, screen } from '@testing-library/react';
+import nock from 'nock';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockApi } from '../../../../utils/nock';
+import ProblemsPage from './ProblemsPage';
+
+describe('ProblemsPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async () => {
+    nockApi()
+      .get('/problems')
+      .query(true)
+      .reply(200, {
+        data: { page: [], totalCount: 0 },
+        problemsMap: {},
+        problemMetadatasMap: {},
+        problemDifficultiesMap: {},
+        problemProgressesMap: {},
+      });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter>
+            <ProblemsPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders filter placeholder when no tags selected', async () => {
+    await renderComponent();
+
+    expect(await screen.findByText(/select some filters on the left/i)).toBeInTheDocument();
+  });
+});

--- a/judgels-client/src/routes/problems/problemsets/ProblemSetsPage/ProblemSetsPage.test.jsx
+++ b/judgels-client/src/routes/problems/problemsets/ProblemSetsPage/ProblemSetsPage.test.jsx
@@ -1,0 +1,54 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockApi } from '../../../../utils/nock';
+import ProblemSetsPage from './ProblemSetsPage';
+
+describe('ProblemSetsPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async response => {
+    nockApi().get('/problemsets').query(true).reply(200, response);
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter>
+            <ProblemSetsPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders problemsets', async () => {
+    await renderComponent({
+      data: {
+        page: [{ jid: 'JIDPS1', slug: 'ps-1', name: 'Problemset One', archiveJid: 'JIDARC1', description: '' }],
+        totalCount: 1,
+      },
+      archiveDescriptionsMap: {},
+      problemSetProgressesMap: {},
+      profilesMap: {},
+    });
+
+    expect(await screen.findByText('Problemset One')).toBeInTheDocument();
+    expect(screen.getByText(/most recently added problemsets/i)).toBeInTheDocument();
+  });
+
+  test('renders empty placeholder', async () => {
+    await renderComponent({
+      data: { page: [], totalCount: 0 },
+      archiveDescriptionsMap: {},
+      problemSetProgressesMap: {},
+      profilesMap: {},
+    });
+
+    await waitFor(() => expect(screen.getByText(/no problemsets/i)).toBeInTheDocument());
+  });
+});

--- a/judgels-client/src/routes/submissions/SubmissionsPage/SubmissionsPage.test.jsx
+++ b/judgels-client/src/routes/submissions/SubmissionsPage/SubmissionsPage.test.jsx
@@ -1,0 +1,45 @@
+import { act, render, screen } from '@testing-library/react';
+import nock from 'nock';
+
+import { setSession } from '../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../test/RouterWrapper';
+import { nockApi } from '../../../utils/nock';
+import SubmissionsPage from './SubmissionsPage';
+
+describe('SubmissionsPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid', username: 'andi' });
+  });
+
+  const renderComponent = async page => {
+    nockApi()
+      .get('/submissions/programming')
+      .query(true)
+      .reply(200, {
+        data: { page, hasPreviousPage: false, hasNextPage: false },
+        config: { canManage: false },
+        profilesMap: {},
+        problemAliasesMap: {},
+        problemNamesMap: {},
+        containerNamesMap: {},
+        containerPathsMap: {},
+      });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter>
+            <SubmissionsPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders empty placeholder', async () => {
+    await renderComponent([]);
+
+    expect(await screen.findByText(/no submissions/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes test gaps surfaced by an audit of the existing coverage.

### Backend — missing permission tests
Two endpoints enforced role checks but lacked `*PermissionIntegrationTests` (unlike their siblings, e.g. `ContestSubmission`):
- `ContestWebApiPermissionIntegrationTests` — `canView` model (mirrors `get_contest`: roles + REGISTRATION/HIDDEN visibility).
- `ContestItemSubmissionApiPermissionIntegrationTests` — `canViewOwn` (get), `canSubmit` (create), `canManage` (regrade).

### Frontend — previously untested pages
Page-level tests (page-test pattern: wrappers + `nock` + `userEvent`) for pages with zero coverage:

| Page | Coverage |
|---|---|
| `account/InfoPage` | load (GET user+info) → render, info form edit → PUT |
| `account/ChangeAvatarPage` | render (with/without current avatar) |
| `problems/ProblemSetsPage` | renders list + empty state |
| `problems/ProblemsPage` | renders filter placeholder |
| `submissions/SubmissionsPage` | renders empty state |

Notes: `InfoPage`'s form test is intentionally thin (the inner `InfoPanel` already has a full form test); `ProblemsPage`/`SubmissionsPage` get render + empty-state coverage (their row components need heavy fixtures), and `ChangeAvatarPage` is render-only (it calls `window.location.reload()` on submit).

## Test plan
- Backend: `./judgels-backends/gradlew -p judgels-backends/judgels-server-app checkstyleIntegTest integTest --tests 'judgels.api.ContestWebApiPermissionIntegrationTests' --tests 'judgels.api.ContestItemSubmissionApiPermissionIntegrationTests'` — pass.
- Frontend: `yarn test --run` on the 5 new files — 8 tests pass; Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)