### PR TITLE
Fix empty app config block in v3 server config template

### DIFF
--- a/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
+++ b/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
@@ -47,9 +47,11 @@ webSecurity:
 judgels:
   baseDataDir: var/data
 
-  app:
 {% if app_licenseKey is defined %}
+  app:
     licenseKey: {{ app_licenseKey }}
+{% else %}
+  app: {}
 {% endif %}
 
 {% if rabbitmq_username is defined %}


### PR DESCRIPTION
924ec48e removed the now-orphaned `name: {{ app_name }}` line from the v3 ansible server config template, leaving the `app:` block with no children whenever `app_licenseKey` is undefined:

```yaml
  app:
{% if app_licenseKey is defined %}
    licenseKey: {{ app_licenseKey }}
{% endif %}
```

YAML parses that as null, and `JudgelsServerConfiguration.getAppConfig()` is a mandatory attribute, so the server container crash-loops on any deployment without a license key:

```
io.dropwizard.configuration.ConfigurationParsingException: var/conf/judgels-server.yml has an error:
  * Failed to parse configuration at: judgels; Cannot construct instance of
    `judgels.ImmutableJudgelsServerConfiguration`, problem: Cannot build
    JudgelsServerConfiguration, some of required attributes are not set [appConfig]
```

Emit an explicit `app: {}` instead. The block carries no information when there is no license key — `getLicenseKey()` is already `Optional` — but the key still has to be present for the mandatory attribute to be satisfied.

Verified by rendering the template with a `judgels_base_url`-style `env/vars.yml` that defines no `app_licenseKey`: `judgels.app` now parses as an empty mapping rather than `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)