### PR TITLE
Tidy up description fields in training admin screens

### DIFF
--- a/judgels-client/src/routes/admin/archives/ArchiveCreateForm/ArchiveCreateForm.jsx
+++ b/judgels-client/src/routes/admin/archives/ArchiveCreateForm/ArchiveCreateForm.jsx
@@ -1,7 +1,7 @@
 import { Button, Intent } from '@blueprintjs/core';
 import { Field, Form } from 'react-final-form';
 
-import { FormTextArea } from '../../../../components/forms/FormTextArea/FormTextArea';
+import { FormRichTextArea } from '../../../../components/forms/FormRichTextArea/FormRichTextArea';
 import { FormTextInput } from '../../../../components/forms/FormTextInput/FormTextInput';
 import { Required, Slug, composeValidators } from '../../../../components/forms/validations';
 import { withSubmissionError } from '../../../../modules/form/submissionError';
@@ -29,7 +29,7 @@ export default function ArchiveCreateForm({ onSubmit, renderFormComponents }) {
   const descriptionField = {
     name: 'description',
     label: 'Description',
-    rows: 5,
+    rows: 15,
   };
 
   const fields = (
@@ -37,7 +37,7 @@ export default function ArchiveCreateForm({ onSubmit, renderFormComponents }) {
       <Field component={FormTextInput} {...slugField} />
       <Field component={FormTextInput} {...nameField} />
       <Field component={FormTextInput} {...categoryField} />
-      <Field component={FormTextArea} {...descriptionField} />
+      <Field component={FormRichTextArea} {...descriptionField} />
     </>
   );
 

--- a/judgels-client/src/routes/admin/archives/ArchiveGeneralEditForm/ArchiveGeneralEditForm.jsx
+++ b/judgels-client/src/routes/admin/archives/ArchiveGeneralEditForm/ArchiveGeneralEditForm.jsx
@@ -3,7 +3,7 @@ import { Flex } from '@blueprintjs/labs';
 import { Field, Form } from 'react-final-form';
 
 import { ActionButtons } from '../../../../components/ActionButtons/ActionButtons';
-import { FormTableTextArea } from '../../../../components/forms/FormTableTextArea/FormTableTextArea';
+import { FormTableRichTextArea } from '../../../../components/forms/FormTableRichTextArea/FormTableRichTextArea';
 import { FormTableTextInput } from '../../../../components/forms/FormTableTextInput/FormTableTextInput';
 import { Required, Slug, composeValidators } from '../../../../components/forms/validations';
 import { withSubmissionError } from '../../../../modules/form/submissionError';
@@ -35,6 +35,7 @@ const descriptionField = {
   keyStyles,
   name: 'description',
   label: 'Description',
+  rows: 15,
 };
 
 export default function ArchiveGeneralEditForm({ onSubmit, initialValues, onCancel }) {
@@ -48,7 +49,7 @@ export default function ArchiveGeneralEditForm({ onSubmit, initialValues, onCanc
                 <Field component={FormTableTextInput} {...slugField} />
                 <Field component={FormTableTextInput} {...nameField} />
                 <Field component={FormTableTextInput} {...categoryField} />
-                <Field component={FormTableTextArea} {...descriptionField} />
+                <Field component={FormTableRichTextArea} {...descriptionField} />
               </tbody>
             </HTMLTable>
             <ActionButtons justifyContent="end">

--- a/judgels-client/src/routes/admin/archives/ArchiveGeneralSection/ArchiveGeneralSection.jsx
+++ b/judgels-client/src/routes/admin/archives/ArchiveGeneralSection/ArchiveGeneralSection.jsx
@@ -4,6 +4,7 @@ import { Flex } from '@blueprintjs/labs';
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { HtmlText } from '../../../../components/HtmlText/HtmlText';
 import { FormTable } from '../../../../components/forms/FormTable/FormTable';
 import { updateArchiveMutationOptions } from '../../../../modules/queries/archive';
 import ArchiveGeneralEditForm from '../ArchiveGeneralEditForm/ArchiveGeneralEditForm';
@@ -21,7 +22,7 @@ export function ArchiveGeneralSection({ archive }) {
     { key: 'slug', title: 'Slug', value: archive.slug },
     { key: 'name', title: 'Name', value: archive.name },
     { key: 'category', title: 'Category', value: archive.category },
-    { key: 'description', title: 'Description', value: archive.description },
+    { key: 'description', title: 'Description', value: <HtmlText>{archive.description || ''}</HtmlText> },
   ];
 
   const updateArchive = async data => {

--- a/judgels-client/src/routes/admin/courses/CourseCreateForm/CourseCreateForm.jsx
+++ b/judgels-client/src/routes/admin/courses/CourseCreateForm/CourseCreateForm.jsx
@@ -1,7 +1,7 @@
 import { Button, Intent } from '@blueprintjs/core';
 import { Field, Form } from 'react-final-form';
 
-import { FormTextArea } from '../../../../components/forms/FormTextArea/FormTextArea';
+import { FormRichTextArea } from '../../../../components/forms/FormRichTextArea/FormRichTextArea';
 import { FormTextInput } from '../../../../components/forms/FormTextInput/FormTextInput';
 import { Required, Slug, composeValidators } from '../../../../components/forms/validations';
 import { withSubmissionError } from '../../../../modules/form/submissionError';
@@ -23,14 +23,14 @@ export default function CourseCreateForm({ onSubmit, renderFormComponents }) {
   const descriptionField = {
     name: 'description',
     label: 'Description',
-    rows: 5,
+    rows: 15,
   };
 
   const fields = (
     <>
       <Field component={FormTextInput} {...slugField} />
       <Field component={FormTextInput} {...nameField} />
-      <Field component={FormTextArea} {...descriptionField} />
+      <Field component={FormRichTextArea} {...descriptionField} />
     </>
   );
 

--- a/judgels-client/src/routes/admin/courses/CourseGeneralEditForm/CourseGeneralEditForm.jsx
+++ b/judgels-client/src/routes/admin/courses/CourseGeneralEditForm/CourseGeneralEditForm.jsx
@@ -3,7 +3,7 @@ import { Flex } from '@blueprintjs/labs';
 import { Field, Form } from 'react-final-form';
 
 import { ActionButtons } from '../../../../components/ActionButtons/ActionButtons';
-import { FormTableTextArea } from '../../../../components/forms/FormTableTextArea/FormTableTextArea';
+import { FormTableRichTextArea } from '../../../../components/forms/FormTableRichTextArea/FormTableRichTextArea';
 import { FormTableTextInput } from '../../../../components/forms/FormTableTextInput/FormTableTextInput';
 import { Required, Slug, composeValidators } from '../../../../components/forms/validations';
 import { withSubmissionError } from '../../../../modules/form/submissionError';
@@ -26,6 +26,7 @@ const nameField = {
 const descriptionField = {
   name: 'description',
   label: 'Description',
+  rows: 15,
 };
 
 export default function CourseGeneralEditForm({ onSubmit, initialValues, onCancel }) {
@@ -38,7 +39,7 @@ export default function CourseGeneralEditForm({ onSubmit, initialValues, onCance
               <tbody>
                 <Field component={FormTableTextInput} {...slugField} />
                 <Field component={FormTableTextInput} {...nameField} />
-                <Field component={FormTableTextArea} {...descriptionField} />
+                <Field component={FormTableRichTextArea} {...descriptionField} />
               </tbody>
             </HTMLTable>
             <ActionButtons justifyContent="end">

--- a/judgels-client/src/routes/admin/courses/CourseGeneralSection/CourseGeneralSection.jsx
+++ b/judgels-client/src/routes/admin/courses/CourseGeneralSection/CourseGeneralSection.jsx
@@ -4,6 +4,7 @@ import { Flex } from '@blueprintjs/labs';
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { HtmlText } from '../../../../components/HtmlText/HtmlText';
 import { FormTable } from '../../../../components/forms/FormTable/FormTable';
 import { updateCourseMutationOptions } from '../../../../modules/queries/course';
 import CourseGeneralEditForm from '../CourseGeneralEditForm/CourseGeneralEditForm';
@@ -20,7 +21,7 @@ export function CourseGeneralSection({ course }) {
   const rows = [
     { key: 'slug', title: 'Slug', value: course.slug },
     { key: 'name', title: 'Name', value: course.name },
-    { key: 'description', title: 'Description', value: course.description },
+    { key: 'description', title: 'Description', value: <HtmlText>{course.description || ''}</HtmlText> },
   ];
 
   const updateCourse = async data => {

--- a/judgels-client/src/routes/admin/curriculums/CurriculumGeneralEditForm/CurriculumGeneralEditForm.jsx
+++ b/judgels-client/src/routes/admin/curriculums/CurriculumGeneralEditForm/CurriculumGeneralEditForm.jsx
@@ -3,7 +3,7 @@ import { Flex } from '@blueprintjs/labs';
 import { Field, Form } from 'react-final-form';
 
 import { ActionButtons } from '../../../../components/ActionButtons/ActionButtons';
-import { FormTableRichTextArea } from '../../../../components/forms/FormTableRichTextArea/FormTableRichTextArea';
+import { FormTableTextArea } from '../../../../components/forms/FormTableTextArea/FormTableTextArea';
 import { FormTableTextInput } from '../../../../components/forms/FormTableTextInput/FormTableTextInput';
 import { Required } from '../../../../components/forms/validations';
 import { withSubmissionError } from '../../../../modules/form/submissionError';
@@ -21,7 +21,6 @@ const descriptionField = {
   keyStyles,
   name: 'description',
   label: 'Description',
-  rows: 15,
 };
 
 export default function CurriculumGeneralEditForm({ onSubmit, initialValues, onCancel }) {
@@ -33,7 +32,7 @@ export default function CurriculumGeneralEditForm({ onSubmit, initialValues, onC
             <HTMLTable striped>
               <tbody>
                 <Field component={FormTableTextInput} {...nameField} />
-                <Field component={FormTableRichTextArea} {...descriptionField} />
+                <Field component={FormTableTextArea} {...descriptionField} />
               </tbody>
             </HTMLTable>
             <ActionButtons justifyContent="end">

--- a/judgels-client/src/routes/admin/problemsets/ProblemSetGeneralSection/ProblemSetGeneralSection.jsx
+++ b/judgels-client/src/routes/admin/problemsets/ProblemSetGeneralSection/ProblemSetGeneralSection.jsx
@@ -4,6 +4,7 @@ import { Flex } from '@blueprintjs/labs';
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import { HtmlText } from '../../../../components/HtmlText/HtmlText';
 import { FormTable } from '../../../../components/forms/FormTable/FormTable';
 import { updateProblemSetMutationOptions } from '../../../../modules/queries/problemSet';
 import ProblemSetGeneralEditForm from '../ProblemSetGeneralEditForm/ProblemSetGeneralEditForm';
@@ -22,7 +23,7 @@ export function ProblemSetGeneralSection({ problemSet, archiveSlug }) {
     { key: 'name', title: 'Name', value: problemSet.name },
     { key: 'archiveSlug', title: 'Archive slug', value: archiveSlug },
     { key: 'contestTime', title: 'Contest time', value: new Date(problemSet.contestTime).toISOString() },
-    { key: 'description', title: 'Description', value: problemSet.description },
+    { key: 'description', title: 'Description', value: <HtmlText>{problemSet.description || ''}</HtmlText> },
   ];
 
   const updateProblemSet = async data => {


### PR DESCRIPTION
- **Curriculum**: description is now a plain textarea (was TinyMCE).
- **Course / archive / problemset**: description renders as HTML in the general section, and is edited with TinyMCE in the general edit form. Course and archive create forms also switched to TinyMCE, so descriptions aren't authored as plain text but rendered as HTML. Problemset already did both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
