### PR TITLE
Make Michael read app name from setting store

### DIFF
--- a/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
+++ b/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
@@ -51,7 +51,6 @@ judgels:
 {% if app_licenseKey is defined %}
     licenseKey: {{ app_licenseKey }}
 {% endif %}
-    name: {{ app_name }}
 
 {% if rabbitmq_username is defined %}
   rabbitmq:

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/BaseJudgelsApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/BaseJudgelsApiIntegrationTests.java
@@ -92,7 +92,6 @@ public abstract class BaseJudgelsApiIntegrationTests extends BaseJudgelsAppInteg
         setEditionAsTLX();
 
         JudgelsAppConfiguration judgelsAppConfig = new JudgelsAppConfiguration.Builder()
-                .name("Judgels")
                 .build();
 
         JudgelsServerGradingConfiguration gradingConfig = new JudgelsServerGradingConfiguration.Builder()

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsAppConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsAppConfiguration.java
@@ -8,7 +8,6 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableJudgelsAppConfiguration.class)
 public interface JudgelsAppConfiguration {
     Optional<String> getLicenseKey();
-    String getName();
 
     class Builder extends ImmutableJudgelsAppConfiguration.Builder {}
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/michael/BaseResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/michael/BaseResource.java
@@ -6,13 +6,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import judgels.api.actor.Actor;
-import judgels.app.JudgelsAppConfiguration;
 import judgels.michael.actor.ActorChecker;
 import judgels.michael.template.HtmlTemplate;
+import judgels.setting.SettingStore;
 import judgels.user.UserRoleChecker;
 
 public abstract class BaseResource {
-    @Inject protected JudgelsAppConfiguration appConfig;
+    @Inject protected SettingStore settingStore;
     @Inject protected ActorChecker actorChecker;
     @Inject protected UserRoleChecker userRoleChecker;
 
@@ -33,7 +33,7 @@ public abstract class BaseResource {
     }
 
     protected HtmlTemplate newTemplate() {
-        return new HtmlTemplate(appConfig.getName());
+        return new HtmlTemplate(settingStore.getSettings().getApp().getName());
     }
 
     protected HtmlTemplate newTemplate(Actor actor) {


### PR DESCRIPTION
## Summary

After the app-settings migration, the app name lived in **two** places — the DB-persisted setting store and the static `app.name` config field. The config copy had a single remaining reader: Michael's admin HTML header (`BaseResource.newTemplate()`). Everything else (React frontend, `/user-web/config`) already reads from the setting store.

Because `SettingCreator` seeds the DB with `DEFAULT_NAME` and ignores the config, Michael could render a **different** name than the React frontend. This makes the setting store the single source of truth.

## Changes

- **`BaseResource`** — inject `SettingStore` instead of `JudgelsAppConfiguration`; `newTemplate()` now reads `getSettings().getApp().getName()`.
- **`JudgelsAppConfiguration`** — remove the now-orphaned `getName()`; only `getLicenseKey()` remains.
- **v3 ansible** (`conf/judgels-server.yml.j2`) — remove the dangling `name: {{ app_name }}` line (`app_name` had already been dropped from the deployment vars, so this was referencing an undefined variable).
- **integTest** — drop the now-invalid `.name("Judgels")` builder call.

No new Dagger wiring needed: `SettingStore` has an `@Inject` constructor and `SettingDao` is already bound in `MichaelComponent` via `JudgelsServerHibernateDaoModule`. All `newTemplate()` callers run under `@UnitOfWork`, so the Hibernate session is available for the read.

## Notes

- **Slogan not wired:** Michael's header renders only the name (`<h1>${name}</h1>`); its subtitle is a hardcoded "| Administration". There's no slogan in the admin UI, so nothing to plumb.
- **Legacy deployments untouched:** the `v2-ubuntu-*` ansible dirs still reference `app_name`, but those target the old multi-service architecture (`jophiel`/`uriel`/`jerahmeel`) where the `name` config field still exists, so they're intentionally left as-is.
- **Breaking-ish:** any deployment whose `judgels-server.yml` still sets `app.name:` will now fail Dropwizard's unknown-property check on startup. Consistent with the prior BREAKING #966 direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)