### PR TITLE
Show unofficial participation in contest history with no rank

### DIFF
--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestHistoryApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestHistoryApiIntegrationTests.java
@@ -46,10 +46,11 @@ class ContestHistoryApiIntegrationTests extends BaseContestApiIntegrationTests {
 
         Contest contest = buildContest()
                 .modules(ContestModuleType.REGISTRATION)
-                .contestants(CONTESTANT)
+                .contestants(CONTESTANT, CONTESTANT_A)
                 .ended()
                 .build();
         setFinalRank(contest.getJid(), contestant.getJid(), 3);
+        setFinalRank(contest.getJid(), contestantA.getJid(), 0);
 
         userRatingClient.updateRatings(adminToken, new UserRatingUpdateData.Builder()
                 .time(Instant.ofEpochSecond(100))
@@ -64,23 +65,13 @@ class ContestHistoryApiIntegrationTests extends BaseContestApiIntegrationTests {
         assertThat(history.getData().get(0).getRating()).contains(UserRating.of(1500, 1400));
         assertThat(history.getContestsMap()).containsKey(contest.getJid());
         assertThat(history.getContestsMap().get(contest.getJid()).getSlug()).isEqualTo(contest.getSlug());
-    }
 
-    @Test
-    void get_public_history__unofficial() {
-        Contest contest = buildContest()
-                .modules(ContestModuleType.REGISTRATION)
-                .contestants(CONTESTANT_A)
-                .ended()
-                .build();
-
-        setFinalRank(contest.getJid(), contestantA.getJid(), 0);
-
-        ContestHistoryResponse history = historyClient.getPublicHistory(CONTESTANT_A);
-        assertThat(history.getData()).hasSize(1);
-        assertThat(history.getData().get(0).getContestJid()).isEqualTo(contest.getJid());
-        assertThat(history.getData().get(0).getRank()).isEqualTo(0);
-        assertThat(history.getContestsMap()).containsKey(contest.getJid());
+        ContestHistoryResponse unofficialHistory = historyClient.getPublicHistory(CONTESTANT_A);
+        assertThat(unofficialHistory.getData()).hasSize(1);
+        assertThat(unofficialHistory.getData().get(0).getContestJid()).isEqualTo(contest.getJid());
+        assertThat(unofficialHistory.getData().get(0).getRank()).isEqualTo(0);
+        assertThat(unofficialHistory.getData().get(0).getRating()).isEmpty();
+        assertThat(unofficialHistory.getContestsMap()).containsKey(contest.getJid());
     }
 
     private static void setFinalRank(String contestJid, String userJid, int rank) {

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestHistoryApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestHistoryApiIntegrationTests.java
@@ -66,6 +66,25 @@ class ContestHistoryApiIntegrationTests extends BaseContestApiIntegrationTests {
         assertThat(history.getContestsMap().get(contest.getJid()).getSlug()).isEqualTo(contest.getSlug());
     }
 
+    @Test
+    void get_public_history__unofficial() {
+        Contest contest = buildContest()
+                .modules(ContestModuleType.REGISTRATION)
+                .contestants(CONTESTANT_A)
+                .ended()
+                .build();
+
+        // Unofficial contestants get final rank 0: the contest still shows up in their history,
+        // but with no official rank.
+        setFinalRank(contest.getJid(), contestantA.getJid(), 0);
+
+        ContestHistoryResponse history = historyClient.getPublicHistory(CONTESTANT_A);
+        assertThat(history.getData()).hasSize(1);
+        assertThat(history.getData().get(0).getContestJid()).isEqualTo(contest.getJid());
+        assertThat(history.getData().get(0).getRank()).isEqualTo(0);
+        assertThat(history.getContestsMap()).containsKey(contest.getJid());
+    }
+
     private static void setFinalRank(String contestJid, String userJid, int rank) {
         Session session = openSession();
         Transaction txn = session.beginTransaction();

--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestHistoryApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestHistoryApiIntegrationTests.java
@@ -74,8 +74,6 @@ class ContestHistoryApiIntegrationTests extends BaseContestApiIntegrationTests {
                 .ended()
                 .build();
 
-        // Unofficial contestants get final rank 0: the contest still shows up in their history,
-        // but with no official rank.
         setFinalRank(contest.getJid(), contestantA.getJid(), 0);
 
         ContestHistoryResponse history = historyClient.getPublicHistory(CONTESTANT_A);

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
@@ -271,9 +271,6 @@ public class ContestScoreboardUpdater {
 
         if (contestTimer.hasEnded(contest)) {
             for (ScoreboardEntry e : scoreboards.get(OFFICIAL).getContent().getEntries()) {
-                // Unofficial contestants have rank 0. They still get a final rank row, so the contest
-                // shows up in their contest history, but with no official rank. Always writing the rank
-                // (instead of skipping) also means a re-run overwrites any rank from a previous run.
                 if (e.hasSubmission()) {
                     contestantStore.updateContestantFinalRank(contest.getJid(), e.getContestantJid(), e.getRank());
                 }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/scoreboard/ContestScoreboardUpdater.java
@@ -271,8 +271,10 @@ public class ContestScoreboardUpdater {
 
         if (contestTimer.hasEnded(contest)) {
             for (ScoreboardEntry e : scoreboards.get(OFFICIAL).getContent().getEntries()) {
-                // rank <= 0 means unofficial (or incognito); such contestants get no final rank.
-                if (e.hasSubmission() && e.getRank() > 0) {
+                // Unofficial contestants have rank 0. They still get a final rank row, so the contest
+                // shows up in their contest history, but with no official rank. Always writing the rank
+                // (instead of skipping) also means a re-run overwrites any rank from a previous run.
+                if (e.hasSubmission()) {
                     contestantStore.updateContestantFinalRank(contest.getJid(), e.getContestantJid(), e.getRank());
                 }
             }

--- a/judgels-client/src/routes/home/profiles/single/contestHistory/ContestHistoryPage/ContestHistoryPage.jsx
+++ b/judgels-client/src/routes/home/profiles/single/contestHistory/ContestHistoryPage/ContestHistoryPage.jsx
@@ -77,7 +77,7 @@ function renderRows(response) {
         <td>
           <ContestLink contest={contestsMap[event.contestJid]} />
         </td>
-        <td>{event.rank}</td>
+        <td>{event.rank === 0 ? '-' : event.rank}</td>
         <td>{ratingChange}</td>
         <td>{ratingDiff}</td>
       </tr>

--- a/judgels-client/src/routes/home/profiles/single/contestHistory/ContestHistoryPage/ContestHistoryPage.test.jsx
+++ b/judgels-client/src/routes/home/profiles/single/contestHistory/ContestHistoryPage/ContestHistoryPage.test.jsx
@@ -1,0 +1,55 @@
+import { act, render, screen, within } from '@testing-library/react';
+
+import { QueryClientProviderWrapper } from '../../../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../../../test/RouterWrapper';
+import { nockApi } from '../../../../../../utils/nock';
+import ContestHistoryPage from './ContestHistoryPage';
+
+describe('ContestHistoryPage', () => {
+  const renderComponent = async response => {
+    nockApi().get('/contest-history/public').query({ username: 'username1' }).reply(200, response);
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter initialEntries={['/profiles/username1']} path="/profiles/$username">
+            <ContestHistoryPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders placeholder when there are no contests', async () => {
+    await renderComponent({ data: [], contestsMap: {} });
+    expect(await screen.findByText(/no contests/i)).toBeInTheDocument();
+  });
+
+  test('renders the ranks, with a dash for unofficial contests', async () => {
+    await renderComponent({
+      data: [
+        { contestJid: 'contestJid1', rank: 3 },
+        { contestJid: 'contestJid2', rank: 0 },
+      ],
+      contestsMap: {
+        contestJid1: { name: 'Contest 1', slug: 'contest-1' },
+        contestJid2: { name: 'Contest 2', slug: 'contest-2' },
+      },
+    });
+
+    const rows = await screen.findAllByRole('row');
+
+    // Rows are rendered most-recent first.
+    expect(
+      rows.slice(1).map(row =>
+        within(row)
+          .getAllByRole('cell')
+          .slice(1, 3)
+          .map(td => td.textContent)
+      )
+    ).toEqual([
+      ['Contest 2', '-'],
+      ['Contest 1', '3'],
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

Two related issues with `finalRank` for unofficial (higher-division) contestants.

**1. The contest vanished from their history.** We skipped unofficial contestants when writing final ranks, leaving `finalRank` null. But "participated" is defined as `finalRank IS NOT NULL` (`ContestRoleHibernateDao.userParticipated`), so the contest never appeared in their contest history at all.

**2. Retroactively enabling the flag left stale ranks.** The final-rank loop only ever *wrote*, never *cleared*:

```java
if (e.hasSubmission() && e.getRank() > 0) {   // unofficial (rank 0) just skipped
    contestantStore.updateContestantFinalRank(...);
}
```

So on an **already-finished** contest, turning on "allow higher divisions unofficially" and refreshing the scoreboard left the Div-1 contestants' **old finalRank in the database**. They kept an outdated rank in their history while the scoreboard showed them unranked — the two views contradicted each other. This never surfaced on a fresh contest, where `finalRank` starts null and "skip" and "clear" look identical.

## Fix

Write the rank for **every** contestant with a submission, unofficial ones included. They get `finalRank = 0` — the *same* "no rank" sentinel the scoreboard already uses:

```java
if (e.hasSubmission()) {
    contestantStore.updateContestantFinalRank(contest.getJid(), e.getContestantJid(), e.getRank());
}
```

This fixes both issues at once:
- `0` is not null → the contest **shows up in their contest history**, rendered with a **dash** instead of a rank.
- Always writing (instead of skipping) means a re-run **overwrites** any rank from a previous run, so retroactively enabling the flag now correctly clears stale ranks.

`finalRank` is only ever null-checked (`isNotNull`) — never compared, ordered, or used in arithmetic — so `0` is safe. Verified across every usage.

Frontend renders it consistently with the scoreboard:
```jsx
<td>{event.rank === 0 ? '-' : event.rank}</td>
```

## Tests

- **Backend integ:** new `get_public_history__unofficial` in `ContestHistoryApiIntegrationTests` — a contestant with `finalRank = 0` appears in history with rank `0`. Both tests in the class pass.
- **Frontend:** new `ContestHistoryPage.test.jsx` (the page had no test) — asserts a rank-0 row renders `-` while a normal rank still renders its number.

## Verification

- Backend: `compileJava` / `compileIntegTestJava` + `checkstyleMain` / `checkstyleIntegTest` clean; `ContestHistoryApiIntegrationTests` passes (2/2).
- Frontend: 293/295 pass. The 2 failures (`ContestFilesPage`, `ContestProblemPage`) are **pre-existing on clean master** — confirmed by stashing and re-running — and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)