### PR TITLE
Add privilege escalation to v3 ansible playbooks

### DIFF
--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-judgels-client.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-judgels-client.yml
@@ -1,4 +1,5 @@
 - hosts: core
   gather_facts: false
+  become: true
   roles:
     - name: judgels-client-deploy

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-judgels-grader.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-judgels-grader.yml
@@ -1,4 +1,5 @@
 - hosts: grader
   gather_facts: false
+  become: true
   roles:
     - name: judgels-grader-deploy

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-judgels-server.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-judgels-server.yml
@@ -1,4 +1,5 @@
 - hosts: core
   gather_facts: false
+  become: true
   roles:
     - name: judgels-server-deploy

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-phpmyadmin.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-phpmyadmin.yml
@@ -1,5 +1,6 @@
 - hosts: core
   gather_facts: false
+  become: true
   roles:
     - name: phpmyadmin-deploy
       vars:

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy.yml
@@ -1,5 +1,6 @@
 - hosts: core
   gather_facts: false
+  become: true
   roles:
     - name: rabbitmq-deploy
     - name: judgels-server-migrate
@@ -22,5 +23,6 @@
 
 - hosts: grader
   gather_facts: false
+  become: true
   roles:
     - name: judgels-grader-deploy

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/dump.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/dump.yml
@@ -1,5 +1,6 @@
 - hosts: core
   gather_facts: true
+  become: true
   vars:
     db_dump_file: /opt/judgels/server/var/tmp/judgels-{{ ansible_date_time.epoch }}.sql
   tasks:
@@ -24,18 +25,23 @@
         state: directory
       delegate_to: localhost
       connection: local
+      become: false
 
     - name: Download judgels database dump file
       synchronize:
         mode: pull
         src: "{{ db_dump_file }}"
         dest: "{{ dump_dir }}/mysql/"
-    
+        rsync_path: sudo rsync
+      become: false
+
     - name: Download MySQL logs
       synchronize:
         mode: pull
         src: /var/log/mysql/
         dest: "{{ dump_dir }}/mysql"
+        rsync_path: sudo rsync
+      become: false
 
     - name: Create judgels-server directory
       file:
@@ -43,12 +49,15 @@
         state: directory
       delegate_to: localhost
       connection: local
+      become: false
 
     - name: Download judgels-server data
       synchronize:
         mode: pull
         src: /opt/judgels/server/var/data/
         dest: "{{ dump_dir }}/judgels-server"
+        rsync_path: sudo rsync
+      become: false
 
     - name: Create system directory
       file:
@@ -56,9 +65,12 @@
         state: directory
       delegate_to: localhost
       connection: local
+      become: false
 
     - name: Download system logs
       synchronize:
         mode: pull
         src: /var/log/auth.log
         dest: "{{ dump_dir }}/system"
+        rsync_path: sudo rsync
+      become: false

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/migrate-judgels-server.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/migrate-judgels-server.yml
@@ -1,4 +1,5 @@
 - hosts: core
   gather_facts: false
+  become: true
   roles:
     - name: judgels-server-migrate

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/optimize.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/optimize.yml
@@ -1,10 +1,12 @@
 - hosts: all
   gather_facts: false
+  become: true
   roles:
     - name: docker-optimize
 
 - hosts: core
   gather_facts: false
+  become: true
   roles:
     - name: mysql-optimize
     - name: nginx-optimize

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/provision.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/provision.yml
@@ -1,5 +1,6 @@
 - hosts: all
   gather_facts: false
+  become: true
   roles:
     - name: python-install
     - name: docker-install
@@ -7,6 +8,7 @@
 
 - hosts: core
   gather_facts: false
+  become: true
   roles:
     - name: mysql-install
     - name: nginx-install
@@ -18,12 +20,14 @@
 
 - hosts: core
   gather_facts: false
+  become: true
   roles:
     - name: judgels-server-provision
     - name: judgels-client-provision
 
 - hosts: grader
   gather_facts: false
+  become: true
   roles:
     - name: isolate-provision
     - name: judgels-grader-provision

--- a/deployment/v3-ubuntu-24.04/ansible/roles/judgels-server-provision/tasks/main.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/roles/judgels-server-provision/tasks/main.yml
@@ -39,6 +39,7 @@
       slurp:
         path: "{{ playbook_dir }}/../env/judgels-grader.pub"
       delegate_to: localhost
+      become: false
       register: judgels_grader_pubkey
     
     - name: Add the public key to the authorized_keys file


### PR DESCRIPTION
No v3 playbook sets `become`, so every task ran as the login user. That only works when connecting as root; with an unprivileged `ansible_user`, the apt/docker/nginx tasks fail with permission errors. `env/hosts.ini` already carries `ansible_become_password`.

Enabled per play rather than globally in `ansible.cfg`, since some tasks must stay unprivileged:

- The `hosts: localhost` keypair play in `provision.yml`, and the `delegate_to: localhost` tasks in `judgels-server-provision` and `dump.yml`, run on the control machine.
- `synchronize` invokes rsync on the control node, so `become` would sudo locally. The remote side gets root via `rsync_path`, needed for `/var/log/mysql` (`0750 root:adm`) and `/var/log/auth.log` (`0640 root:adm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)