### PR TITLE
Add Curriculum admin page

### DIFF
--- a/judgels-backends/judgels-server-api/src/main/java/tlx/api/curriculum/CurriculumUpdateData.java
+++ b/judgels-backends/judgels-server-api/src/main/java/tlx/api/curriculum/CurriculumUpdateData.java
@@ -5,11 +5,10 @@ import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonDeserialize(as = ImmutableCurriculum.class)
-public interface Curriculum {
-    String getJid();
-    String getName();
+@JsonDeserialize(as = ImmutableCurriculumUpdateData.class)
+public interface CurriculumUpdateData {
+    Optional<String> getName();
     Optional<String> getDescription();
 
-    class Builder extends ImmutableCurriculum.Builder {}
+    class Builder extends ImmutableCurriculumUpdateData.Builder {}
 }

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumResource.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumResource.java
@@ -1,16 +1,30 @@
 package tlx.curriculum;
 
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static judgels.service.ServiceUtils.checkAllowed;
+import static judgels.service.ServiceUtils.checkFound;
 
 import io.dropwizard.hibernate.UnitOfWork;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import judgels.service.actor.ActorChecker;
+import judgels.service.api.actor.AuthHeader;
+import tlx.api.curriculum.Curriculum;
+import tlx.api.curriculum.CurriculumUpdateData;
 import tlx.api.curriculum.CurriculumsResponse;
+import tlx.role.TrainingAdminRoleChecker;
 
 @Path("/api/v2/curriculums")
 public class CurriculumResource {
+    @Inject protected ActorChecker actorChecker;
+    @Inject protected TrainingAdminRoleChecker roleChecker;
     @Inject protected CurriculumStore curriculumStore;
 
     @Inject public CurriculumResource() {}
@@ -22,5 +36,22 @@ public class CurriculumResource {
         return new CurriculumsResponse.Builder()
                 .data(curriculumStore.getCurriculums())
                 .build();
+    }
+
+    @POST
+    @Path("/{curriculumJid}")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @UnitOfWork
+    public Curriculum updateCurriculum(
+            @HeaderParam(AUTHORIZATION) AuthHeader authHeader,
+            @PathParam("curriculumJid") String curriculumJid,
+            CurriculumUpdateData data) {
+
+        String actorJid = actorChecker.check(authHeader);
+        checkFound(curriculumStore.getCurriculumByJid(curriculumJid));
+        checkAllowed(roleChecker.isAdmin(actorJid));
+
+        return curriculumStore.updateCurriculum(curriculumJid, data);
     }
 }

--- a/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumStore.java
+++ b/judgels-backends/judgels-server-app/src/main/java/tlx/curriculum/CurriculumStore.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import judgels.persistence.dao.CurriculumDao;
 import judgels.persistence.model.CurriculumModel;
 import tlx.api.curriculum.Curriculum;
+import tlx.api.curriculum.CurriculumUpdateData;
 
 public class CurriculumStore {
     private final CurriculumDao curriculumDao;
@@ -33,6 +34,10 @@ public class CurriculumStore {
                 CurriculumStore::fromModel);
     }
 
+    public Optional<Curriculum> getCurriculumByJid(String curriculumJid) {
+        return curriculumDao.selectByJid(curriculumJid).map(CurriculumStore::fromModel);
+    }
+
     public Curriculum createCurriculum(String name, String description) {
         CurriculumModel model = new CurriculumModel();
         model.name = name;
@@ -40,8 +45,16 @@ public class CurriculumStore {
         return fromModel(curriculumDao.insert(model));
     }
 
+    public Curriculum updateCurriculum(String curriculumJid, CurriculumUpdateData data) {
+        CurriculumModel model = curriculumDao.findByJid(curriculumJid);
+        data.getName().ifPresent(name -> model.name = name);
+        data.getDescription().ifPresent(description -> model.description = description);
+        return fromModel(curriculumDao.update(model));
+    }
+
     private static Curriculum fromModel(CurriculumModel m) {
         return new Curriculum.Builder()
+                .jid(m.jid)
                 .name(m.name)
                 .description(m.description)
                 .build();

--- a/judgels-client/src/modules/api/curriculum.js
+++ b/judgels-client/src/modules/api/curriculum.js
@@ -1,0 +1,18 @@
+import { APP_CONFIG } from '../../conf';
+import { get, post } from './http';
+
+export const baseCurriculumsURL = `${APP_CONFIG.apiUrl}/curriculums`;
+
+export function baseCurriculumURL(curriculumJid) {
+  return `${baseCurriculumsURL}/${curriculumJid}`;
+}
+
+export const curriculumAPI = {
+  updateCurriculum: (token, curriculumJid, data) => {
+    return post(`${baseCurriculumURL(curriculumJid)}`, token, data);
+  },
+
+  getCurriculums: token => {
+    return get(baseCurriculumsURL, token);
+  },
+};

--- a/judgels-client/src/modules/queries/curriculum.js
+++ b/judgels-client/src/modules/queries/curriculum.js
@@ -1,0 +1,28 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { curriculumAPI } from '../api/curriculum';
+import { queryClient } from '../queryClient';
+import { getToken } from '../session';
+
+export const curriculumsQueryOptions = () =>
+  queryOptions({
+    queryKey: ['curriculums'],
+    queryFn: () => curriculumAPI.getCurriculums(getToken()),
+  });
+
+export const curriculumByJidQueryOptions = curriculumJid =>
+  queryOptions({
+    queryKey: ['curriculum-by-jid', curriculumJid],
+    queryFn: async () => {
+      const response = await curriculumAPI.getCurriculums(getToken());
+      return response.data.find(c => c.jid === curriculumJid);
+    },
+  });
+
+export const updateCurriculumMutationOptions = curriculumJid => ({
+  mutationFn: data => curriculumAPI.updateCurriculum(getToken(), curriculumJid, data),
+  onSuccess: () => {
+    queryClient.invalidateQueries(curriculumsQueryOptions());
+    queryClient.invalidateQueries({ queryKey: ['curriculum-by-jid'] });
+  },
+});

--- a/judgels-client/src/routes/admin/AdminLayout.jsx
+++ b/judgels-client/src/routes/admin/AdminLayout.jsx
@@ -2,6 +2,7 @@ import {
   Box,
   Cog,
   Console,
+  Learning,
   PanelStats,
   People,
   PredictiveAnalysis,
@@ -72,6 +73,11 @@ export default function AdminLayout() {
       title: 'Training',
       visible: isTrainingAdmin,
       children: [
+        {
+          path: 'curriculums',
+          titleIcon: <Learning />,
+          title: 'Curriculum',
+        },
         {
           path: 'courses',
           titleIcon: <PredictiveAnalysis />,

--- a/judgels-client/src/routes/admin/curriculums/CurriculumGeneralEditForm/CurriculumGeneralEditForm.jsx
+++ b/judgels-client/src/routes/admin/curriculums/CurriculumGeneralEditForm/CurriculumGeneralEditForm.jsx
@@ -1,0 +1,48 @@
+import { Button, HTMLTable, Intent } from '@blueprintjs/core';
+import { Flex } from '@blueprintjs/labs';
+import { Field, Form } from 'react-final-form';
+
+import { ActionButtons } from '../../../../components/ActionButtons/ActionButtons';
+import { FormTableRichTextArea } from '../../../../components/forms/FormTableRichTextArea/FormTableRichTextArea';
+import { FormTableTextInput } from '../../../../components/forms/FormTableTextInput/FormTableTextInput';
+import { Required } from '../../../../components/forms/validations';
+import { withSubmissionError } from '../../../../modules/form/submissionError';
+
+const keyStyles = { width: '250px' };
+
+const nameField = {
+  keyStyles,
+  name: 'name',
+  label: 'Name',
+  validate: Required,
+};
+
+const descriptionField = {
+  keyStyles,
+  name: 'description',
+  label: 'Description',
+  rows: 15,
+};
+
+export default function CurriculumGeneralEditForm({ onSubmit, initialValues, onCancel }) {
+  return (
+    <Form onSubmit={withSubmissionError(onSubmit)} initialValues={initialValues}>
+      {({ handleSubmit, submitting }) => (
+        <Flex asChild flexDirection="column" gap={2}>
+          <form onSubmit={handleSubmit}>
+            <HTMLTable striped>
+              <tbody>
+                <Field component={FormTableTextInput} {...nameField} />
+                <Field component={FormTableRichTextArea} {...descriptionField} />
+              </tbody>
+            </HTMLTable>
+            <ActionButtons justifyContent="end">
+              <Button text="Cancel" disabled={submitting} onClick={onCancel} />
+              <Button type="submit" text="Save" intent={Intent.PRIMARY} loading={submitting} />
+            </ActionButtons>
+          </form>
+        </Flex>
+      )}
+    </Form>
+  );
+}

--- a/judgels-client/src/routes/admin/curriculums/CurriculumGeneralSection/CurriculumGeneralSection.jsx
+++ b/judgels-client/src/routes/admin/curriculums/CurriculumGeneralSection/CurriculumGeneralSection.jsx
@@ -1,0 +1,70 @@
+import { Button, Intent } from '@blueprintjs/core';
+import { Edit } from '@blueprintjs/icons';
+import { Flex } from '@blueprintjs/labs';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { FormTable } from '../../../../components/forms/FormTable/FormTable';
+import { updateCurriculumMutationOptions } from '../../../../modules/queries/curriculum';
+import CurriculumGeneralEditForm from '../CurriculumGeneralEditForm/CurriculumGeneralEditForm';
+
+import * as toastActions from '../../../../modules/toast/toastActions';
+
+export function CurriculumGeneralSection({ curriculum }) {
+  const updateCurriculumMutation = useMutation(updateCurriculumMutationOptions(curriculum.jid));
+
+  const [isEditing, setIsEditing] = useState(false);
+
+  const keyStyles = { width: '250px' };
+
+  const rows = [
+    { key: 'name', title: 'Name', value: curriculum.name },
+    { key: 'description', title: 'Description', value: curriculum.description },
+  ];
+
+  const updateCurriculum = async data => {
+    await updateCurriculumMutation.mutateAsync(data, {
+      onSuccess: () => toastActions.showSuccessToast('Curriculum updated.'),
+    });
+    setIsEditing(false);
+  };
+
+  const renderEditButton = () => {
+    return (
+      !isEditing && (
+        <Button small intent={Intent.PRIMARY} icon={<Edit />} onClick={() => setIsEditing(true)}>
+          Edit
+        </Button>
+      )
+    );
+  };
+
+  const renderContent = () => {
+    if (isEditing) {
+      const initialValues = {
+        name: curriculum.name || '',
+        description: curriculum.description || '',
+      };
+      return (
+        <CurriculumGeneralEditForm
+          initialValues={initialValues}
+          onSubmit={updateCurriculum}
+          onCancel={() => setIsEditing(false)}
+        />
+      );
+    }
+    return <FormTable keyStyles={keyStyles} rows={rows} />;
+  };
+
+  return (
+    <div>
+      <Flex asChild justifyContent="space-between" alignItems="baseline">
+        <h4>
+          <span>General</span>
+          {renderEditButton()}
+        </h4>
+      </Flex>
+      {renderContent()}
+    </div>
+  );
+}

--- a/judgels-client/src/routes/admin/curriculums/CurriculumPage/CurriculumPage.jsx
+++ b/judgels-client/src/routes/admin/curriculums/CurriculumPage/CurriculumPage.jsx
@@ -1,0 +1,18 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+
+import { ContentCard } from '../../../../components/ContentCard/ContentCard';
+import { curriculumByJidQueryOptions } from '../../../../modules/queries/curriculum';
+import { CurriculumGeneralSection } from '../CurriculumGeneralSection/CurriculumGeneralSection';
+
+export default function CurriculumPage() {
+  const { curriculumJid } = useParams({ strict: false });
+
+  const { data: curriculum } = useSuspenseQuery(curriculumByJidQueryOptions(curriculumJid));
+
+  return (
+    <ContentCard title={`Curriculum › ${curriculum.name}`}>
+      <CurriculumGeneralSection curriculum={curriculum} />
+    </ContentCard>
+  );
+}

--- a/judgels-client/src/routes/admin/curriculums/CurriculumPage/CurriculumPage.test.jsx
+++ b/judgels-client/src/routes/admin/curriculums/CurriculumPage/CurriculumPage.test.jsx
@@ -1,0 +1,81 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockApi } from '../../../../utils/nock';
+import CurriculumPage from './CurriculumPage';
+
+describe('CurriculumPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async () => {
+    nockApi()
+      .get('/curriculums')
+      .reply(200, { data: [{ jid: 'JIDCURRICULUM1', name: 'Curriculum 1', description: 'Description 1' }] });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter initialEntries={['/admin/curriculums/JIDCURRICULUM1']} path="/admin/curriculums/$curriculumJid">
+            <CurriculumPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('details', async () => {
+    await renderComponent();
+
+    await screen.findAllByText(/Curriculum 1/);
+
+    const table = screen.getByRole('table');
+
+    expect(
+      within(table)
+        .getAllByRole('row')
+        .map(row =>
+          within(row)
+            .getAllByRole('cell')
+            .map(cell => cell.textContent)
+        )
+    ).toEqual([
+      ['Name', 'Curriculum 1'],
+      ['Description', 'Description 1'],
+    ]);
+  });
+
+  test('general form', async () => {
+    await renderComponent();
+
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: /edit/i }));
+
+    const name = screen.getByRole('textbox', { name: /^name/i });
+    expect(name).toHaveValue('Curriculum 1');
+    await user.clear(name);
+    await user.type(name, 'New Curriculum');
+
+    const description = document.querySelector('textarea[name="description"]');
+    expect(description).toHaveValue('Description 1');
+    await user.clear(description);
+    await user.type(description, 'New Description');
+
+    nockApi()
+      .post('/curriculums/JIDCURRICULUM1', {
+        name: 'New Curriculum',
+        description: 'New Description',
+      })
+      .reply(200);
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(nock.isDone()).toBe(true));
+  });
+});

--- a/judgels-client/src/routes/admin/curriculums/CurriculumsPage/CurriculumsPage.jsx
+++ b/judgels-client/src/routes/admin/curriculums/CurriculumsPage/CurriculumsPage.jsx
@@ -1,0 +1,47 @@
+import { HTMLTable } from '@blueprintjs/core';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+
+import { ContentCard } from '../../../../components/ContentCard/ContentCard';
+import { LoadingContentCard } from '../../../../components/LoadingContentCard/LoadingContentCard';
+import { curriculumsQueryOptions } from '../../../../modules/queries/curriculum';
+
+export default function CurriculumsPage() {
+  const { data: response } = useQuery(curriculumsQueryOptions());
+
+  const renderCurriculums = () => {
+    if (!response) {
+      return <LoadingContentCard />;
+    }
+
+    const { data: curriculums } = response;
+    if (curriculums.length === 0) {
+      return (
+        <p>
+          <small>No curriculums.</small>
+        </p>
+      );
+    }
+
+    const rows = curriculums.map(curriculum => (
+      <tr key={curriculum.jid}>
+        <td>
+          <Link to={`/admin/curriculums/${curriculum.jid}`}>{curriculum.name}</Link>
+        </td>
+      </tr>
+    ));
+
+    return (
+      <HTMLTable striped className="table-list-condensed">
+        <thead>
+          <tr>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </HTMLTable>
+    );
+  };
+
+  return <ContentCard title="Curriculum">{renderCurriculums()}</ContentCard>;
+}

--- a/judgels-client/src/routes/admin/curriculums/CurriculumsPage/CurriculumsPage.test.jsx
+++ b/judgels-client/src/routes/admin/curriculums/CurriculumsPage/CurriculumsPage.test.jsx
@@ -1,0 +1,50 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+
+import { setSession } from '../../../../modules/session';
+import { QueryClientProviderWrapper } from '../../../../test/QueryClientProviderWrapper';
+import { TestRouter } from '../../../../test/RouterWrapper';
+import { nockApi } from '../../../../utils/nock';
+import CurriculumsPage from './CurriculumsPage';
+
+describe('CurriculumsPage', () => {
+  beforeEach(() => {
+    setSession('token', { jid: 'userJid' });
+  });
+
+  const renderComponent = async ({
+    curriculums = [{ jid: 'JIDCURRICULUM1', name: 'Curriculum 1', description: 'Description 1' }],
+  } = {}) => {
+    nockApi().get('/curriculums').reply(200, { data: curriculums });
+
+    await act(async () =>
+      render(
+        <QueryClientProviderWrapper>
+          <TestRouter initialEntries={['/admin/curriculums']}>
+            <CurriculumsPage />
+          </TestRouter>
+        </QueryClientProviderWrapper>
+      )
+    );
+  };
+
+  test('renders placeholder when there are no curriculums', async () => {
+    await renderComponent({ curriculums: [] });
+    expect(await screen.findByText(/no curriculums/i)).toBeInTheDocument();
+  });
+
+  test('renders the curriculums table', async () => {
+    await renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('row').length).toBeGreaterThan(1);
+    });
+    const rows = screen.getAllByRole('row');
+    expect(
+      rows.map(row =>
+        within(row)
+          .queryAllByRole('cell')
+          .map(cell => cell.textContent)
+      )
+    ).toEqual([[], ['Curriculum 1']]);
+  });
+});

