### PR TITLE
Fix repeated [user:username] not rendered in HtmlText

### DIFF
--- a/judgels-client/src/components/HtmlText/HtmlText.jsx
+++ b/judgels-client/src/components/HtmlText/HtmlText.jsx
@@ -20,7 +20,9 @@ export class HtmlText extends Component {
     if (profilesMap) {
       Object.keys(profilesMap).forEach(userJid => {
         const profile = profilesMap[userJid];
-        str = str.replace('[user:' + profile.username + ']', renderToString(<UserRef profile={profile} useAnchor />));
+        str = str
+          .split('[user:' + profile.username + ']')
+          .join(renderToString(<UserRef profile={profile} useAnchor />));
       });
     }
 

--- a/judgels-client/src/components/HtmlText/HtmlText.test.jsx
+++ b/judgels-client/src/components/HtmlText/HtmlText.test.jsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+
+import { HtmlText } from './HtmlText';
+
+describe('HtmlText', () => {
+  const profilesMap = {
+    userJid123: { username: 'user1' },
+    userJid456: { username: 'user2' },
+  };
+
+  const renderComponent = children => render(<HtmlText profilesMap={profilesMap}>{children}</HtmlText>);
+
+  test('renders user refs', () => {
+    const { container } = renderComponent('<p>Hello [user:user1] and [user:user2], I mean [user:user1]!</p>');
+
+    const links = container.querySelectorAll('a');
+    expect([...links].map(link => link.textContent)).toEqual(['user1', 'user2', 'user1']);
+    expect([...links].map(link => link.getAttribute('href'))).toEqual([
+      '/profiles/user1',
+      '/profiles/user2',
+      '/profiles/user1',
+    ]);
+    expect(container.textContent).not.toContain('[user:');
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/ia-toki/judgels/issues/972

On contest overview (and anywhere `HtmlText` is used), if the same `[user:username]` tag appeared twice, the second one was not rendered and showed up as literal text.

`String.prototype.replace` with a string pattern only replaces the first occurrence. Switched to `split(...).join(...)`, which replaces all of them. `replaceAll` would work too, but with a string replacement it still interprets `$` sequences (`$&`, `$'`, …) specially, and the replacement here is rendered HTML that could contain a `$`.

Added a test covering distinct and repeated mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)