### PR TITLE
fix: remove column flex from problemset page header

### DIFF
--- a/judgels-client/src/routes/problems/problemsets/ProblemSetsPage/ProblemSetsPage.jsx
+++ b/judgels-client/src/routes/problems/problemsets/ProblemSetsPage/ProblemSetsPage.jsx
@@ -24,7 +24,7 @@ export default function ProblemSetsPage() {
     return (
       <>
         <Flex justifyContent="end">{renderFilter()}</Flex>
-        {renderFilterResultsBanner()}
+        <div>{renderFilterResultsBanner()}</div>
         <hr />
       </>
     );

--- a/judgels-client/src/routes/problems/problemsets/ProblemSetsPage/ProblemSetsPage.test.jsx
+++ b/judgels-client/src/routes/problems/problemsets/ProblemSetsPage/ProblemSetsPage.test.jsx
@@ -12,13 +12,13 @@ describe('ProblemSetsPage', () => {
     setSession('token', { jid: 'userJid' });
   });
 
-  const renderComponent = async response => {
+  const renderComponent = async (response, initialEntries = ['/']) => {
     nockApi().get('/problemsets').query(true).reply(200, response);
 
     await act(async () =>
       render(
         <QueryClientProviderWrapper>
-          <TestRouter>
+          <TestRouter initialEntries={initialEntries}>
             <ProblemSetsPage />
           </TestRouter>
         </QueryClientProviderWrapper>
@@ -39,6 +39,46 @@ describe('ProblemSetsPage', () => {
 
     expect(await screen.findByText('Problemset One')).toBeInTheDocument();
     expect(screen.getByText(/most recently added problemsets/i)).toBeInTheDocument();
+  });
+
+  test('renders archive filter banner', async () => {
+    await renderComponent(
+      {
+        data: {
+          page: [{ jid: 'JIDPS1', slug: 'ps-1', name: 'Problemset One', archiveJid: 'JIDARC1', description: '' }],
+          totalCount: 1,
+        },
+        archiveName: 'Archive One',
+        archiveDescriptionsMap: {},
+        problemSetProgressesMap: {},
+        profilesMap: {},
+      },
+      ['/problemsets?archive=archive-1']
+    );
+
+    expect(await screen.findByText('Problemset One')).toBeInTheDocument();
+    expect(screen.getByText(/problemsets in archive/i)).toBeInTheDocument();
+    expect(screen.getByText('Archive One')).toBeInTheDocument();
+  });
+
+  test('renders search results banner', async () => {
+    await renderComponent(
+      {
+        data: {
+          page: [{ jid: 'JIDPS1', slug: 'ps-1', name: 'Problemset One', archiveJid: 'JIDARC1', description: '' }],
+          totalCount: 1,
+        },
+        archiveName: 'Archive One',
+        archiveDescriptionsMap: {},
+        problemSetProgressesMap: {},
+        profilesMap: {},
+      },
+      ['/problemsets?name=foo&archive=archive-1']
+    );
+
+    expect(await screen.findByText('Problemset One')).toBeInTheDocument();
+    expect(screen.getByText(/search results for:/i)).toBeInTheDocument();
+    expect(screen.getByText('foo')).toBeInTheDocument();
   });
 
   test('renders empty placeholder', async () => {


### PR DESCRIPTION
## Current Issue

<img width="1343" height="204" alt="gambar" src="https://github.com/user-attachments/assets/ccf5bd5d-0b25-4119-b7d0-099f40323f72" />

## Expected behavior

The text should not be in the flex