--- a/judgels-client/src/routes/admin/routes.jsx
+++ b/judgels-client/src/routes/admin/routes.jsx
@@ -8,6 +8,7 @@ import { chapterLessonsQueryOptions } from '../../modules/queries/chapterLesson'
 import { chapterProblemsQueryOptions } from '../../modules/queries/chapterProblem';
 import { courseBySlugQueryOptions } from '../../modules/queries/course';
 import { courseChaptersQueryOptions } from '../../modules/queries/courseChapter';
+import { curriculumByJidQueryOptions } from '../../modules/queries/curriculum';
 import { problemSetBySlugQueryOptions } from '../../modules/queries/problemSet';
 import { problemSetProblemsQueryOptions } from '../../modules/queries/problemSetProblem';
 import { userByUsernameQueryOptions } from '../../modules/queries/user';
@@ -61,6 +62,21 @@ export const createAdminRoutes = appRoute => {
     getParentRoute: () => adminRoute,
     path: 'contests',
     component: lazyRouteComponent(retryImport(() => import('./contests/ContestsPage/ContestsPage'))),
+  });
+
+  const adminCurriculumsRoute = createRoute({
+    getParentRoute: () => adminRoute,
+    path: 'curriculums',
+    component: lazyRouteComponent(retryImport(() => import('./curriculums/CurriculumsPage/CurriculumsPage'))),
+  });
+
+  const adminCurriculumRoute = createRoute({
+    getParentRoute: () => adminRoute,
+    path: 'curriculums/$curriculumJid',
+    component: lazyRouteComponent(retryImport(() => import('./curriculums/CurriculumPage/CurriculumPage'))),
+    loader: async ({ params: { curriculumJid } }) => {
+      await queryClient.ensureQueryData(curriculumByJidQueryOptions(curriculumJid));
+    },
   });
 
   const adminCoursesRoute = createRoute({
@@ -145,6 +161,8 @@ export const createAdminRoutes = appRoute => {
     adminRolesRoute,
     adminRatingsRoute,
     adminContestsRoute,
+    adminCurriculumsRoute,
+    adminCurriculumRoute,
     adminCoursesRoute,
     adminCourseRoute,
     adminChaptersRoute,


### PR DESCRIPTION
Adds a **Curriculum** entry to the admin sidebar, above Courses, in the Training section. It lists the curriculums and lets an admin edit one. There is no create action, since only a single curriculum is supported.

### Backend
- `Curriculum` now exposes `jid`.
- New `CurriculumUpdateData` (optional `name`, `description`).
- `CurriculumStore`: `getCurriculumByJid()`, `updateCurriculum()`.
- `CurriculumResource`: `POST /api/v2/curriculums/{curriculumJid}`, restricted to training admins.

### Frontend
- `modules/api/curriculum.js` and `modules/queries/curriculum.js`.
- `routes/admin/curriculums/`: `CurriculumsPage` (name list, no create button), `CurriculumPage`, `CurriculumGeneralSection`, `CurriculumGeneralEditForm` (name + rich-text description).
- Routes `admin/curriculums` and `admin/curriculums/$curriculumJid`.

### Testing
- New tests for `CurriculumsPage` and `CurriculumPage` (details + edit-and-save).
- `compileJava`, `compileIntegTestJava`, `checkstyleMain`, and `yarn build` pass. The 2 failing client tests (`ContestFilesPage`, programming `ContestProblemPage`) also fail on a clean `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
