### PR TITLE
Add "allow higher divisions unofficially" to division contests

### DIFF
--- a/judgels-backends/judgels-server-api/src/main/java/judgels/api/contest/module/DivisionModuleConfig.java
+++ b/judgels-backends/judgels-server-api/src/main/java/judgels/api/contest/module/DivisionModuleConfig.java
@@ -15,5 +15,10 @@ public interface DivisionModuleConfig extends ModuleConfig {
 
     int getDivision();
 
+    @Value.Default
+    default boolean getAllowHigherDivisionsUnofficially() {
+        return false;
+    }
+
     class Builder extends ImmutableDivisionModuleConfig.Builder {}
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
@@ -21,6 +21,7 @@ import judgels.api.contest.Contest;
 import judgels.api.contest.ContestStyle;
 import judgels.api.contest.contestant.ContestContestant;
 import judgels.api.contest.module.ContestModulesConfig;
+import judgels.api.contest.module.DivisionModuleConfig;
 import judgels.api.contest.module.ExternalScoreboardModuleConfig;
 import judgels.api.contest.module.StyleModuleConfig;
 import judgels.api.contest.problem.ContestProblem;
@@ -31,11 +32,13 @@ import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
 import judgels.api.submission.bundle.ItemSubmission;
 import judgels.api.submission.programming.Submission;
+import judgels.api.user.rating.UserRating;
 import judgels.contest.ContestStore;
 import judgels.contest.ContestTimer;
 import judgels.contest.contestant.ContestContestantStore;
 import judgels.contest.module.ContestModuleStore;
 import judgels.contest.problem.ContestProblemStore;
+import judgels.contest.rating.ContestRatingProvider;
 import judgels.grading.api.ScoringConfig;
 import judgels.problem.ProblemService;
 import judgels.profile.ProfileStore;
@@ -57,6 +60,7 @@ public class ContestScoreboardUpdater {
     private final ContestScoreboardPusher scoreboardPusher;
     private final ProfileStore profileStore;
     private final ProblemService problemService;
+    private final ContestRatingProvider ratingProvider;
 
     public ContestScoreboardUpdater(
             ObjectMapper objectMapper,
@@ -72,7 +76,8 @@ public class ContestScoreboardUpdater {
             ScoreboardProcessorRegistry scoreboardProcessorRegistry,
             ContestScoreboardPusher scoreboardPusher,
             ProfileStore profileStore,
-            ProblemService problemService) {
+            ProblemService problemService,
+            ContestRatingProvider ratingProvider) {
 
         this.objectMapper = objectMapper;
         this.contestTimer = contestTimer;
@@ -88,6 +93,7 @@ public class ContestScoreboardUpdater {
         this.scoreboardPusher = scoreboardPusher;
         this.profileStore = profileStore;
         this.problemService = problemService;
+        this.ratingProvider = ratingProvider;
     }
 
     @UnitOfWork
@@ -179,6 +185,21 @@ public class ContestScoreboardUpdater {
 
         Map<String, Profile> profilesMap = profileStore.getProfiles(contestantJidsSet, contest.getBeginTime());
 
+        // If the contest lets higher divisions participate unofficially, contestants outside the
+        // contest's own division are shown on the scoreboard but excluded from rank numbering.
+        Set<String> unofficialContestantJids = new HashSet<>();
+        Optional<DivisionModuleConfig> divisionConfig = moduleStore.getDivisionModuleConfig(contest.getJid());
+        if (divisionConfig.isPresent() && divisionConfig.get().getAllowHigherDivisionsUnofficially()) {
+            int division = divisionConfig.get().getDivision();
+            for (String contestantJid : contestantJidsSet) {
+                Optional<UserRating> rating = Optional.ofNullable(profilesMap.get(contestantJid))
+                        .flatMap(Profile::getRating);
+                if (!ratingProvider.isRatingInDivision(rating, division)) {
+                    unofficialContestantJids.add(contestantJid);
+                }
+            }
+        }
+
         Map<String, ScoringConfig> problemScoringConfigsMap = contest.getStyle() == ContestStyle.BUNDLE
                 ? Map.of()
                 : problemService.getProgrammingProblemScoringConfigs(problemJidsSet);
@@ -226,7 +247,8 @@ public class ContestScoreboardUpdater {
                     problemScoringConfigsMap,
                     profilesMap,
                     programmingSubmissions,
-                    bundleItemSubmissions);
+                    bundleItemSubmissions,
+                    unofficialContestantJids);
 
             Scoreboard scoreboard = processor.create(state, result.getEntries());
 
@@ -248,7 +270,8 @@ public class ContestScoreboardUpdater {
 
         if (contestTimer.hasEnded(contest)) {
             for (ScoreboardEntry e : scoreboards.get(OFFICIAL).getContent().getEntries()) {
-                if (e.hasSubmission()) {
+                // rank <= 0 means unofficial (or incognito); such contestants get no final rank.
+                if (e.hasSubmission() && e.getRank() > 0) {
                     contestantStore.updateContestantFinalRank(contest.getJid(), e.getContestantJid(), e.getRank());
                 }
             }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdaterModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdaterModule.java
@@ -11,6 +11,7 @@ import judgels.contest.ContestTimer;
 import judgels.contest.contestant.ContestContestantStore;
 import judgels.contest.module.ContestModuleStore;
 import judgels.contest.problem.ContestProblemStore;
+import judgels.contest.rating.ContestRatingProvider;
 import judgels.contest.submission.bundle.ContestItemSubmissionStore;
 import judgels.contest.submission.programming.ContestSubmissionStore;
 import judgels.problem.ProblemService;
@@ -66,7 +67,8 @@ public class ContestScoreboardUpdaterModule {
             ScoreboardProcessorRegistry scoreboardProcessorRegistry,
             ContestScoreboardPusher scoreboardPusher,
             ProfileStore profileStore,
-            ProblemService problemService) {
+            ProblemService problemService,
+            ContestRatingProvider ratingProvider) {
 
         return unitOfWorkAwareProxyFactory.create(
                 ContestScoreboardUpdater.class,
@@ -84,7 +86,8 @@ public class ContestScoreboardUpdaterModule {
                         ScoreboardProcessorRegistry.class,
                         ContestScoreboardPusher.class,
                         ProfileStore.class,
-                        ProblemService.class},
+                        ProblemService.class,
+                        ContestRatingProvider.class},
                 new Object[] {
                         objectMapper,
                         contestTimer,
@@ -99,6 +102,7 @@ public class ContestScoreboardUpdaterModule {
                         scoreboardProcessorRegistry,
                         scoreboardPusher,
                         profileStore,
-                        problemService});
+                        problemService,
+                        ratingProvider});
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessor.java
@@ -22,6 +22,7 @@ public interface ScoreboardProcessor {
 
     boolean requiresGradingDetails(StyleModuleConfig styleModuleConfig);
 
+    // Contestants in unofficialContestantJids are shown but excluded from rank numbering (rank 0).
     ScoreboardProcessResult process(
             ScoreboardState scoreboardState,
             Optional<ScoreboardIncrementalContent> incrementalContent,
@@ -32,7 +33,8 @@ public interface ScoreboardProcessor {
             Map<String, ScoringConfig> problemScoringConfigsMap,
             Map<String, Profile> profilesMap,
             List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions);
+            List<ItemSubmission> bundleItemSubmissions,
+            Set<String> unofficialContestantJids);
 
     ScoreboardEntry clearEntryRank(ScoreboardEntry entry);
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessor.java
@@ -64,7 +64,8 @@ public class BundleScoreboardProcessor implements ScoreboardProcessor {
             Map<String, ScoringConfig> problemScoringConfigsMap,
             Map<String, Profile> profilesMap,
             List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions) {
+            List<ItemSubmission> bundleItemSubmissions,
+            Set<String> unofficialContestantJids) {
 
         List<String> problemJids = scoreboardState.getProblemJids();
 
@@ -119,7 +120,8 @@ public class BundleScoreboardProcessor implements ScoreboardProcessor {
                 })
                 .collect(Collectors.toList());
 
-        entries = sortEntriesAndAssignRanks(new UsingTotalScoresBundleScoreboardEntryComparator(), entries);
+        entries = sortEntriesAndAssignRanks(
+                new UsingTotalScoresBundleScoreboardEntryComparator(), entries, unofficialContestantJids);
         return new ScoreboardProcessResult.Builder()
                 .entries(entries)
                 .incrementalContent(new BundleScoreboardIncrementalContent())
@@ -136,23 +138,30 @@ public class BundleScoreboardProcessor implements ScoreboardProcessor {
 
     private static List<BundleScoreboardEntry> sortEntriesAndAssignRanks(
             UsingTotalScoresBundleScoreboardEntryComparator comparator,
-            List<BundleScoreboardEntry> entries) {
+            List<BundleScoreboardEntry> entries,
+            Set<String> unofficialContestantJids) {
 
         entries.sort(comparator);
 
         ImmutableList.Builder<BundleScoreboardEntry> newEntries = ImmutableList.builder();
 
-        int previousRank = 0;
-        for (int i = 0; i < entries.size(); i++) {
-            int assignedRank;
-            if (i == 0 || comparator.compareWithoutTieBreakerForEqualRanks(entries.get(i), entries.get(i - 1)) != 0) {
-                assignedRank = i + 1;
-            } else {
-                assignedRank = previousRank;
+        int officialRank = 0;
+        int officialCount = 0;
+        BundleScoreboardEntry previousOfficial = null;
+        for (BundleScoreboardEntry entry : entries) {
+            if (unofficialContestantJids.contains(entry.getContestantJid())) {
+                newEntries.add(new BundleScoreboardEntry.Builder().from(entry).rank(0).build());
+                continue;
             }
-            previousRank = assignedRank;
 
-            newEntries.add(new BundleScoreboardEntry.Builder().from(entries.get(i)).rank(assignedRank).build());
+            officialCount++;
+            if (previousOfficial == null
+                    || comparator.compareWithoutTieBreakerForEqualRanks(entry, previousOfficial) != 0) {
+                officialRank = officialCount;
+            }
+            previousOfficial = entry;
+
+            newEntries.add(new BundleScoreboardEntry.Builder().from(entry).rank(officialRank).build());
         }
 
         return newEntries.build();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessor.java
@@ -72,7 +72,8 @@ public class GcjScoreboardProcessor implements ScoreboardProcessor {
             Map<String, ScoringConfig> problemScoringConfigsMap,
             Map<String, Profile> profilesMap,
             List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions) {
+            List<ItemSubmission> bundleItemSubmissions,
+            Set<String> unofficialContestantJids) {
 
         GcjStyleModuleConfig gcjStyleModuleConfig = (GcjStyleModuleConfig) styleModuleConfig;
 
@@ -210,7 +211,7 @@ public class GcjScoreboardProcessor implements ScoreboardProcessor {
                     .build());
         }
 
-        entries = sortEntriesAndAssignRanks(entries);
+        entries = sortEntriesAndAssignRanks(entries, unofficialContestantJids);
 
         return new ScoreboardProcessResult.Builder()
                 .entries(entries)
@@ -231,18 +232,30 @@ public class GcjScoreboardProcessor implements ScoreboardProcessor {
                 .build();
     }
 
-    private List<GcjScoreboardEntry> sortEntriesAndAssignRanks(List<GcjScoreboardEntry> entries) {
+    private List<GcjScoreboardEntry> sortEntriesAndAssignRanks(
+            List<GcjScoreboardEntry> entries, Set<String> unofficialContestantJids) {
         ScoreboardEntryComparator<GcjScoreboardEntry> comparator = new StandardGcjScoreboardEntryComparator();
         entries.sort(comparator);
 
         List<GcjScoreboardEntry> result = new ArrayList<>();
 
-        int currentRank = 1;
-        for (int i = 0; i < entries.size(); i++) {
-            if (i != 0 && comparator.compareWithoutTieBreakerForEqualRanks(entries.get(i), entries.get(i - 1)) != 0) {
-                currentRank = i + 1;
+        int officialRank = 0;
+        int officialCount = 0;
+        GcjScoreboardEntry previousOfficial = null;
+        for (GcjScoreboardEntry entry : entries) {
+            if (unofficialContestantJids.contains(entry.getContestantJid())) {
+                result.add(new GcjScoreboardEntry.Builder().from(entry).rank(0).build());
+                continue;
             }
-            result.add(new GcjScoreboardEntry.Builder().from(entries.get(i)).rank(currentRank).build());
+
+            officialCount++;
+            if (previousOfficial == null
+                    || comparator.compareWithoutTieBreakerForEqualRanks(entry, previousOfficial) != 0) {
+                officialRank = officialCount;
+            }
+            previousOfficial = entry;
+
+            result.add(new GcjScoreboardEntry.Builder().from(entry).rank(officialRank).build());
         }
 
         return result;

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessor.java
@@ -72,7 +72,8 @@ public class IcpcScoreboardProcessor implements ScoreboardProcessor {
             Map<String, ScoringConfig> problemScoringConfigsMap,
             Map<String, Profile> profilesMap,
             List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions) {
+            List<ItemSubmission> bundleItemSubmissions,
+            Set<String> unofficialContestantJids) {
 
         IcpcStyleModuleConfig icpcStyleModuleConfig = (IcpcStyleModuleConfig) styleModuleConfig;
 
@@ -215,7 +216,7 @@ public class IcpcScoreboardProcessor implements ScoreboardProcessor {
                     .build());
         }
 
-        entries = sortEntriesAndAssignRanks(entries);
+        entries = sortEntriesAndAssignRanks(entries, unofficialContestantJids);
 
         return new ScoreboardProcessResult.Builder()
                 .entries(entries)
@@ -239,18 +240,30 @@ public class IcpcScoreboardProcessor implements ScoreboardProcessor {
                 .build();
     }
 
-    private List<IcpcScoreboardEntry> sortEntriesAndAssignRanks(List<IcpcScoreboardEntry> entries) {
+    private List<IcpcScoreboardEntry> sortEntriesAndAssignRanks(
+            List<IcpcScoreboardEntry> entries, Set<String> unofficialContestantJids) {
         ScoreboardEntryComparator<IcpcScoreboardEntry> comparator = new StandardIcpcScoreboardEntryComparator();
         entries.sort(comparator);
 
         List<IcpcScoreboardEntry> result = new ArrayList<>();
 
-        int currentRank = 1;
-        for (int i = 0; i < entries.size(); i++) {
-            if (i != 0 && comparator.compareWithoutTieBreakerForEqualRanks(entries.get(i), entries.get(i - 1)) != 0) {
-                currentRank = i + 1;
+        int officialRank = 0;
+        int officialCount = 0;
+        IcpcScoreboardEntry previousOfficial = null;
+        for (IcpcScoreboardEntry entry : entries) {
+            if (unofficialContestantJids.contains(entry.getContestantJid())) {
+                result.add(new IcpcScoreboardEntry.Builder().from(entry).rank(0).build());
+                continue;
             }
-            result.add(new IcpcScoreboardEntry.Builder().from(entries.get(i)).rank(currentRank).build());
+
+            officialCount++;
+            if (previousOfficial == null
+                    || comparator.compareWithoutTieBreakerForEqualRanks(entry, previousOfficial) != 0) {
+                officialRank = officialCount;
+            }
+            previousOfficial = entry;
+
+            result.add(new IcpcScoreboardEntry.Builder().from(entry).rank(officialRank).build());
         }
 
         return result;

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessor.java
@@ -75,7 +75,8 @@ public class IoiScoreboardProcessor implements ScoreboardProcessor {
             Map<String, ScoringConfig> problemScoringConfigsMap,
             Map<String, Profile> profilesMap,
             List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions) {
+            List<ItemSubmission> bundleItemSubmissions,
+            Set<String> unofficialContestantJids) {
 
         IoiStyleModuleConfig ioiStyleModuleConfig = (IoiStyleModuleConfig) styleModuleConfig;
 
@@ -208,7 +209,7 @@ public class IoiScoreboardProcessor implements ScoreboardProcessor {
                     .build());
         }
 
-        entries = sortEntriesAndAssignRanks(getComparator(ioiStyleModuleConfig), entries);
+        entries = sortEntriesAndAssignRanks(getComparator(ioiStyleModuleConfig), entries, unofficialContestantJids);
 
         return new ScoreboardProcessResult.Builder()
                .entries(entries)
@@ -271,7 +272,12 @@ public class IoiScoreboardProcessor implements ScoreboardProcessor {
             newEntries.add(newEntry);
         }
 
-        newEntries = sortEntriesAndAssignRanks(getComparator(config), newEntries);
+        // Preserve unofficial participants (rank 0 from the original processing) across the re-rank.
+        Set<String> unofficialContestantJids = content.getEntries().stream()
+                .filter(e -> e.getRank() == 0)
+                .map(IoiScoreboardEntry::getContestantJid)
+                .collect(Collectors.toSet());
+        newEntries = sortEntriesAndAssignRanks(getComparator(config), newEntries, unofficialContestantJids);
 
         return new IoiScoreboard.Builder()
                 .state(newState)
@@ -287,23 +293,30 @@ public class IoiScoreboardProcessor implements ScoreboardProcessor {
 
     private static List<IoiScoreboardEntry> sortEntriesAndAssignRanks(
             IoiScoreboardEntryComparator comparator,
-            List<IoiScoreboardEntry> entries) {
+            List<IoiScoreboardEntry> entries,
+            Set<String> unofficialContestantJids) {
 
         entries.sort(comparator);
 
         ImmutableList.Builder<IoiScoreboardEntry> newEntries = ImmutableList.builder();
 
-        int previousRank = 0;
-        for (int i = 0; i < entries.size(); i++) {
-            int assignedRank;
-            if (i == 0 || comparator.compareWithoutTieBreakerForEqualRanks(entries.get(i), entries.get(i - 1)) != 0) {
-                assignedRank = i + 1;
-            } else {
-                assignedRank = previousRank;
+        int officialRank = 0;
+        int officialCount = 0;
+        IoiScoreboardEntry previousOfficial = null;
+        for (IoiScoreboardEntry entry : entries) {
+            if (unofficialContestantJids.contains(entry.getContestantJid())) {
+                newEntries.add(new IoiScoreboardEntry.Builder().from(entry).rank(0).build());
+                continue;
             }
-            previousRank = assignedRank;
 
-            newEntries.add(new IoiScoreboardEntry.Builder().from(entries.get(i)).rank(assignedRank).build());
+            officialCount++;
+            if (previousOfficial == null
+                    || comparator.compareWithoutTieBreakerForEqualRanks(entry, previousOfficial) != 0) {
+                officialRank = officialCount;
+            }
+            previousOfficial = entry;
+
+            newEntries.add(new IoiScoreboardEntry.Builder().from(entry).rank(officialRank).build());
         }
 
         return newEntries.build();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessor.java
@@ -72,7 +72,8 @@ public class TrocScoreboardProcessor implements ScoreboardProcessor {
             Map<String, ScoringConfig> problemScoringConfigsMap,
             Map<String, Profile> profilesMap,
             List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions) {
+            List<ItemSubmission> bundleItemSubmissions,
+            Set<String> unofficialContestantJids) {
 
         TrocStyleModuleConfig trocStyleModuleConfig = (TrocStyleModuleConfig) styleModuleConfig;
 
@@ -218,7 +219,7 @@ public class TrocScoreboardProcessor implements ScoreboardProcessor {
                             .collect(Collectors.toList()))
                     .build());
         }
-        entries = sortEntriesAndAssignRanks(entries);
+        entries = sortEntriesAndAssignRanks(entries, unofficialContestantJids);
 
         return new ScoreboardProcessResult.Builder()
                 .entries(entries)
@@ -240,18 +241,30 @@ public class TrocScoreboardProcessor implements ScoreboardProcessor {
                 .build();
     }
 
-    private List<TrocScoreboardEntry> sortEntriesAndAssignRanks(List<TrocScoreboardEntry> entries) {
+    private List<TrocScoreboardEntry> sortEntriesAndAssignRanks(
+            List<TrocScoreboardEntry> entries, Set<String> unofficialContestantJids) {
         ScoreboardEntryComparator<TrocScoreboardEntry> comparator = new StandardTrocScoreboardEntryComparator();
         entries.sort(comparator);
 
         List<TrocScoreboardEntry> result = new ArrayList<>();
 
-        int currentRank = 1;
-        for (int i = 0; i < entries.size(); i++) {
-            if (i != 0 && comparator.compareWithoutTieBreakerForEqualRanks(entries.get(i), entries.get(i - 1)) != 0) {
-                currentRank = i + 1;
+        int officialRank = 0;
+        int officialCount = 0;
+        TrocScoreboardEntry previousOfficial = null;
+        for (TrocScoreboardEntry entry : entries) {
+            if (unofficialContestantJids.contains(entry.getContestantJid())) {
+                result.add(new TrocScoreboardEntry.Builder().from(entry).rank(0).build());
+                continue;
             }
-            result.add(new TrocScoreboardEntry.Builder().from(entries.get(i)).rank(currentRank).build());
+
+            officialCount++;
+            if (previousOfficial == null
+                    || comparator.compareWithoutTieBreakerForEqualRanks(entry, previousOfficial) != 0) {
+                officialRank = officialCount;
+            }
+            previousOfficial = entry;
+
+            result.add(new TrocScoreboardEntry.Builder().from(entry).rank(officialRank).build());
         }
 
         return result;

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/contest/rating/ContestRatingResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/contest/rating/ContestRatingResource.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import judgels.api.contest.Contest;
 import judgels.api.contest.ContestInfo;
+import judgels.api.contest.module.DivisionModuleConfig;
 import judgels.api.contest.scoreboard.Scoreboard;
 import judgels.api.contest.scoreboard.ScoreboardEntry;
 import judgels.api.profile.Profile;
@@ -30,6 +31,7 @@ import judgels.api.user.rating.UserRating;
 import judgels.api.user.rating.UserRatingEvent;
 import judgels.contest.ContestRoleChecker;
 import judgels.contest.ContestStore;
+import judgels.contest.module.ContestModuleStore;
 import judgels.contest.rating.ContestRatingProvider;
 import judgels.contest.scoreboard.ContestScoreboardBuilder;
 import judgels.contest.scoreboard.ContestScoreboardStore;
@@ -49,6 +51,7 @@ public class ContestRatingResource {
     @Inject protected ActorChecker actorChecker;
     @Inject protected ContestRoleChecker contestRoleChecker;
     @Inject protected ContestStore contestStore;
+    @Inject protected ContestModuleStore moduleStore;
     @Inject protected ContestScoreboardStore scoreboardStore;
     @Inject protected ContestScoreboardBuilder scoreboardBuilder;
     @Inject protected ContestRatingProvider ratingProvider;
@@ -118,12 +121,22 @@ public class ContestRatingResource {
 
         Map<String, Profile> profilesMap = profileStore.getProfiles(ranksMap.keySet(), contest.getBeginTime());
 
+        // If the contest allows higher divisions to participate unofficially, only contestants in
+        // the contest's own division are rated; the higher-division participants are left untouched.
+        Optional<DivisionModuleConfig> divisionConfig = moduleStore.getDivisionModuleConfig(contest.getJid());
+        boolean officialDivisionOnly =
+                divisionConfig.isPresent() && divisionConfig.get().getAllowHigherDivisionsUnofficially();
+
         List<String> contestantJids = Lists.newArrayList();
         Map<String, UserRating> currentRatingsMap = new HashMap<>();
 
         for (Map.Entry<String, Profile> entry : profilesMap.entrySet()) {
             String contestantJid = entry.getKey();
             Optional<UserRating> rating = entry.getValue().getRating();
+
+            if (officialDivisionOnly && !ratingProvider.isRatingInDivision(rating, divisionConfig.get().getDivision())) {
+                continue;
+            }
 
             contestantJids.add(contestantJid);
             if (rating.isPresent()) {

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessorTests.java
@@ -132,7 +132,8 @@ public class BundleScoreboardProcessorTests {
                     Map.of(),
                     profilesMap,
                     List.of(),
-                    submissions);
+                    submissions,
+                    Set.of());
 
             assertThat(Lists.transform(result.getEntries(), e -> (BundleScoreboardEntry) e)).containsExactly(
                     new BundleScoreboardEntry.Builder()
@@ -208,7 +209,8 @@ public class BundleScoreboardProcessorTests {
                         Map.of(),
                         profilesMap,
                         List.of(),
-                        submissions);
+                        submissions,
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (BundleScoreboardEntry) e)).containsExactly(
                         new BundleScoreboardEntry.Builder()
@@ -268,7 +270,8 @@ public class BundleScoreboardProcessorTests {
                         Map.of(),
                         profilesMap,
                         List.of(),
-                        submissions);
+                        submissions,
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (BundleScoreboardEntry) e)).containsExactly(
                         new BundleScoreboardEntry.Builder()

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessorTests.java
@@ -91,7 +91,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                     problemScoringConfigsMap,
                     profilesMap,
                     submissions,
-                    List.of());
+                    List.of(),
+                    Set.of());
 
             assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                     new GcjScoreboardEntry.Builder()
@@ -142,7 +143,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -193,7 +195,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -245,7 +248,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -294,7 +298,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -359,7 +364,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -436,7 +442,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -505,7 +512,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         baseSubmissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -555,7 +563,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -605,7 +614,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -655,7 +665,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -736,7 +747,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new GcjScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)
@@ -765,7 +777,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         List.of(),
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new GcjScoreboardIncrementalContent.Builder()
                         .from(incrementalContent)
@@ -785,7 +798,8 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new GcjScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessorTests.java
@@ -92,7 +92,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                     problemScoringConfigsMap,
                     profilesMap,
                     submissions,
-                    List.of());
+                    List.of(),
+                    Set.of());
 
             assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                     new IcpcScoreboardEntry.Builder()
@@ -127,6 +128,46 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                             .build());
         }
 
+        @Test
+        void unofficial_contestants_are_shown_but_not_ranked() {
+            Set<ContestContestant> threeContestants = ImmutableSet.of(
+                    new ContestContestant.Builder().userJid("c1").build(),
+                    new ContestContestant.Builder().userJid("c2").build(),
+                    new ContestContestant.Builder().userJid("c3").build());
+            Map<String, Set<ContestContestant>> threeContestantsMap = Map.of(contest.getJid(), threeContestants);
+            Map<String, Profile> threeProfilesMap = ImmutableMap.of(
+                    "c1", new Profile.Builder().username("c1").build(),
+                    "c2", new Profile.Builder().username("c2").build(),
+                    "c3", new Profile.Builder().username("c3").build());
+
+            // Sorted order is c2 (2 solved), then c3 (1 solved, earlier), then c1 (1 solved, later).
+            List<Submission> submissions = ImmutableList.of(
+                    createSubmission(1, 300, "c2", "p1", 100, Verdict.ACCEPTED),
+                    createSubmission(2, 360, "c2", "p2", 100, Verdict.ACCEPTED),
+                    createSubmission(3, 300, "c3", "p1", 100, Verdict.ACCEPTED),
+                    createSubmission(4, 400, "c1", "p2", 100, Verdict.ACCEPTED));
+
+            ScoreboardProcessResult result = scoreboardProcessor.process(
+                    state,
+                    Optional.empty(),
+                    styleModuleConfig,
+                    threeContestantsMap,
+                    contestBeginTimesMap,
+                    Map.of(),
+                    problemScoringConfigsMap,
+                    threeProfilesMap,
+                    submissions,
+                    List.of(),
+                    Set.of("c3"));
+
+            // c3 is unofficial: shown in place but rank 0; official c1/c2 get dense ranks 1 and 2.
+            assertThat(Lists.transform(result.getEntries(), e -> Map.entry(e.getContestantJid(), e.getRank())))
+                    .containsExactly(
+                            Map.entry("c2", 1),
+                            Map.entry("c3", 0),
+                            Map.entry("c1", 2));
+        }
+
         @Nested
         class ProblemOrdering {
             private List<Submission> submissions = ImmutableList.of(
@@ -145,7 +186,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -197,7 +239,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -252,7 +295,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -303,7 +347,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -371,7 +416,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -451,7 +497,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -523,7 +570,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         baseSubmissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -575,7 +623,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -627,7 +676,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -679,7 +729,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -765,7 +816,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IcpcScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)
@@ -798,7 +850,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         List.of(),
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IcpcScoreboardIncrementalContent.Builder()
                         .from(incrementalContent)
@@ -818,7 +871,8 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IcpcScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessorTests.java
@@ -90,7 +90,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                     problemScoringConfigsMap,
                     profilesMap,
                     submissions,
-                    List.of());
+                    List.of(),
+                    Set.of());
 
             assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                     new IoiScoreboardEntry.Builder()
@@ -138,7 +139,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                     problemScoringConfigsMap,
                     profilesMap,
                     submissions,
-                    List.of());
+                    List.of(),
+                    Set.of());
 
             assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                     new IoiScoreboardEntry.Builder()
@@ -204,7 +206,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -259,7 +262,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -321,7 +325,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -367,7 +372,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -450,7 +456,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -495,7 +502,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -571,7 +579,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IoiScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)
@@ -600,7 +609,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         List.of(),
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IoiScoreboardIncrementalContent.Builder()
                         .from(incrementalContent)
@@ -620,7 +630,8 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IoiScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessorTests.java
@@ -95,7 +95,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                     problemScoringConfigsMap,
                     profilesMap,
                     submissions,
-                    List.of());
+                    List.of(),
+                    Set.of());
 
             assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                     new TrocScoreboardEntry.Builder()
@@ -146,7 +147,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -197,7 +199,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -249,7 +252,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -298,7 +302,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -363,7 +368,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -440,7 +446,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -509,7 +516,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         baseSubmissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -559,7 +567,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -609,7 +618,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -659,7 +669,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -741,7 +752,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new TrocScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)
@@ -772,7 +784,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         List.of(),
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new TrocScoreboardIncrementalContent.Builder()
                         .from(incrementalContent)
@@ -792,7 +805,8 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         problemScoringConfigsMap,
                         profilesMap,
                         submissions,
-                        List.of());
+                        List.of(),
+                        Set.of());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new TrocScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)

--- a/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsForm/ContestEditConfigsForm.jsx
+++ b/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsForm/ContestEditConfigsForm.jsx
@@ -203,6 +203,11 @@ export default function ContestEditConfigsForm({ onSubmit, initialValues, config
       validate: Required,
       keyClassName: 'contest-edit-configs-form__key',
     };
+    const divisionAllowHigherDivisionsUnofficiallyField = {
+      name: 'divisionAllowHigherDivisionsUnofficially',
+      label: 'Allow higher divisions to participate unofficially?',
+      keyClassName: 'contest-edit-configs-form__key',
+    };
 
     return (
       <div className="contest-edit-configs-form__config">
@@ -210,6 +215,7 @@ export default function ContestEditConfigsForm({ onSubmit, initialValues, config
         <HTMLTable striped>
           <tbody>
             <Field component={FormTableTextInput} {...divisionDivisionField} />
+            <Field component={FormTableCheckbox} {...divisionAllowHigherDivisionsUnofficiallyField} />
           </tbody>
         </HTMLTable>
       </div>

--- a/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsTab/ContestEditConfigsTab.jsx
+++ b/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsTab/ContestEditConfigsTab.jsx
@@ -104,6 +104,7 @@ export default function ContestEditConfigsTab() {
         initialValues = {
           ...initialValues,
           divisionDivision: division.division,
+          divisionAllowHigherDivisionsUnofficially: division.allowHigherDivisionsUnofficially,
         };
       }
       if (editorial) {
@@ -215,7 +216,10 @@ export default function ContestEditConfigsTab() {
     if (division) {
       newConfig = {
         ...newConfig,
-        division: { division: +data.divisionDivision },
+        division: {
+          division: +data.divisionDivision,
+          allowHigherDivisionsUnofficially: data.divisionAllowHigherDivisionsUnofficially,
+        },
       };
     }
     if (editorial) {

--- a/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsTab/ContestEditConfigsTab.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsTab/ContestEditConfigsTab.test.jsx
@@ -28,6 +28,7 @@ describe('ContestEditConfigsTab', () => {
       },
       division: {
         division: 1,
+        allowHigherDivisionsUnofficially: false,
       },
       editorial: {
         preface: '<p>Thank you</p>',
@@ -89,6 +90,11 @@ describe('ContestEditConfigsTab', () => {
     await user.clear(divisionDivision);
     await user.type(divisionDivision, '2');
 
+    const divisionAllowHigherDivisionsUnofficially = screen.getByRole('checkbox', {
+      name: /allow higher divisions to participate unofficially/i,
+    });
+    await user.click(divisionAllowHigherDivisionsUnofficially);
+
     const frozenScoreboardFreezeTime = screen.getByRole('textbox', { name: /freeze time/i });
     await user.clear(frozenScoreboardFreezeTime);
     await user.type(frozenScoreboardFreezeTime, '1h 5m');
@@ -130,6 +136,7 @@ describe('ContestEditConfigsTab', () => {
         },
         division: {
           division: 2,
+          allowHigherDivisionsUnofficially: true,
         },
         frozenScoreboard: {
           isOfficialScoreboardAllowed: true,

--- a/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsTable/ContestEditConfigsTable.jsx
+++ b/judgels-client/src/routes/contests/contests/single/components/ContestEditConfigsTable/ContestEditConfigsTable.jsx
@@ -111,12 +111,17 @@ export function ContestEditConfigsTable({ config }) {
     );
   };
 
-  const renderDivisionConfig = ({ division }) => {
+  const renderDivisionConfig = ({ division, allowHigherDivisionsUnofficially }) => {
     const rows = [
       {
         key: 'divisionDivision',
         title: 'Division',
         value: <>{division}</>,
+      },
+      {
+        key: 'divisionAllowHigherDivisionsUnofficially',
+        title: 'Allow higher divisions to participate unofficially?',
+        value: allowHigherDivisionsUnofficially ? <SmallTick /> : <SmallCross />,
       },
     ];
     return (

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/BundleScoreboardTable/BundleScoreboardTable.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/BundleScoreboardTable/BundleScoreboardTable.jsx
@@ -13,7 +13,7 @@ export function BundleScoreboardTable({ userJid, scoreboard, profilesMap, onClic
 
   const renderRow = entry => {
     let cells = [
-      <td key="rank">{entry.rank === -1 ? '?' : entry.rank}</td>,
+      <td key="rank">{entry.rank === -1 ? '?' : entry.rank === 0 ? '-' : entry.rank}</td>,
       <td key="contestantJid" className="contestant-cell">
         <UserRef profile={profilesMap[entry.contestantJid]} />
       </td>,

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/BundleScoreboardTable/BundleScoreboardTable.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/BundleScoreboardTable/BundleScoreboardTable.test.jsx
@@ -62,6 +62,15 @@ describe('BundleScoreboardTable', () => {
     expect(ranks).toEqual(['?', '?']);
   });
 
+  test('unofficial ranks show dashes', async () => {
+    const entries = mockScoreboard.content.entries.map((entry, i) => (i === 1 ? { ...entry, rank: 0 } : entry));
+    const scoreboard = { ...mockScoreboard, content: { entries } };
+    await renderComponent({ scoreboard });
+    const rows = screen.getAllByRole('row').slice(1);
+    const ranks = rows.map(row => within(row).getAllByRole('cell')[0].textContent);
+    expect(ranks).toEqual(['1', '-']);
+  });
+
   test('display names', async () => {
     await renderComponent();
     const rows = screen.getAllByRole('row').slice(1);

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/GcjScoreboardTable/GcjScoreboardTable.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/GcjScoreboardTable/GcjScoreboardTable.jsx
@@ -14,7 +14,7 @@ export function GcjScoreboardTable({ userJid, scoreboard: { state, content }, pr
 
   const renderRow = entry => {
     let cells = [
-      <td key="rank">{entry.rank === -1 ? '?' : entry.rank}</td>,
+      <td key="rank">{entry.rank === -1 ? '?' : entry.rank === 0 ? '-' : entry.rank}</td>,
       <td key="contestantJid" className="contestant-cell">
         <UserRef profile={profilesMap[entry.contestantJid]} showFlag />
       </td>,

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/GcjScoreboardTable/GcjScoreboardTable.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/GcjScoreboardTable/GcjScoreboardTable.test.jsx
@@ -77,6 +77,15 @@ describe('GcjScoreboardTable', () => {
     expect(ranks).toEqual(['?', '?']);
   });
 
+  test('unofficial ranks show dashes', async () => {
+    const entries = mockScoreboard.content.entries.map((entry, i) => (i === 1 ? { ...entry, rank: 0 } : entry));
+    const scoreboard = { ...mockScoreboard, content: { entries } };
+    await renderComponent({ scoreboard });
+    const rows = screen.getAllByRole('row').slice(1);
+    const ranks = rows.map(row => within(row).getAllByRole('cell')[0].textContent);
+    expect(ranks).toEqual(['1', '-']);
+  });
+
   test('display names', async () => {
     await renderComponent();
     const rows = screen.getAllByRole('row').slice(1);

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/IcpcScoreboardTable/IcpcScoreboardTable.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/IcpcScoreboardTable/IcpcScoreboardTable.jsx
@@ -14,7 +14,7 @@ export function IcpcScoreboardTable({ userJid, scoreboard: { state, content }, p
 
   const renderRow = entry => {
     let cells = [
-      <td key="rank">{entry.rank === -1 ? '?' : entry.rank}</td>,
+      <td key="rank">{entry.rank === -1 ? '?' : entry.rank === 0 ? '-' : entry.rank}</td>,
       <td key="contestantJid" className="contestant-cell">
         <UserRef profile={profilesMap[entry.contestantJid]} showFlag />
       </td>,

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/IcpcScoreboardTable/IcpcScoreboardTable.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/IcpcScoreboardTable/IcpcScoreboardTable.test.jsx
@@ -86,6 +86,15 @@ describe('IcpcScoreboardTable', () => {
     expect(ranks).toEqual(['?', '?']);
   });
 
+  test('unofficial ranks show dashes', async () => {
+    const entries = mockScoreboard.content.entries.map((entry, i) => (i === 1 ? { ...entry, rank: 0 } : entry));
+    const scoreboard = { ...mockScoreboard, content: { entries } };
+    await renderComponent({ scoreboard });
+    const rows = screen.getAllByRole('row').slice(1);
+    const ranks = rows.map(row => within(row).getAllByRole('cell')[0].textContent);
+    expect(ranks).toEqual(['1', '-']);
+  });
+
   test('display names', async () => {
     await renderComponent();
     const rows = screen.getAllByRole('row').slice(1);

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/IoiScoreboardTable/IoiScoreboardTable.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/IoiScoreboardTable/IoiScoreboardTable.jsx
@@ -13,7 +13,7 @@ export function IoiScoreboardTable({ userJid, scoreboard: { state, content }, pr
 
   const renderRow = entry => {
     let cells = [
-      <td key="rank">{entry.rank === -1 ? '?' : entry.rank}</td>,
+      <td key="rank">{entry.rank === -1 ? '?' : entry.rank === 0 ? '-' : entry.rank}</td>,
       <td key="contestantJid" className="contestant-cell">
         <UserRef profile={profilesMap[entry.contestantJid]} showFlag />
       </td>,

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/IoiScoreboardTable/IoiScoreboardTable.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/IoiScoreboardTable/IoiScoreboardTable.test.jsx
@@ -71,6 +71,15 @@ describe('IoiScoreboardTable', () => {
     expect(ranks).toEqual(['?', '?']);
   });
 
+  test('unofficial ranks show dashes', async () => {
+    const entries = mockScoreboard.content.entries.map((entry, i) => (i === 1 ? { ...entry, rank: 0 } : entry));
+    const scoreboard = { ...mockScoreboard, content: { entries } };
+    await renderComponent({ scoreboard });
+    const rows = screen.getAllByRole('row').slice(1);
+    const ranks = rows.map(row => within(row).getAllByRole('cell')[0].textContent);
+    expect(ranks).toEqual(['1', '-']);
+  });
+
   test('display names', async () => {
     await renderComponent();
     const rows = screen.getAllByRole('row').slice(1);

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/TrocScoreboardTable/TrocScoreboardTable.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/TrocScoreboardTable/TrocScoreboardTable.jsx
@@ -14,7 +14,7 @@ export function TrocScoreboardTable({ userJid, scoreboard: { state, content }, p
 
   const renderRow = entry => {
     let cells = [
-      <td key="rank">{entry.rank === -1 ? '?' : entry.rank}</td>,
+      <td key="rank">{entry.rank === -1 ? '?' : entry.rank === 0 ? '-' : entry.rank}</td>,
       <td key="contestantJid" className="contestant-cell">
         <UserRef profile={profilesMap[entry.contestantJid]} showFlag />
       </td>,

--- a/judgels-client/src/routes/contests/contests/single/scoreboard/TrocScoreboardTable/TrocScoreboardTable.test.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/TrocScoreboardTable/TrocScoreboardTable.test.jsx
@@ -77,6 +77,15 @@ describe('TrocScoreboardTable', () => {
     expect(ranks).toEqual(['?', '?']);
   });
 
+  test('unofficial ranks show dashes', async () => {
+    const entries = mockScoreboard.content.entries.map((entry, i) => (i === 1 ? { ...entry, rank: 0 } : entry));
+    const scoreboard = { ...mockScoreboard, content: { entries } };
+    await renderComponent({ scoreboard });
+    const rows = screen.getAllByRole('row').slice(1);
+    const ranks = rows.map(row => within(row).getAllByRole('cell')[0].textContent);
+    expect(ranks).toEqual(['1', '-']);
+  });
+
   test('display names', async () => {
     await renderComponent();
     const rows = screen.getAllByRole('row').slice(1);


### PR DESCRIPTION
## Summary

Adds a per-contest option on the **Division** module — **"Allow higher divisions to participate unofficially"** — so higher-division users can join a lower-division contest (e.g. Div 1 in a Div 2 round) as unofficial participants.

When enabled, contestants outside the contest's own division are:
- **excluded from the rating calculation** (their ratings are left untouched);
- **shown on the scoreboard but not ranked** — their rank cell shows a dash (`-`) while official contestants keep dense ranks `1..N`;
- **given no `finalRank`** (no official placement recorded in contest/rating history).

Division membership is determined from each contestant's **begin-time** rating via the existing `ContestRatingProvider.isRatingInDivision`, consistent between the rating calc and the scoreboard.

## Changes

**Backend**
- `DivisionModuleConfig`: new backward-compatible `@Value.Default boolean getAllowHigherDivisionsUnofficially()`.
- `ContestRatingResource.getRatingChanges`: filters unofficial contestants out of the rating changes.
- `ScoreboardProcessor.process(...)`: takes a new `Set<String> unofficialContestantJids`; all 5 style processors (IOI/ICPC/GCJ/Troc/Bundle) assign `rank 0` to unofficial entries and dense ranks (with correct ties) to official ones. Empty set ⇒ identical to previous behavior. Ranks are recomputed in full each pass, so **incremental scoreboard computation is unaffected** (ranks are never cached in incremental state).
- `ContestScoreboardUpdater`: computes the unofficial set (injects `ContestRatingProvider`) and guards `finalRank` with `rank > 0`.

**Frontend**
- Division config **form** gains the checkbox; **table** shows it read-only (tick/cross).
- All 5 scoreboard tables render `rank === 0` as a dash.

## Tests
- New ICPC processor test: official dense ranks + unofficial `rank 0`, including a tie-order case. Existing processor tests (all 5 styles) unchanged and passing — confirms backward compatibility.
- New "unofficial ranks show dashes" test in all 5 scoreboard table test files.
- Division config tab test updated to toggle and assert the new field.

## Verification
- Backend: `:judgels-server-app:compileJava` + `checkstyleMain` clean; all `*ScoreboardProcessorTests` pass.
- Frontend: scoreboard + config-tab tests pass; `yarn format` clean.

## Note
Division membership relies on the TLX rating provider; enabling the flag on a non-TLX build would mark everyone unofficial. This matches the existing rating-calc behavior and the Division module's TLX intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)