### PR TITLE
Redirect to detail page after creating course/chapter/archive/problemset

### DIFF
--- a/judgels-client/src/routes/admin/archives/ArchiveCreateDialog/ArchiveCreateDialog.jsx
+++ b/judgels-client/src/routes/admin/archives/ArchiveCreateDialog/ArchiveCreateDialog.jsx
@@ -1,6 +1,7 @@
 import { Button, Classes, Dialog, Intent } from '@blueprintjs/core';
 import { Plus } from '@blueprintjs/icons';
 import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 import { createArchiveMutationOptions } from '../../../../modules/queries/archive';
@@ -9,6 +10,7 @@ import ArchiveCreateForm from '../ArchiveCreateForm/ArchiveCreateForm';
 import * as toastActions from '../../../../modules/toast/toastActions';
 
 export function ArchiveCreateDialog() {
+  const navigate = useNavigate();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const createArchiveMutation = useMutation(createArchiveMutationOptions);
@@ -31,8 +33,9 @@ export function ArchiveCreateDialog() {
 
   const createArchive = async data => {
     await createArchiveMutation.mutateAsync(data, {
-      onSuccess: () => {
+      onSuccess: (_data, { slug }) => {
         setIsDialogOpen(false);
+        navigate({ to: `/admin/archives/${slug}` });
         toastActions.showSuccessToast('Archive created.');
       },
     });

--- a/judgels-client/src/routes/admin/chapters/ChapterCreateDialog/ChapterCreateDialog.jsx
+++ b/judgels-client/src/routes/admin/chapters/ChapterCreateDialog/ChapterCreateDialog.jsx
@@ -1,6 +1,7 @@
 import { Button, Classes, Dialog, Intent } from '@blueprintjs/core';
 import { Plus } from '@blueprintjs/icons';
 import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 import { createChapterMutationOptions } from '../../../../modules/queries/chapter';
@@ -9,6 +10,7 @@ import ChapterCreateForm from '../ChapterCreateForm/ChapterCreateForm';
 import * as toastActions from '../../../../modules/toast/toastActions';
 
 export function ChapterCreateDialog() {
+  const navigate = useNavigate();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const createChapterMutation = useMutation(createChapterMutationOptions);
@@ -31,8 +33,9 @@ export function ChapterCreateDialog() {
 
   const createChapter = async data => {
     await createChapterMutation.mutateAsync(data, {
-      onSuccess: () => {
+      onSuccess: chapter => {
         setIsDialogOpen(false);
+        navigate({ to: `/admin/chapters/${chapter.jid}` });
         toastActions.showSuccessToast('Chapter created.');
       },
     });

--- a/judgels-client/src/routes/admin/chapters/ChapterCreateDialog/ChapterCreateDialog.test.jsx
+++ b/judgels-client/src/routes/admin/chapters/ChapterCreateDialog/ChapterCreateDialog.test.jsx
@@ -32,7 +32,7 @@ describe('ChapterCreateDialog', () => {
     const name = screen.getByRole('textbox');
     await user.type(name, 'New Chapter');
 
-    nockApi().post('/chapters', { name: 'New Chapter' }).reply(200);
+    nockApi().post('/chapters', { name: 'New Chapter' }).reply(200, { jid: 'chapterJid', name: 'New Chapter' });
 
     const submitButton = screen.getByRole('button', { name: /create/i });
     await user.click(submitButton);

--- a/judgels-client/src/routes/admin/courses/CourseCreateDialog/CourseCreateDialog.jsx
+++ b/judgels-client/src/routes/admin/courses/CourseCreateDialog/CourseCreateDialog.jsx
@@ -1,6 +1,7 @@
 import { Button, Classes, Dialog, Intent } from '@blueprintjs/core';
 import { Plus } from '@blueprintjs/icons';
 import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 import { createCourseMutationOptions } from '../../../../modules/queries/course';
@@ -9,6 +10,7 @@ import CourseCreateForm from '../CourseCreateForm/CourseCreateForm';
 import * as toastActions from '../../../../modules/toast/toastActions';
 
 export function CourseCreateDialog() {
+  const navigate = useNavigate();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const createCourseMutation = useMutation(createCourseMutationOptions);
@@ -31,8 +33,9 @@ export function CourseCreateDialog() {
 
   const createCourse = async data => {
     await createCourseMutation.mutateAsync(data, {
-      onSuccess: () => {
+      onSuccess: (_data, { slug }) => {
         setIsDialogOpen(false);
+        navigate({ to: `/admin/courses/${slug}` });
         toastActions.showSuccessToast('Course created.');
       },
     });

--- a/judgels-client/src/routes/admin/problemsets/ProblemSetCreateDialog/ProblemSetCreateDialog.jsx
+++ b/judgels-client/src/routes/admin/problemsets/ProblemSetCreateDialog/ProblemSetCreateDialog.jsx
@@ -1,6 +1,7 @@
 import { Button, Classes, Dialog, Intent } from '@blueprintjs/core';
 import { Plus } from '@blueprintjs/icons';
 import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 import { createProblemSetMutationOptions } from '../../../../modules/queries/problemSet';
@@ -9,6 +10,7 @@ import ProblemSetCreateForm from '../ProblemSetCreateForm/ProblemSetCreateForm';
 import * as toastActions from '../../../../modules/toast/toastActions';
 
 export function ProblemSetCreateDialog() {
+  const navigate = useNavigate();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const createProblemSetMutation = useMutation(createProblemSetMutationOptions);
@@ -39,8 +41,9 @@ export function ProblemSetCreateDialog() {
         contestTime: new Date(data.contestTime).getTime(),
       },
       {
-        onSuccess: () => {
+        onSuccess: (_data, { slug }) => {
           setIsDialogOpen(false);
+          navigate({ to: `/admin/problemsets/${slug}` });
           toastActions.showSuccessToast('Problemset created.');
         },
       }


### PR DESCRIPTION
Previously, creating a course, chapter, archive, or problemset from the admin pages only closed the dialog and showed a toast, leaving the user on the list page.

Now each of these redirects to the newly created entity's detail page, matching the existing behavior of `ContestCreateDialog`:

- Course -> `/admin/courses/{slug}`
- Archive -> `/admin/archives/{slug}`
- Problemset -> `/admin/problemsets/{slug}`
- Chapter -> `/admin/chapters/{jid}` (the chapter route is keyed by JID, so this uses the JID from the create response)