### PR TITLE
Create initial curriculum automatically on startup in TLX mode

### DIFF
--- a/judgels-backends/judgels-server-app/src/integTest/java/tlx/curriculum/CurriculumCreatorIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/tlx/curriculum/CurriculumCreatorIntegrationTests.java
@@ -1,0 +1,42 @@
+package tlx.curriculum;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import judgels.persistence.hibernate.WithHibernateSession;
+import judgels.persistence.model.CurriculumModel;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tlx.api.curriculum.Curriculum;
+import tlx.training.BaseTrainingIntegrationTests;
+import tlx.training.TrainingIntegrationTestComponent;
+
+@WithHibernateSession(models = {CurriculumModel.class})
+public class CurriculumCreatorIntegrationTests extends BaseTrainingIntegrationTests {
+    private CurriculumStore curriculumStore;
+    private CurriculumCreator curriculumCreator;
+
+    @BeforeEach
+    void setUpSession(SessionFactory sessionFactory) {
+        TrainingIntegrationTestComponent component = createComponent(sessionFactory);
+        curriculumStore = component.curriculumStore();
+        curriculumCreator = new CurriculumCreator(curriculumStore);
+    }
+
+    @Test
+    void ensure_curriculum_exists() {
+        // initially, there is no curriculum
+        assertThat(curriculumStore.getCurriculum()).isEmpty();
+
+        curriculumCreator.ensureCurriculumExists();
+
+        // now, a curriculum exists
+        Curriculum curriculum = curriculumStore.getCurriculum().get();
+        assertThat(curriculum.getName()).isEqualTo("Curriculum");
+
+        curriculumCreator.ensureCurriculumExists();
+
+        // no new curriculum is created
+        assertThat(curriculumStore.getCurriculums()).hasSize(1);
+    }
+}

--- a/judgels-backends/judgels-server-app/src/integTest/java/tlx/training/TrainingIntegrationTestComponent.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/tlx/training/TrainingIntegrationTestComponent.java
@@ -11,6 +11,7 @@ import tlx.chapter.ChapterStore;
 import tlx.chapter.problem.ChapterProblemStore;
 import tlx.course.CourseStore;
 import tlx.course.chapter.CourseChapterStore;
+import tlx.curriculum.CurriculumStore;
 import tlx.problemset.ProblemSetStore;
 import tlx.problemset.problem.ProblemSetProblemStore;
 import tlx.stats.StatsStore;
@@ -24,6 +25,7 @@ import tlx.training.submission.bundle.TrainingItemSubmissionModule;
         TrainingItemSubmissionModule.class})
 @TlxScope
 public interface TrainingIntegrationTestComponent {
+    CurriculumStore curriculumStore();
     CourseStore courseStore();
     CourseChapterStore courseChapterStore();
     ChapterStore chapterStore();

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/JudgelsServerApplication.java
@@ -207,6 +207,8 @@ public class JudgelsServerApplication extends Application<JudgelsServerApplicati
                 trainingSubmissionModule,
                 new TrainingItemSubmissionModule(trainingConfig.getStatsConfig()));
 
+        component.curriculumCreator().ensureCurriculumExists();
+
         env.jersey().register(component.sessionResource());
         env.jersey().register(component.userAccountResource());
         env.jersey().register(component.userRegistrationWebResource());

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/TlxServerComponent.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/TlxServerComponent.java
@@ -2,6 +2,7 @@ package tlx;
 
 import dagger.Subcomponent;
 import judgels.submission.programming.GradingResponsePoller;
+import tlx.curriculum.CurriculumModule;
 import tlx.mailer.MailerModule;
 import tlx.recaptcha.RecaptchaModule;
 import tlx.tasks.TlxTaskModule;
@@ -16,6 +17,7 @@ import tlx.user.registration.UserRegistrationModule;
         RecaptchaModule.class,
         UserRegistrationModule.class,
         UserResetPasswordModule.class,
+        CurriculumModule.class,
         TrainingSubmissionModule.class,
         TrainingItemSubmissionModule.class,
         TlxTaskModule.class})
@@ -37,6 +39,7 @@ public interface TlxServerComponent {
     tlx.user.registration.web.UserRegistrationWebResource userRegistrationWebResource();
     tlx.user.rating.UserRatingResource userRatingResource();
     tlx.contest.rating.ContestRatingResource contestRatingResource();
+    tlx.curriculum.CurriculumCreator curriculumCreator();
     tlx.curriculum.CurriculumResource curriculumResource();
     tlx.archive.ArchiveResource archiveResource();
     tlx.course.CourseResource courseResource();

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumCreator.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumCreator.java
@@ -1,0 +1,24 @@
+package tlx.curriculum;
+
+import io.dropwizard.hibernate.UnitOfWork;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CurriculumCreator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CurriculumCreator.class);
+
+    private final CurriculumStore curriculumStore;
+
+    public CurriculumCreator(CurriculumStore curriculumStore) {
+        this.curriculumStore = curriculumStore;
+    }
+
+    @UnitOfWork
+    public void ensureCurriculumExists() {
+        if (curriculumStore.getCurriculum().isPresent()) {
+            return;
+        }
+        curriculumStore.createCurriculum("Curriculum", "<p>Curriculum description</p>");
+        LOGGER.info("Created initial curriculum");
+    }
+}

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumModule.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumModule.java
@@ -1,0 +1,20 @@
+package tlx.curriculum;
+
+import dagger.Module;
+import dagger.Provides;
+import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
+import tlx.TlxScope;
+
+@Module
+public class CurriculumModule {
+    @Provides
+    @TlxScope
+    CurriculumCreator curriculumCreator(
+            UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory,
+            CurriculumStore curriculumStore) {
+        return unitOfWorkAwareProxyFactory.create(
+                CurriculumCreator.class,
+                new Class<?>[]{CurriculumStore.class},
+                new Object[]{curriculumStore});
+    }
+}

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumStore.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumStore.java
@@ -33,6 +33,13 @@ public class CurriculumStore {
                 CurriculumStore::fromModel);
     }
 
+    public Curriculum createCurriculum(String name, String description) {
+        CurriculumModel model = new CurriculumModel();
+        model.name = name;
+        model.description = description;
+        return fromModel(curriculumDao.insert(model));
+    }
+
     private static Curriculum fromModel(CurriculumModel m) {
         return new Curriculum.Builder()
                 .name(m.name)


### PR DESCRIPTION
In TLX mode, courses require a curriculum to exist, but there was no way to create one other than inserting a row into the database manually.

This adds a `CurriculumCreator`, modeled on the existing `SuperadminCreator` / `SettingCreator`, which creates an initial curriculum on startup if none exists. It runs only in TLX mode, from `runTlxServer()`.

The created curriculum uses placeholder name and description, which admins can then edit in the database (there is still no API to update a curriculum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)