### PR TITLE
Let app mode set the edition again for v3.0

### DIFF
--- a/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
+++ b/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
@@ -47,11 +47,10 @@ webSecurity:
 judgels:
   baseDataDir: var/data
 
-{% if app_licenseKey is defined %}
   app:
+    mode: {{ app_mode | default('JUDGELS', true) }}
+{% if app_licenseKey is defined %}
     licenseKey: {{ app_licenseKey }}
-{% else %}
-  app: {}
 {% endif %}
 
 {% if rabbitmq_username is defined %}
@@ -122,7 +121,7 @@ judgels:
   superadmin:
     initialPassword: {{ superadmin_initialPassword }}
 
-{% if app_licenseKey is defined %}
+{% if app_mode | default('JUDGELS', true) == 'TLX' or app_licenseKey is defined %}
 training:
 {% if training_aws_accessKey is defined %}
   aws:

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsApp.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsApp.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 public class JudgelsApp {
     private static final Logger LOGGER = LoggerFactory.getLogger(JudgelsApp.class);
+    private static final String TLX_MODE = "TLX";
     private static final String TLX_HASH = "73d675663861b55f68aef37a9edce4e90392c0a3a11ffed47893d774a6203bf6";
 
     private static JudgelsAppEdition edition = JudgelsAppEdition.FREE;
@@ -38,6 +39,11 @@ public class JudgelsApp {
     }
 
     private static void initializeEdition(JudgelsAppConfiguration config) {
+        if (config.getMode().filter(TLX_MODE::equals).isPresent()) {
+            edition = JudgelsAppEdition.TLX;
+            return;
+        }
+
         if (config.getLicenseKey().isEmpty()) {
             return;
         }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsAppConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsAppConfiguration.java
@@ -7,6 +7,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(as = ImmutableJudgelsAppConfiguration.class)
 public interface JudgelsAppConfiguration {
+    Optional<String> getMode();
     Optional<String> getLicenseKey();
 
     class Builder extends ImmutableJudgelsAppConfiguration.Builder {}

--- a/judgels-backends/judgels-server-app/var/conf/judgels-server.yml.example
+++ b/judgels-backends/judgels-server-app/var/conf/judgels-server.yml.example
@@ -47,7 +47,7 @@ judgels:
   baseDataDir: var/data
 
   app:
-    name: Judgels
+    mode: JUDGELS
 
 #  rabbitmq:
 #    host: localhost


### PR DESCRIPTION
The license key is currently the only way to enable the TLX edition on the server, while the frontend has always read the same thing from `app_mode`. This temporarily brings back app mode: `judgels.app.mode: TLX` sets the edition, so one ansible var (`app_mode`) drives both sides again.

Nothing is removed — the license key path still works, so dropping the mode branch later restores license-key-only behavior.

## Changes

- **`JudgelsAppConfiguration`**: add `mode`, keeping `licenseKey`.
- **`JudgelsApp`**: edition is TLX when mode is TLX, otherwise fall through to the existing license key hash check.
- **v3 ansible template**: always emit the `app` block with `mode: {{ app_mode | default('JUDGELS', true) }}`, appending `licenseKey` when defined. This also removes the `app: {}` empty-block branch from #977/#979. The TLX-only `training` block is gated on either marker.
- **Example config**: it still carried the `app.name` field that was dropped in 924ec48e when Michael moved to the setting store; Dropwizard rejects unknown fields, so the example could not start as written. Replaced with `mode: JUDGELS`.

No frontend changes: `conf.js` and the client ansible template already read `app_mode`.

v2 deployment templates are left untouched — they target older released backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)