### PR TITLE
Add a plain HTTP nginx option for deployments without a domain

### DIFF
--- a/deployment/v3-ubuntu-24.04/ansible/conf/judgels-client.js.j2
+++ b/deployment/v3-ubuntu-24.04/ansible/conf/judgels-client.js.j2
@@ -1,6 +1,10 @@
 window.conf = {
   mode: '{{ app_mode | default('JUDGELS', true) }}',
+{% if nginx_certbot_enabled | default(true) | bool %}
   apiUrl: 'https://{{ nginx_domain_judgels_server_api }}/v2',
+{% else %}
+  apiUrl: '/api/v2',
+{% endif %}
 {% if googleAnalytics_trackingId is defined %}
   googleAnalytics: {
     trackingId: '{{ googleAnalytics_trackingId }}',

--- a/deployment/v3-ubuntu-24.04/ansible/conf/nginx-judgels-http.conf.j2
+++ b/deployment/v3-ubuntu-24.04/ansible/conf/nginx-judgels-http.conf.j2
@@ -1,0 +1,36 @@
+upstream judgels_client {
+    {% for host in groups['core'] %}
+    server {{ host }}:5000;
+    {% endfor %}
+}
+
+upstream judgels_server_api {
+    {% for host in groups['core'] %}
+    server {{ host }}:9101;
+    {% endfor %}
+}
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    server_name _;
+
+    location /api/ {
+        include proxy_params;
+        proxy_pass http://judgels_server_api;
+        proxy_set_header Connection "";
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        client_max_body_size 512M;
+    }
+
+    location / {
+        include proxy_params;
+        proxy_pass http://judgels_client;
+        proxy_set_header Connection "";
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        client_max_body_size 512M;
+    }
+}

--- a/deployment/v3-ubuntu-24.04/ansible/env-example/vars.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/env-example/vars.yml
@@ -1,11 +1,13 @@
 app_version: latest
 
+nginx_certbot_enabled: true
+nginx_certbot_email: admin@judgels.com
+
 nginx_domain_judgels_client: judgels.com
 nginx_domain_judgels_server_api: api.judgels.com
 nginx_domain_judgels_server_admin: admin.judgels.com
 # nginx_domain_judgels_server_admin_auth_basic_user: user # <-- CHANGE THIS !!!
 # nginx_domain_judgels_server_admin_auth_basic_pass: pass # <-- CHANGE THIS !!!
-nginx_certbot_email: admin@judgels.com
 
 # java_opts_judgels_server: -Xmx1g
 # java_opts_judgels_grader: -Xmx1g

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-nginx-http.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy-nginx-http.yml
@@ -1,0 +1,5 @@
+- hosts: core
+  gather_facts: false
+  become: true
+  roles:
+    - name: nginx-http-deploy

--- a/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/playbooks/deploy.yml
@@ -6,7 +6,10 @@
     - name: judgels-server-migrate
     - name: judgels-server-deploy
     - name: judgels-client-deploy
+    - name: nginx-http-deploy
+      when: not (nginx_certbot_enabled | default(true) | bool)
     - name: nginx-certbot-deploy
+      when: nginx_certbot_enabled | default(true) | bool
       vars:
         domains:
           - name: judgels-server-api

--- a/deployment/v3-ubuntu-24.04/ansible/roles/nginx-http-deploy/handlers/main.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/roles/nginx-http-deploy/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Reload nginx
+  service:
+    name: nginx
+    state: reloaded

--- a/deployment/v3-ubuntu-24.04/ansible/roles/nginx-http-deploy/tasks/main.yml
+++ b/deployment/v3-ubuntu-24.04/ansible/roles/nginx-http-deploy/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: Add nginx judgels HTTP config
+  template:
+    src: "{{ playbook_dir }}/../conf/nginx-judgels-http.conf.j2"
+    dest: /etc/nginx/sites-available/judgels-http
+    owner: www-data
+    group: www-data
+    mode: 0644
+  notify: Reload nginx
+
+- name: Enable nginx judgels HTTP config
+  file:
+    src: /etc/nginx/sites-available/judgels-http
+    dest: /etc/nginx/sites-enabled/judgels-http
+    owner: www-data
+    group: www-data
+    state: link
+  notify: Reload nginx
+
+- name: Start nginx
+  service:
+    name: nginx
+    state: started


### PR DESCRIPTION

Adds `nginx_certbot_enabled`, defaulting to `true` so existing deployments are unaffected. When `false`, `deploy.yml` runs the new `nginx-http-deploy` role instead:

- one plain HTTP default server on port 80, proxying `/api` to the judgels server on 9101 and everything else to the client on 5000
- the client's `apiUrl` becomes a relative `/api/v2`

The server block matches any Host and the client has no address baked into it, so one deployed config serves the private IP, a public IP or a domain interchangeably.

Michael is not reachable in this mode for now.

`playbooks/deploy-nginx-http.yml` is included for applying the nginx config alone, matching the existing `deploy-*.yml` playbooks. It is unconditional, unlike the role in `deploy.yml`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)