### PR TITLE
Replace ScoreboardProcessor.process positional params with a request object

### DIFF
--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
@@ -237,7 +237,7 @@ public class ContestScoreboardUpdater {
             Optional<ScoreboardIncrementalContent> incrementalContent = Optional.ofNullable(
                     incrementalMark.getIncrementalContents().get(type));
 
-            ScoreboardProcessResult result = processor.process(new ScoreboardProcessRequest.Builder()
+            ScoreboardProcessResult result = processor.process(new ScoreboardProcessParams.Builder()
                     .scoreboardState(state)
                     .incrementalContent(incrementalContent)
                     .styleModuleConfig(styleModuleConfig)

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
@@ -237,18 +237,19 @@ public class ContestScoreboardUpdater {
             Optional<ScoreboardIncrementalContent> incrementalContent = Optional.ofNullable(
                     incrementalMark.getIncrementalContents().get(type));
 
-            ScoreboardProcessResult result = processor.process(
-                    state,
-                    incrementalContent,
-                    styleModuleConfig,
-                    contestContestantsMap,
-                    contestBeginTimesMap,
-                    contestFreezeTimesMap,
-                    problemScoringConfigsMap,
-                    profilesMap,
-                    programmingSubmissions,
-                    bundleItemSubmissions,
-                    unofficialContestantJids);
+            ScoreboardProcessResult result = processor.process(new ScoreboardProcessRequest.Builder()
+                    .scoreboardState(state)
+                    .incrementalContent(incrementalContent)
+                    .styleModuleConfig(styleModuleConfig)
+                    .contestContestantsMap(contestContestantsMap)
+                    .contestBeginTimesMap(contestBeginTimesMap)
+                    .contestFreezeTimesMap(contestFreezeTimesMap)
+                    .problemScoringConfigsMap(problemScoringConfigsMap)
+                    .profilesMap(profilesMap)
+                    .programmingSubmissions(programmingSubmissions)
+                    .bundleItemSubmissions(bundleItemSubmissions)
+                    .unofficialContestantJids(unofficialContestantJids)
+                    .build());
 
             Scoreboard scoreboard = processor.create(state, result.getEntries());
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessParams.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessParams.java
@@ -15,7 +15,7 @@ import judgels.grading.api.ScoringConfig;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface ScoreboardProcessRequest {
+public interface ScoreboardProcessParams {
     ScoreboardState getScoreboardState();
     Optional<ScoreboardIncrementalContent> getIncrementalContent();
     StyleModuleConfig getStyleModuleConfig();
@@ -30,5 +30,5 @@ public interface ScoreboardProcessRequest {
     // Contestants who are shown on the scoreboard but excluded from rank numbering (rank 0).
     Set<String> getUnofficialContestantJids();
 
-    class Builder extends ImmutableScoreboardProcessRequest.Builder {}
+    class Builder extends ImmutableScoreboardProcessParams.Builder {}
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessRequest.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessRequest.java
@@ -1,0 +1,34 @@
+package judgels.contest.scoreboard;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import judgels.api.contest.contestant.ContestContestant;
+import judgels.api.contest.module.StyleModuleConfig;
+import judgels.api.contest.scoreboard.ScoreboardState;
+import judgels.api.profile.Profile;
+import judgels.api.submission.bundle.ItemSubmission;
+import judgels.api.submission.programming.Submission;
+import judgels.grading.api.ScoringConfig;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ScoreboardProcessRequest {
+    ScoreboardState getScoreboardState();
+    Optional<ScoreboardIncrementalContent> getIncrementalContent();
+    StyleModuleConfig getStyleModuleConfig();
+    Map<String, Set<ContestContestant>> getContestContestantsMap();
+    Map<String, Instant> getContestBeginTimesMap();
+    Map<String, Instant> getContestFreezeTimesMap();
+    Map<String, ScoringConfig> getProblemScoringConfigsMap();
+    Map<String, Profile> getProfilesMap();
+    List<Submission> getProgrammingSubmissions();
+    List<ItemSubmission> getBundleItemSubmissions();
+
+    // Contestants who are shown on the scoreboard but excluded from rank numbering (rank 0).
+    Set<String> getUnofficialContestantJids();
+
+    class Builder extends ImmutableScoreboardProcessRequest.Builder {}
+}

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessor.java
@@ -1,20 +1,11 @@
 package judgels.contest.scoreboard;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.Instant;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import judgels.api.contest.contestant.ContestContestant;
 import judgels.api.contest.module.StyleModuleConfig;
 import judgels.api.contest.scoreboard.Scoreboard;
 import judgels.api.contest.scoreboard.ScoreboardEntry;
 import judgels.api.contest.scoreboard.ScoreboardState;
-import judgels.api.profile.Profile;
-import judgels.api.submission.bundle.ItemSubmission;
-import judgels.api.submission.programming.Submission;
-import judgels.grading.api.ScoringConfig;
 
 public interface ScoreboardProcessor {
     Scoreboard parse(ObjectMapper mapper, String json);
@@ -22,19 +13,7 @@ public interface ScoreboardProcessor {
 
     boolean requiresGradingDetails(StyleModuleConfig styleModuleConfig);
 
-    // Contestants in unofficialContestantJids are shown but excluded from rank numbering (rank 0).
-    ScoreboardProcessResult process(
-            ScoreboardState scoreboardState,
-            Optional<ScoreboardIncrementalContent> incrementalContent,
-            StyleModuleConfig styleModuleConfig,
-            Map<String, Set<ContestContestant>> contestContestantsMap,
-            Map<String, Instant> contestBeginTimesMap,
-            Map<String, Instant> contestFreezeTimesMap,
-            Map<String, ScoringConfig> problemScoringConfigsMap,
-            Map<String, Profile> profilesMap,
-            List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions,
-            Set<String> unofficialContestantJids);
+    ScoreboardProcessResult process(ScoreboardProcessRequest request);
 
     ScoreboardEntry clearEntryRank(ScoreboardEntry entry);
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ScoreboardProcessor.java
@@ -13,7 +13,7 @@ public interface ScoreboardProcessor {
 
     boolean requiresGradingDetails(StyleModuleConfig styleModuleConfig);
 
-    ScoreboardProcessResult process(ScoreboardProcessRequest request);
+    ScoreboardProcessResult process(ScoreboardProcessParams param);
 
     ScoreboardEntry clearEntryRank(ScoreboardEntry entry);
 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessor.java
@@ -22,7 +22,7 @@ import judgels.api.contest.scoreboard.ScoreboardEntry;
 import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.submission.bundle.ItemSubmission;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
 
@@ -52,13 +52,13 @@ public class BundleScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
-        ScoreboardState scoreboardState = request.getScoreboardState();
-        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
-        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
-        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
-        List<ItemSubmission> bundleItemSubmissions = request.getBundleItemSubmissions();
-        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
+    public ScoreboardProcessResult process(ScoreboardProcessParams param) {
+        ScoreboardState scoreboardState = param.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = param.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = param.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = param.getContestContestantsMap();
+        List<ItemSubmission> bundleItemSubmissions = param.getBundleItemSubmissions();
+        Set<String> unofficialContestantJids = param.getUnofficialContestantJids();
 
         List<String> problemJids = scoreboardState.getProblemJids();
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessor.java
@@ -20,13 +20,11 @@ import judgels.api.contest.scoreboard.BundleScoreboard.BundleScoreboardContent;
 import judgels.api.contest.scoreboard.BundleScoreboard.BundleScoreboardEntry;
 import judgels.api.contest.scoreboard.ScoreboardEntry;
 import judgels.api.contest.scoreboard.ScoreboardState;
-import judgels.api.profile.Profile;
 import judgels.api.submission.bundle.ItemSubmission;
-import judgels.api.submission.programming.Submission;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
-import judgels.grading.api.ScoringConfig;
 
 public class BundleScoreboardProcessor implements ScoreboardProcessor {
     @Override
@@ -54,18 +52,13 @@ public class BundleScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(
-            ScoreboardState scoreboardState,
-            Optional<ScoreboardIncrementalContent> incrementalContent,
-            StyleModuleConfig styleModuleConfig,
-            Map<String, Set<ContestContestant>> contestContestantsMap,
-            Map<String, Instant> contestBeginTimesMap,
-            Map<String, Instant> contestFreezeTimesMap,
-            Map<String, ScoringConfig> problemScoringConfigsMap,
-            Map<String, Profile> profilesMap,
-            List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions,
-            Set<String> unofficialContestantJids) {
+    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
+        ScoreboardState scoreboardState = request.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
+        List<ItemSubmission> bundleItemSubmissions = request.getBundleItemSubmissions();
+        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
 
         List<String> problemJids = scoreboardState.getProblemJids();
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessor.java
@@ -30,7 +30,7 @@ import judgels.api.submission.programming.Submission;
 import judgels.api.user.rating.UserRating;
 import judgels.contest.scoreboard.ScoreboardEntryComparator;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
 import judgels.grading.api.Verdict;
@@ -61,16 +61,16 @@ public class GcjScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
-        ScoreboardState scoreboardState = request.getScoreboardState();
-        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
-        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
-        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
-        Map<String, Instant> contestBeginTimesMap = request.getContestBeginTimesMap();
-        Map<String, Instant> contestFreezeTimesMap = request.getContestFreezeTimesMap();
-        Map<String, Profile> profilesMap = request.getProfilesMap();
-        List<Submission> programmingSubmissions = request.getProgrammingSubmissions();
-        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
+    public ScoreboardProcessResult process(ScoreboardProcessParams param) {
+        ScoreboardState scoreboardState = param.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = param.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = param.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = param.getContestContestantsMap();
+        Map<String, Instant> contestBeginTimesMap = param.getContestBeginTimesMap();
+        Map<String, Instant> contestFreezeTimesMap = param.getContestFreezeTimesMap();
+        Map<String, Profile> profilesMap = param.getProfilesMap();
+        List<Submission> programmingSubmissions = param.getProgrammingSubmissions();
+        Set<String> unofficialContestantJids = param.getUnofficialContestantJids();
 
         GcjStyleModuleConfig gcjStyleModuleConfig = (GcjStyleModuleConfig) styleModuleConfig;
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessor.java
@@ -26,14 +26,13 @@ import judgels.api.contest.scoreboard.GcjScoreboard.GcjScoreboardProblemState;
 import judgels.api.contest.scoreboard.ScoreboardEntry;
 import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
-import judgels.api.submission.bundle.ItemSubmission;
 import judgels.api.submission.programming.Submission;
 import judgels.api.user.rating.UserRating;
 import judgels.contest.scoreboard.ScoreboardEntryComparator;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
-import judgels.grading.api.ScoringConfig;
 import judgels.grading.api.Verdict;
 
 public class GcjScoreboardProcessor implements ScoreboardProcessor {
@@ -62,18 +61,16 @@ public class GcjScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(
-            ScoreboardState scoreboardState,
-            Optional<ScoreboardIncrementalContent> incrementalContent,
-            StyleModuleConfig styleModuleConfig,
-            Map<String, Set<ContestContestant>> contestContestantsMap,
-            Map<String, Instant> contestBeginTimesMap,
-            Map<String, Instant> contestFreezeTimesMap,
-            Map<String, ScoringConfig> problemScoringConfigsMap,
-            Map<String, Profile> profilesMap,
-            List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions,
-            Set<String> unofficialContestantJids) {
+    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
+        ScoreboardState scoreboardState = request.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
+        Map<String, Instant> contestBeginTimesMap = request.getContestBeginTimesMap();
+        Map<String, Instant> contestFreezeTimesMap = request.getContestFreezeTimesMap();
+        Map<String, Profile> profilesMap = request.getProfilesMap();
+        List<Submission> programmingSubmissions = request.getProgrammingSubmissions();
+        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
 
         GcjStyleModuleConfig gcjStyleModuleConfig = (GcjStyleModuleConfig) styleModuleConfig;
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessor.java
@@ -26,14 +26,13 @@ import judgels.api.contest.scoreboard.IcpcScoreboard.IcpcScoreboardProblemState;
 import judgels.api.contest.scoreboard.ScoreboardEntry;
 import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
-import judgels.api.submission.bundle.ItemSubmission;
 import judgels.api.submission.programming.Submission;
 import judgels.api.user.rating.UserRating;
 import judgels.contest.scoreboard.ScoreboardEntryComparator;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
-import judgels.grading.api.ScoringConfig;
 import judgels.grading.api.Verdict;
 
 public class IcpcScoreboardProcessor implements ScoreboardProcessor {
@@ -62,18 +61,16 @@ public class IcpcScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(
-            ScoreboardState scoreboardState,
-            Optional<ScoreboardIncrementalContent> incrementalContent,
-            StyleModuleConfig styleModuleConfig,
-            Map<String, Set<ContestContestant>> contestContestantsMap,
-            Map<String, Instant> contestBeginTimesMap,
-            Map<String, Instant> contestFreezeTimesMap,
-            Map<String, ScoringConfig> problemScoringConfigsMap,
-            Map<String, Profile> profilesMap,
-            List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions,
-            Set<String> unofficialContestantJids) {
+    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
+        ScoreboardState scoreboardState = request.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
+        Map<String, Instant> contestBeginTimesMap = request.getContestBeginTimesMap();
+        Map<String, Instant> contestFreezeTimesMap = request.getContestFreezeTimesMap();
+        Map<String, Profile> profilesMap = request.getProfilesMap();
+        List<Submission> programmingSubmissions = request.getProgrammingSubmissions();
+        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
 
         IcpcStyleModuleConfig icpcStyleModuleConfig = (IcpcStyleModuleConfig) styleModuleConfig;
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessor.java
@@ -30,7 +30,7 @@ import judgels.api.submission.programming.Submission;
 import judgels.api.user.rating.UserRating;
 import judgels.contest.scoreboard.ScoreboardEntryComparator;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
 import judgels.grading.api.Verdict;
@@ -61,16 +61,16 @@ public class IcpcScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
-        ScoreboardState scoreboardState = request.getScoreboardState();
-        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
-        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
-        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
-        Map<String, Instant> contestBeginTimesMap = request.getContestBeginTimesMap();
-        Map<String, Instant> contestFreezeTimesMap = request.getContestFreezeTimesMap();
-        Map<String, Profile> profilesMap = request.getProfilesMap();
-        List<Submission> programmingSubmissions = request.getProgrammingSubmissions();
-        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
+    public ScoreboardProcessResult process(ScoreboardProcessParams param) {
+        ScoreboardState scoreboardState = param.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = param.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = param.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = param.getContestContestantsMap();
+        Map<String, Instant> contestBeginTimesMap = param.getContestBeginTimesMap();
+        Map<String, Instant> contestFreezeTimesMap = param.getContestFreezeTimesMap();
+        Map<String, Profile> profilesMap = param.getProfilesMap();
+        List<Submission> programmingSubmissions = param.getProgrammingSubmissions();
+        Set<String> unofficialContestantJids = param.getUnofficialContestantJids();
 
         IcpcStyleModuleConfig icpcStyleModuleConfig = (IcpcStyleModuleConfig) styleModuleConfig;
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessor.java
@@ -30,7 +30,7 @@ import judgels.api.submission.programming.Grading;
 import judgels.api.submission.programming.Submission;
 import judgels.api.user.rating.UserRating;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
 import judgels.grading.api.ScoringConfig;
@@ -65,17 +65,17 @@ public class IoiScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
-        ScoreboardState scoreboardState = request.getScoreboardState();
-        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
-        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
-        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
-        Map<String, Instant> contestBeginTimesMap = request.getContestBeginTimesMap();
-        Map<String, Instant> contestFreezeTimesMap = request.getContestFreezeTimesMap();
-        Map<String, ScoringConfig> problemScoringConfigsMap = request.getProblemScoringConfigsMap();
-        Map<String, Profile> profilesMap = request.getProfilesMap();
-        List<Submission> programmingSubmissions = request.getProgrammingSubmissions();
-        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
+    public ScoreboardProcessResult process(ScoreboardProcessParams param) {
+        ScoreboardState scoreboardState = param.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = param.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = param.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = param.getContestContestantsMap();
+        Map<String, Instant> contestBeginTimesMap = param.getContestBeginTimesMap();
+        Map<String, Instant> contestFreezeTimesMap = param.getContestFreezeTimesMap();
+        Map<String, ScoringConfig> problemScoringConfigsMap = param.getProblemScoringConfigsMap();
+        Map<String, Profile> profilesMap = param.getProfilesMap();
+        List<Submission> programmingSubmissions = param.getProgrammingSubmissions();
+        Set<String> unofficialContestantJids = param.getUnofficialContestantJids();
 
         IoiStyleModuleConfig ioiStyleModuleConfig = (IoiStyleModuleConfig) styleModuleConfig;
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessor.java
@@ -26,11 +26,11 @@ import judgels.api.contest.scoreboard.IoiScoreboard.IoiScoreboardEntry;
 import judgels.api.contest.scoreboard.ScoreboardEntry;
 import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
-import judgels.api.submission.bundle.ItemSubmission;
 import judgels.api.submission.programming.Grading;
 import judgels.api.submission.programming.Submission;
 import judgels.api.user.rating.UserRating;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
 import judgels.grading.api.ScoringConfig;
@@ -65,18 +65,17 @@ public class IoiScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(
-            ScoreboardState scoreboardState,
-            Optional<ScoreboardIncrementalContent> incrementalContent,
-            StyleModuleConfig styleModuleConfig,
-            Map<String, Set<ContestContestant>> contestContestantsMap,
-            Map<String, Instant> contestBeginTimesMap,
-            Map<String, Instant> contestFreezeTimesMap,
-            Map<String, ScoringConfig> problemScoringConfigsMap,
-            Map<String, Profile> profilesMap,
-            List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions,
-            Set<String> unofficialContestantJids) {
+    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
+        ScoreboardState scoreboardState = request.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
+        Map<String, Instant> contestBeginTimesMap = request.getContestBeginTimesMap();
+        Map<String, Instant> contestFreezeTimesMap = request.getContestFreezeTimesMap();
+        Map<String, ScoringConfig> problemScoringConfigsMap = request.getProblemScoringConfigsMap();
+        Map<String, Profile> profilesMap = request.getProfilesMap();
+        List<Submission> programmingSubmissions = request.getProgrammingSubmissions();
+        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
 
         IoiStyleModuleConfig ioiStyleModuleConfig = (IoiStyleModuleConfig) styleModuleConfig;
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessor.java
@@ -30,7 +30,7 @@ import judgels.api.submission.programming.Submission;
 import judgels.api.user.rating.UserRating;
 import judgels.contest.scoreboard.ScoreboardEntryComparator;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
 import judgels.grading.api.Verdict;
@@ -61,16 +61,16 @@ public class TrocScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
-        ScoreboardState scoreboardState = request.getScoreboardState();
-        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
-        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
-        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
-        Map<String, Instant> contestBeginTimesMap = request.getContestBeginTimesMap();
-        Map<String, Instant> contestFreezeTimesMap = request.getContestFreezeTimesMap();
-        Map<String, Profile> profilesMap = request.getProfilesMap();
-        List<Submission> programmingSubmissions = request.getProgrammingSubmissions();
-        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
+    public ScoreboardProcessResult process(ScoreboardProcessParams param) {
+        ScoreboardState scoreboardState = param.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = param.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = param.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = param.getContestContestantsMap();
+        Map<String, Instant> contestBeginTimesMap = param.getContestBeginTimesMap();
+        Map<String, Instant> contestFreezeTimesMap = param.getContestFreezeTimesMap();
+        Map<String, Profile> profilesMap = param.getProfilesMap();
+        List<Submission> programmingSubmissions = param.getProgrammingSubmissions();
+        Set<String> unofficialContestantJids = param.getUnofficialContestantJids();
 
         TrocStyleModuleConfig trocStyleModuleConfig = (TrocStyleModuleConfig) styleModuleConfig;
 

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessor.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessor.java
@@ -26,14 +26,13 @@ import judgels.api.contest.scoreboard.TrocScoreboard.TrocScoreboardContent;
 import judgels.api.contest.scoreboard.TrocScoreboard.TrocScoreboardEntry;
 import judgels.api.contest.scoreboard.TrocScoreboard.TrocScoreboardProblemState;
 import judgels.api.profile.Profile;
-import judgels.api.submission.bundle.ItemSubmission;
 import judgels.api.submission.programming.Submission;
 import judgels.api.user.rating.UserRating;
 import judgels.contest.scoreboard.ScoreboardEntryComparator;
 import judgels.contest.scoreboard.ScoreboardIncrementalContent;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.contest.scoreboard.ScoreboardProcessor;
-import judgels.grading.api.ScoringConfig;
 import judgels.grading.api.Verdict;
 
 public class TrocScoreboardProcessor implements ScoreboardProcessor {
@@ -62,18 +61,16 @@ public class TrocScoreboardProcessor implements ScoreboardProcessor {
     }
 
     @Override
-    public ScoreboardProcessResult process(
-            ScoreboardState scoreboardState,
-            Optional<ScoreboardIncrementalContent> incrementalContent,
-            StyleModuleConfig styleModuleConfig,
-            Map<String, Set<ContestContestant>> contestContestantsMap,
-            Map<String, Instant> contestBeginTimesMap,
-            Map<String, Instant> contestFreezeTimesMap,
-            Map<String, ScoringConfig> problemScoringConfigsMap,
-            Map<String, Profile> profilesMap,
-            List<Submission> programmingSubmissions,
-            List<ItemSubmission> bundleItemSubmissions,
-            Set<String> unofficialContestantJids) {
+    public ScoreboardProcessResult process(ScoreboardProcessRequest request) {
+        ScoreboardState scoreboardState = request.getScoreboardState();
+        Optional<ScoreboardIncrementalContent> incrementalContent = request.getIncrementalContent();
+        StyleModuleConfig styleModuleConfig = request.getStyleModuleConfig();
+        Map<String, Set<ContestContestant>> contestContestantsMap = request.getContestContestantsMap();
+        Map<String, Instant> contestBeginTimesMap = request.getContestBeginTimesMap();
+        Map<String, Instant> contestFreezeTimesMap = request.getContestFreezeTimesMap();
+        Map<String, Profile> profilesMap = request.getProfilesMap();
+        List<Submission> programmingSubmissions = request.getProgrammingSubmissions();
+        Set<String> unofficialContestantJids = request.getUnofficialContestantJids();
 
         TrocStyleModuleConfig trocStyleModuleConfig = (TrocStyleModuleConfig) styleModuleConfig;
 

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessorTests.java
@@ -22,7 +22,7 @@ import judgels.api.profile.Profile;
 import judgels.api.submission.bundle.Grading;
 import judgels.api.submission.bundle.ItemSubmission;
 import judgels.api.submission.bundle.Verdict;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -122,7 +122,7 @@ public class BundleScoreboardProcessorTests {
                             .build()
             );
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                     .scoreboardState(state)
                     .styleModuleConfig(styleModuleConfig)
                     .contestContestantsMap(contestContestantsMap)
@@ -196,7 +196,7 @@ public class BundleScoreboardProcessorTests {
                                 .build()
                 );
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -254,7 +254,7 @@ public class BundleScoreboardProcessorTests {
                                 .build()
                 );
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/bundle/BundleScoreboardProcessorTests.java
@@ -10,7 +10,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import judgels.api.contest.Contest;
 import judgels.api.contest.ContestStyle;
@@ -23,6 +22,7 @@ import judgels.api.profile.Profile;
 import judgels.api.submission.bundle.Grading;
 import judgels.api.submission.bundle.ItemSubmission;
 import judgels.api.submission.bundle.Verdict;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -122,18 +122,15 @@ public class BundleScoreboardProcessorTests {
                             .build()
             );
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(
-                    state,
-                    Optional.empty(),
-                    styleModuleConfig,
-                    contestContestantsMap,
-                    contestBeginTimesMap,
-                    contestFreezeTimesMap,
-                    Map.of(),
-                    profilesMap,
-                    List.of(),
-                    submissions,
-                    Set.of());
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                    .scoreboardState(state)
+                    .styleModuleConfig(styleModuleConfig)
+                    .contestContestantsMap(contestContestantsMap)
+                    .contestBeginTimesMap(contestBeginTimesMap)
+                    .contestFreezeTimesMap(contestFreezeTimesMap)
+                    .profilesMap(profilesMap)
+                    .bundleItemSubmissions(submissions)
+                    .build());
 
             assertThat(Lists.transform(result.getEntries(), e -> (BundleScoreboardEntry) e)).containsExactly(
                     new BundleScoreboardEntry.Builder()
@@ -199,18 +196,15 @@ public class BundleScoreboardProcessorTests {
                                 .build()
                 );
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        Map.of(),
-                        profilesMap,
-                        List.of(),
-                        submissions,
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .profilesMap(profilesMap)
+                        .bundleItemSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (BundleScoreboardEntry) e)).containsExactly(
                         new BundleScoreboardEntry.Builder()
@@ -260,18 +254,15 @@ public class BundleScoreboardProcessorTests {
                                 .build()
                 );
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        Map.of(),
-                        profilesMap,
-                        List.of(),
-                        submissions,
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .profilesMap(profilesMap)
+                        .bundleItemSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (BundleScoreboardEntry) e)).containsExactly(
                         new BundleScoreboardEntry.Builder()

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessorTests.java
@@ -10,7 +10,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import judgels.api.contest.Contest;
 import judgels.api.contest.ContestStyle;
@@ -738,7 +737,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
             void empty_new_submissions() {
                 ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
                         .scoreboardState(state)
-                        .incrementalContent(Optional.of(incrementalContent))
+                        .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
                         .contestBeginTimesMap(contestBeginTimesMap)
@@ -756,7 +755,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
             void existing_incremental_content() {
                 ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
                         .scoreboardState(state)
-                        .incrementalContent(Optional.of(incrementalContent))
+                        .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
                         .contestBeginTimesMap(contestBeginTimesMap)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessorTests.java
@@ -23,6 +23,7 @@ import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
 import judgels.api.submission.programming.Submission;
 import judgels.contest.scoreboard.AbstractProgrammingScoreboardProcessorTests;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.grading.api.ScoringConfig;
 import judgels.grading.api.Verdict;
@@ -81,18 +82,15 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                     createSubmission(4, 410, "c1", "p2", 100, Verdict.ACCEPTED),
                     createSubmission(5, 900, "c2", "p1", 100, Verdict.ACCEPTED));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(
-                    state,
-                    Optional.empty(),
-                    styleModuleConfig,
-                    contestContestantsMap,
-                    contestBeginTimesMap,
-                    Map.of(),
-                    problemScoringConfigsMap,
-                    profilesMap,
-                    submissions,
-                    List.of(),
-                    Set.of());
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                    .scoreboardState(state)
+                    .styleModuleConfig(styleModuleConfig)
+                    .contestContestantsMap(contestContestantsMap)
+                    .contestBeginTimesMap(contestBeginTimesMap)
+                    .problemScoringConfigsMap(problemScoringConfigsMap)
+                    .profilesMap(profilesMap)
+                    .programmingSubmissions(submissions)
+                    .build());
 
             assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                     new GcjScoreboardEntry.Builder()
@@ -133,18 +131,15 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void base_case() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -185,18 +180,15 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .problemPoints(ImmutableList.of(10, 1))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -238,18 +230,15 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         createSubmission(1, 300, "c1", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c2", "p2", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -288,18 +277,15 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         createSubmission(1, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c1", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -354,18 +340,15 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         createSubmission(1, 660, "c1", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c2", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -432,18 +415,15 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         createSubmission(2, 900, "c1", "p2", 0, Verdict.WRONG_ANSWER),
                         createSubmission(3, 900, "c3", "p2", 0, Verdict.WRONG_ANSWER));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -502,18 +482,16 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void no_pending() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        baseSubmissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(baseSubmissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -553,18 +531,16 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .add(createSubmission(4, 501, "c1", "p1", 100, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -604,18 +580,16 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .add(createSubmission(4, 501, "c1", "p2", 0, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -655,18 +629,16 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .add(createSubmission(4, 500, "c1", "p2", 0, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (GcjScoreboardEntry) e)).containsExactly(
                         new GcjScoreboardEntry.Builder()
@@ -737,18 +709,15 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new GcjScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)
@@ -767,18 +736,15 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_new_submissions() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.of(incrementalContent),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        List.of(),
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .incrementalContent(Optional.of(incrementalContent))
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new GcjScoreboardIncrementalContent.Builder()
                         .from(incrementalContent)
@@ -788,18 +754,16 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.of(incrementalContent),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .incrementalContent(Optional.of(incrementalContent))
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new GcjScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/gcj/GcjScoreboardProcessorTests.java
@@ -22,7 +22,7 @@ import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
 import judgels.api.submission.programming.Submission;
 import judgels.contest.scoreboard.AbstractProgrammingScoreboardProcessorTests;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.grading.api.ScoringConfig;
 import judgels.grading.api.Verdict;
@@ -81,7 +81,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                     createSubmission(4, 410, "c1", "p2", 100, Verdict.ACCEPTED),
                     createSubmission(5, 900, "c2", "p1", 100, Verdict.ACCEPTED));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                     .scoreboardState(state)
                     .styleModuleConfig(styleModuleConfig)
                     .contestContestantsMap(contestContestantsMap)
@@ -130,7 +130,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void base_case() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -179,7 +179,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .problemPoints(ImmutableList.of(10, 1))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -229,7 +229,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         createSubmission(1, 300, "c1", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c2", "p2", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -276,7 +276,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         createSubmission(1, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c1", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -339,7 +339,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         createSubmission(1, 660, "c1", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c2", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -414,7 +414,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         createSubmission(2, 900, "c1", "p2", 0, Verdict.WRONG_ANSWER),
                         createSubmission(3, 900, "c3", "p2", 0, Verdict.WRONG_ANSWER));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -481,7 +481,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void no_pending() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -530,7 +530,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .add(createSubmission(4, 501, "c1", "p1", 100, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -579,7 +579,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .add(createSubmission(4, 501, "c1", "p2", 0, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -628,7 +628,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .add(createSubmission(4, 500, "c1", "p2", 0, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -708,7 +708,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -735,7 +735,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_new_submissions() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
@@ -753,7 +753,7 @@ class GcjScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessorTests.java
@@ -10,7 +10,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import judgels.api.contest.Contest;
 import judgels.api.contest.ContestStyle;
@@ -809,7 +808,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
             void empty_new_submissions() {
                 ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
                         .scoreboardState(state)
-                        .incrementalContent(Optional.of(incrementalContent))
+                        .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
                         .contestBeginTimesMap(contestBeginTimesMap)
@@ -827,7 +826,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
             void existing_incremental_content() {
                 ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
                         .scoreboardState(state)
-                        .incrementalContent(Optional.of(incrementalContent))
+                        .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
                         .contestBeginTimesMap(contestBeginTimesMap)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessorTests.java
@@ -23,6 +23,7 @@ import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
 import judgels.api.submission.programming.Submission;
 import judgels.contest.scoreboard.AbstractProgrammingScoreboardProcessorTests;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.grading.api.ScoringConfig;
 import judgels.grading.api.Verdict;
@@ -82,18 +83,15 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                     createSubmission(6, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                     createSubmission(7, 920, "c2", "p1", 0, Verdict.COMPILATION_ERROR));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(
-                    state,
-                    Optional.empty(),
-                    styleModuleConfig,
-                    contestContestantsMap,
-                    contestBeginTimesMap,
-                    Map.of(),
-                    problemScoringConfigsMap,
-                    profilesMap,
-                    submissions,
-                    List.of(),
-                    Set.of());
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                    .scoreboardState(state)
+                    .styleModuleConfig(styleModuleConfig)
+                    .contestContestantsMap(contestContestantsMap)
+                    .contestBeginTimesMap(contestBeginTimesMap)
+                    .problemScoringConfigsMap(problemScoringConfigsMap)
+                    .profilesMap(profilesMap)
+                    .programmingSubmissions(submissions)
+                    .build());
 
             assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                     new IcpcScoreboardEntry.Builder()
@@ -147,18 +145,16 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                     createSubmission(3, 300, "c3", "p1", 100, Verdict.ACCEPTED),
                     createSubmission(4, 400, "c1", "p2", 100, Verdict.ACCEPTED));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(
-                    state,
-                    Optional.empty(),
-                    styleModuleConfig,
-                    threeContestantsMap,
-                    contestBeginTimesMap,
-                    Map.of(),
-                    problemScoringConfigsMap,
-                    threeProfilesMap,
-                    submissions,
-                    List.of(),
-                    Set.of("c3"));
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                    .scoreboardState(state)
+                    .styleModuleConfig(styleModuleConfig)
+                    .contestContestantsMap(threeContestantsMap)
+                    .contestBeginTimesMap(contestBeginTimesMap)
+                    .problemScoringConfigsMap(problemScoringConfigsMap)
+                    .profilesMap(threeProfilesMap)
+                    .programmingSubmissions(submissions)
+                    .unofficialContestantJids(Set.of("c3"))
+                    .build());
 
             // c3 is unofficial: shown in place but rank 0; official c1/c2 get dense ranks 1 and 2.
             assertThat(Lists.transform(result.getEntries(), e -> Map.entry(e.getContestantJid(), e.getRank())))
@@ -176,18 +172,15 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void base_case() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -229,18 +222,15 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .addProblemAliases("B", "A")
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -285,18 +275,15 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(2, 360, "c2", "p2", 100, Verdict.ACCEPTED),
                         createSubmission(3, 900, "c2", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -337,18 +324,15 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(1, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c1", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -406,18 +390,15 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(2, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(3, 900, "c3", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -487,18 +468,15 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(2, 900, "c1", "p2", 0, Verdict.WRONG_ANSWER),
                         createSubmission(3, 900, "c3", "p2", 0, Verdict.WRONG_ANSWER));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -560,18 +538,16 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void no_pending() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        baseSubmissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(baseSubmissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -613,18 +589,16 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 501, "c1", "p1", 100, Verdict.ACCEPTED))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -666,18 +640,16 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 501, "c1", "p2", 100, Verdict.ACCEPTED))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -719,18 +691,16 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 500, "c1", "p2", 100, Verdict.ACCEPTED))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IcpcScoreboardEntry) e)).containsExactly(
                         new IcpcScoreboardEntry.Builder()
@@ -806,18 +776,15 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IcpcScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)
@@ -840,18 +807,15 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void empty_new_submissions() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.of(incrementalContent),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        List.of(),
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .incrementalContent(Optional.of(incrementalContent))
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IcpcScoreboardIncrementalContent.Builder()
                         .from(incrementalContent)
@@ -861,18 +825,16 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.of(incrementalContent),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .incrementalContent(Optional.of(incrementalContent))
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IcpcScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/icpc/IcpcScoreboardProcessorTests.java
@@ -22,7 +22,7 @@ import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
 import judgels.api.submission.programming.Submission;
 import judgels.contest.scoreboard.AbstractProgrammingScoreboardProcessorTests;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.grading.api.ScoringConfig;
 import judgels.grading.api.Verdict;
@@ -82,7 +82,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                     createSubmission(6, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                     createSubmission(7, 920, "c2", "p1", 0, Verdict.COMPILATION_ERROR));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                     .scoreboardState(state)
                     .styleModuleConfig(styleModuleConfig)
                     .contestContestantsMap(contestContestantsMap)
@@ -144,7 +144,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                     createSubmission(3, 300, "c3", "p1", 100, Verdict.ACCEPTED),
                     createSubmission(4, 400, "c1", "p2", 100, Verdict.ACCEPTED));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                     .scoreboardState(state)
                     .styleModuleConfig(styleModuleConfig)
                     .contestContestantsMap(threeContestantsMap)
@@ -171,7 +171,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void base_case() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -221,7 +221,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .addProblemAliases("B", "A")
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -274,7 +274,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(2, 360, "c2", "p2", 100, Verdict.ACCEPTED),
                         createSubmission(3, 900, "c2", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -323,7 +323,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(1, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c1", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -389,7 +389,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(2, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(3, 900, "c3", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -467,7 +467,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(2, 900, "c1", "p2", 0, Verdict.WRONG_ANSWER),
                         createSubmission(3, 900, "c3", "p2", 0, Verdict.WRONG_ANSWER));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -537,7 +537,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void no_pending() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -588,7 +588,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 501, "c1", "p1", 100, Verdict.ACCEPTED))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -639,7 +639,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 501, "c1", "p2", 100, Verdict.ACCEPTED))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -690,7 +690,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 500, "c1", "p2", 100, Verdict.ACCEPTED))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -775,7 +775,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -806,7 +806,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void empty_new_submissions() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
@@ -824,7 +824,7 @@ class IcpcScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessorTests.java
@@ -26,7 +26,7 @@ import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
 import judgels.api.submission.programming.Submission;
 import judgels.contest.scoreboard.AbstractProgrammingScoreboardProcessorTests;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.grading.api.LanguageRestriction;
 import judgels.grading.api.ScoringConfig;
@@ -81,7 +81,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                     createMilliSubmission(2, 20, "c1", "p2", 50, Verdict.OK),
                     createMilliSubmission(3, 25, "c1", "p1", 0, Verdict.WRONG_ANSWER));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                     .scoreboardState(state)
                     .styleModuleConfig(styleModuleConfig)
                     .contestContestantsMap(contestContestantsMap)
@@ -127,7 +127,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                     createMilliSubmission(2, 22, "c1", "p2", 50, Verdict.OK),
                     createMilliSubmission(3, 25, "c1", "p2", 90, Verdict.WRONG_ANSWER));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                     .scoreboardState(state)
                     .styleModuleConfig(styleModuleConfig)
                     .contestContestantsMap(contestContestantsMap)
@@ -192,7 +192,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -245,7 +245,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
@@ -306,7 +306,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void base_case() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -350,7 +350,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .addProblemAliases("B", "A")
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -431,7 +431,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
             void sorted_without_last_affecting_penalty() {
                 styleModuleConfig = new IoiStyleModuleConfig.Builder().usingLastAffectingPenalty(false).build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -474,7 +474,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
             void sorted_with_last_affecting_penalty() {
                 styleModuleConfig = new IoiStyleModuleConfig.Builder().usingLastAffectingPenalty(true).build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -548,7 +548,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -575,7 +575,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_new_submissions() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
@@ -593,7 +593,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessorTests.java
@@ -26,6 +26,7 @@ import judgels.api.contest.scoreboard.ScoreboardState;
 import judgels.api.profile.Profile;
 import judgels.api.submission.programming.Submission;
 import judgels.contest.scoreboard.AbstractProgrammingScoreboardProcessorTests;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.grading.api.LanguageRestriction;
 import judgels.grading.api.ScoringConfig;
@@ -80,18 +81,15 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                     createMilliSubmission(2, 20, "c1", "p2", 50, Verdict.OK),
                     createMilliSubmission(3, 25, "c1", "p1", 0, Verdict.WRONG_ANSWER));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(
-                    state,
-                    Optional.empty(),
-                    styleModuleConfig,
-                    contestContestantsMap,
-                    contestBeginTimesMap,
-                    Map.of(),
-                    problemScoringConfigsMap,
-                    profilesMap,
-                    submissions,
-                    List.of(),
-                    Set.of());
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                    .scoreboardState(state)
+                    .styleModuleConfig(styleModuleConfig)
+                    .contestContestantsMap(contestContestantsMap)
+                    .contestBeginTimesMap(contestBeginTimesMap)
+                    .problemScoringConfigsMap(problemScoringConfigsMap)
+                    .profilesMap(profilesMap)
+                    .programmingSubmissions(submissions)
+                    .build());
 
             assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                     new IoiScoreboardEntry.Builder()
@@ -129,18 +127,16 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                     createMilliSubmission(2, 22, "c1", "p2", 50, Verdict.OK),
                     createMilliSubmission(3, 25, "c1", "p2", 90, Verdict.WRONG_ANSWER));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(
-                    state,
-                    Optional.empty(),
-                    styleModuleConfig,
-                    contestContestantsMap,
-                    contestBeginTimesMap,
-                    contestFreezeTimesMap,
-                    problemScoringConfigsMap,
-                    profilesMap,
-                    submissions,
-                    List.of(),
-                    Set.of());
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                    .scoreboardState(state)
+                    .styleModuleConfig(styleModuleConfig)
+                    .contestContestantsMap(contestContestantsMap)
+                    .contestBeginTimesMap(contestBeginTimesMap)
+                    .contestFreezeTimesMap(contestFreezeTimesMap)
+                    .problemScoringConfigsMap(problemScoringConfigsMap)
+                    .profilesMap(profilesMap)
+                    .programmingSubmissions(submissions)
+                    .build());
 
             assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                     new IoiScoreboardEntry.Builder()
@@ -196,18 +192,15 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -252,18 +245,16 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.of(incrementalContent),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .incrementalContent(Optional.of(incrementalContent))
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -315,18 +306,15 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void base_case() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -362,18 +350,15 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
                         .addProblemAliases("B", "A")
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -446,18 +431,15 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
             void sorted_without_last_affecting_penalty() {
                 styleModuleConfig = new IoiStyleModuleConfig.Builder().usingLastAffectingPenalty(false).build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -492,18 +474,15 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
             void sorted_with_last_affecting_penalty() {
                 styleModuleConfig = new IoiStyleModuleConfig.Builder().usingLastAffectingPenalty(true).build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (IoiScoreboardEntry) e)).containsExactly(
                         new IoiScoreboardEntry.Builder()
@@ -569,18 +548,15 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IoiScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)
@@ -599,18 +575,15 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void empty_new_submissions() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.of(incrementalContent),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        List.of(),
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .incrementalContent(Optional.of(incrementalContent))
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IoiScoreboardIncrementalContent.Builder()
                         .from(incrementalContent)
@@ -620,18 +593,16 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.of(incrementalContent),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .incrementalContent(Optional.of(incrementalContent))
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new IoiScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/ioi/IoiScoreboardProcessorTests.java
@@ -247,7 +247,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
             void existing_incremental_content() {
                 ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
                         .scoreboardState(state)
-                        .incrementalContent(Optional.of(incrementalContent))
+                        .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
                         .contestBeginTimesMap(contestBeginTimesMap)
@@ -577,7 +577,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
             void empty_new_submissions() {
                 ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
                         .scoreboardState(state)
-                        .incrementalContent(Optional.of(incrementalContent))
+                        .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
                         .contestBeginTimesMap(contestBeginTimesMap)
@@ -595,7 +595,7 @@ class IoiScoreboardProcessorTests extends AbstractProgrammingScoreboardProcessor
             void existing_incremental_content() {
                 ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
                         .scoreboardState(state)
-                        .incrementalContent(Optional.of(incrementalContent))
+                        .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
                         .contestBeginTimesMap(contestBeginTimesMap)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessorTests.java
@@ -22,7 +22,7 @@ import judgels.api.contest.scoreboard.TrocScoreboard.TrocScoreboardProblemState;
 import judgels.api.profile.Profile;
 import judgels.api.submission.programming.Submission;
 import judgels.contest.scoreboard.AbstractProgrammingScoreboardProcessorTests;
-import judgels.contest.scoreboard.ScoreboardProcessRequest;
+import judgels.contest.scoreboard.ScoreboardProcessParams;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.grading.api.ScoringConfig;
 import judgels.grading.api.Verdict;
@@ -85,7 +85,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                     createSubmission(8, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                     createSubmission(9, 920, "c2", "p1", 100, Verdict.COMPILATION_ERROR));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                     .scoreboardState(state)
                     .styleModuleConfig(styleModuleConfig)
                     .contestContestantsMap(contestContestantsMap)
@@ -134,7 +134,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void base_case() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -183,7 +183,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .problemPoints(ImmutableList.of(10, 1))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -233,7 +233,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(1, 300, "c1", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c2", "p2", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -280,7 +280,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(1, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c1", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -343,7 +343,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(1, 660, "c1", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c2", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -418,7 +418,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(2, 900, "c1", "p2", 0, Verdict.WRONG_ANSWER),
                         createSubmission(3, 900, "c3", "p2", 0, Verdict.WRONG_ANSWER));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -485,7 +485,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void no_pending() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -534,7 +534,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 501, "c1", "p1", 100, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -583,7 +583,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 501, "c1", "p2", 0, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -632,7 +632,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 500, "c1", "p2", 0, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -713,7 +713,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
@@ -742,7 +742,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void empty_new_submissions() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
@@ -760,7 +760,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessParams.Builder()
                         .scoreboardState(state)
                         .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessorTests.java
@@ -23,6 +23,7 @@ import judgels.api.contest.scoreboard.TrocScoreboard.TrocScoreboardProblemState;
 import judgels.api.profile.Profile;
 import judgels.api.submission.programming.Submission;
 import judgels.contest.scoreboard.AbstractProgrammingScoreboardProcessorTests;
+import judgels.contest.scoreboard.ScoreboardProcessRequest;
 import judgels.contest.scoreboard.ScoreboardProcessResult;
 import judgels.grading.api.ScoringConfig;
 import judgels.grading.api.Verdict;
@@ -85,18 +86,15 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                     createSubmission(8, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                     createSubmission(9, 920, "c2", "p1", 100, Verdict.COMPILATION_ERROR));
 
-            ScoreboardProcessResult result = scoreboardProcessor.process(
-                    state,
-                    Optional.empty(),
-                    styleModuleConfig,
-                    contestContestantsMap,
-                    contestBeginTimesMap,
-                    Map.of(),
-                    problemScoringConfigsMap,
-                    profilesMap,
-                    submissions,
-                    List.of(),
-                    Set.of());
+            ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                    .scoreboardState(state)
+                    .styleModuleConfig(styleModuleConfig)
+                    .contestContestantsMap(contestContestantsMap)
+                    .contestBeginTimesMap(contestBeginTimesMap)
+                    .problemScoringConfigsMap(problemScoringConfigsMap)
+                    .profilesMap(profilesMap)
+                    .programmingSubmissions(submissions)
+                    .build());
 
             assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                     new TrocScoreboardEntry.Builder()
@@ -137,18 +135,15 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void base_case() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -189,18 +184,15 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .problemPoints(ImmutableList.of(10, 1))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -242,18 +234,15 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(1, 300, "c1", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c2", "p2", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -292,18 +281,15 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(1, 900, "c2", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c1", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -358,18 +344,15 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(1, 660, "c1", "p1", 100, Verdict.ACCEPTED),
                         createSubmission(2, 900, "c2", "p1", 100, Verdict.ACCEPTED));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -436,18 +419,15 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         createSubmission(2, 900, "c1", "p2", 0, Verdict.WRONG_ANSWER),
                         createSubmission(3, 900, "c3", "p2", 0, Verdict.WRONG_ANSWER));
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -506,18 +486,16 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void no_pending() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        baseSubmissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(baseSubmissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -557,18 +535,16 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 501, "c1", "p1", 100, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -608,18 +584,16 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 501, "c1", "p2", 0, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -659,18 +633,16 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
                         .add(createSubmission(4, 500, "c1", "p2", 0, Verdict.PENDING))
                         .build();
 
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        contestFreezeTimesMap,
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .contestFreezeTimesMap(contestFreezeTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(Lists.transform(result.getEntries(), e -> (TrocScoreboardEntry) e)).containsExactly(
                         new TrocScoreboardEntry.Builder()
@@ -742,18 +714,15 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void empty_initial_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.empty(),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new TrocScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)
@@ -774,18 +743,15 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void empty_new_submissions() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.of(incrementalContent),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        List.of(),
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .incrementalContent(Optional.of(incrementalContent))
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new TrocScoreboardIncrementalContent.Builder()
                         .from(incrementalContent)
@@ -795,18 +761,16 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
 
             @Test
             void existing_incremental_content() {
-                ScoreboardProcessResult result = scoreboardProcessor.process(
-                        state,
-                        Optional.of(incrementalContent),
-                        styleModuleConfig,
-                        contestContestantsMap,
-                        contestBeginTimesMap,
-                        Map.of(),
-                        problemScoringConfigsMap,
-                        profilesMap,
-                        submissions,
-                        List.of(),
-                        Set.of());
+                ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
+                        .scoreboardState(state)
+                        .incrementalContent(Optional.of(incrementalContent))
+                        .styleModuleConfig(styleModuleConfig)
+                        .contestContestantsMap(contestContestantsMap)
+                        .contestBeginTimesMap(contestBeginTimesMap)
+                        .problemScoringConfigsMap(problemScoringConfigsMap)
+                        .profilesMap(profilesMap)
+                        .programmingSubmissions(submissions)
+                        .build());
 
                 assertThat(result.getIncrementalContent()).isEqualTo(new TrocScoreboardIncrementalContent.Builder()
                         .lastSubmissionId(9)

--- a/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessorTests.java
+++ b/judgels-backends/judgels-server-app/src/test/java/judgels/contest/scoreboard/troc/TrocScoreboardProcessorTests.java
@@ -10,7 +10,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import judgels.api.contest.Contest;
 import judgels.api.contest.ContestStyle;
@@ -745,7 +744,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
             void empty_new_submissions() {
                 ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
                         .scoreboardState(state)
-                        .incrementalContent(Optional.of(incrementalContent))
+                        .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
                         .contestBeginTimesMap(contestBeginTimesMap)
@@ -763,7 +762,7 @@ class TrocScoreboardProcessorTests extends AbstractProgrammingScoreboardProcesso
             void existing_incremental_content() {
                 ScoreboardProcessResult result = scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
                         .scoreboardState(state)
-                        .incrementalContent(Optional.of(incrementalContent))
+                        .incrementalContent(incrementalContent)
                         .styleModuleConfig(styleModuleConfig)
                         .contestContestantsMap(contestContestantsMap)
                         .contestBeginTimesMap(contestBeginTimesMap)


### PR DESCRIPTION
## Motivation

`ScoreboardProcessor.process(...)` had grown to **11 positional parameters**. Beyond being unwieldy, it was a genuine correctness hazard: `contestBeginTimesMap` and `contestFreezeTimesMap` are both `Map<String, Instant>` and sit *adjacent* in the list — transposing them compiles cleanly and would silently corrupt freeze handling.

## Change

Introduce `ScoreboardProcessRequest`, an Immutables value type mirroring the `ScoreboardProcessResult` that already lives in the same package:

```java
ScoreboardProcessResult process(ScoreboardProcessRequest request);
```

Each processor destructures the fields it actually uses at the top of `process()`, so **the method bodies are unchanged** — the diff in the 5 processors is confined to the signature.

## Why it's a net win

Immutables defaults `Map`/`List`/`Set`/`Optional` attributes to empty, so call sites only set what they care about. The test call sites drop their `Optional.empty()` / `Map.of()` / `List.of()` / `Set.of()` arguments entirely:

```java
// before: 11 positional args
scoreboardProcessor.process(
        state, Optional.empty(), styleModuleConfig, contestContestantsMap,
        contestBeginTimesMap, Map.of(), problemScoringConfigsMap, profilesMap,
        submissions, List.of(), Set.of());

// after: only what matters, named
scoreboardProcessor.process(new ScoreboardProcessRequest.Builder()
        .scoreboardState(state)
        .styleModuleConfig(styleModuleConfig)
        .contestContestantsMap(contestContestantsMap)
        .contestBeginTimesMap(contestBeginTimesMap)
        .problemScoringConfigsMap(problemScoringConfigsMap)
        .profilesMap(profilesMap)
        .programmingSubmissions(submissions)
        .build());
```

Results:
- **Named construction eliminates the transposition bug** between the two `Map<String, Instant>` params.
- **Net −185 lines** (604 insertions / 789 deletions) across 13 files.
- **Future params cost nothing** — add a field with a default instead of touching the interface, all 5 processors, and all 57 test call sites (exactly the tax the last feature paid).

## Verification

No behavior change.

- `:judgels-server-app:compileJava` / `compileTestJava` / `compileIntegTestJava` and `checkstyleMain` / `checkstyleTest` / `checkstyleIntegTest` all clean.
- All `judgels.contest.scoreboard.*` tests pass with **0 failures / 0 errors**, including the `IncrementalProcess` suites for every style — confirming the `Optional` incremental content still flows correctly through the builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)