### PR TITLE
Refresh contest web config after updating contest settings

### DIFF
--- a/judgels-client/src/modules/queries/contest.js
+++ b/judgels-client/src/modules/queries/contest.js
@@ -6,6 +6,7 @@ import { BadRequestError, NotFoundError, RemoteError } from '../api/error';
 import { problemSetAPI } from '../api/problemSet';
 import { SubmissionError } from '../form/submissionError';
 import { contestContestantsQueryOptions } from '../queries/contestContestant';
+import { contestWebConfigQueryOptions } from '../queries/contestWeb';
 import { queryClient } from '../queryClient';
 import { getToken } from '../session';
 
@@ -46,6 +47,7 @@ export const updateContestMutationOptions = (contestJid, contestSlug) => ({
   },
   onSuccess: () => {
     queryClient.invalidateQueries(contestBySlugQueryOptions(contestSlug));
+    queryClient.invalidateQueries(contestWebConfigQueryOptions(contestJid));
   },
 });
 

--- a/judgels-client/src/modules/queries/contestModule.js
+++ b/judgels-client/src/modules/queries/contestModule.js
@@ -37,5 +37,6 @@ export const upsertContestModuleConfigMutationOptions = contestJid => ({
   mutationFn: config => contestModuleAPI.upsertConfig(getToken(), contestJid, config),
   onSuccess: () => {
     queryClient.invalidateQueries(contestModuleConfigQueryOptions(contestJid));
+    queryClient.invalidateQueries(contestWebConfigQueryOptions(contestJid));
   },
 });


### PR DESCRIPTION
The contest state widget renders `state` and `remainingStateDuration` from the contest web config (the server derives both from the contest timer), not from the contest object itself.

`updateContestMutationOptions` only invalidated the contest-by-slug query, and `upsertContestModuleConfigMutationOptions` only invalidated the module config query. So after saving a new end time (or a new virtual duration), the state widget kept showing the old state and countdown until the next 20s `refetchInterval` poll.

Invalidate the web config query in both mutations as well, like the module enable/disable mutations already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
