### PR TITLE
Avoid blank logout page when logout is disabled

### DIFF
--- a/judgels-client/src/components/UserWidget/UserWidget.jsx
+++ b/judgels-client/src/components/UserWidget/UserWidget.jsx
@@ -1,10 +1,11 @@
-import { Alignment, Menu, MenuDivider, Navbar, Popover, Position } from '@blueprintjs/core';
+import { Alignment, Menu, MenuDivider, MenuItem, Navbar, Popover, Position } from '@blueprintjs/core';
 import { ChevronDown, Menu as IconMenu } from '@blueprintjs/icons';
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { Link, useNavigate } from '@tanstack/react-router';
 
 import { isTLX } from '../../conf';
 import { getRatingClass } from '../../modules/api/userRating';
+import { logOutMutationOptions } from '../../modules/queries/session';
 import { avatarUrlQueryOptions } from '../../modules/queries/userAvatar';
 import { userWebConfigQueryOptions } from '../../modules/queries/userWeb';
 import { useSession } from '../../modules/session';
@@ -13,17 +14,23 @@ import MenuItemLink from '../MenuItemLink/MenuItemLink';
 import './UserWidget.scss';
 
 export function UserWidget({ user, profile, items, homeRoute }) {
+  const navigate = useNavigate();
   const { data: avatarUrl } = useQuery({
     ...avatarUrlQueryOptions(user?.jid),
     enabled: !!user,
   });
+  const logOutMutation = useMutation(logOutMutationOptions);
+
+  const logOut = () => {
+    logOutMutation.mutate(undefined, { onSuccess: () => navigate({ to: '/' }) });
+  };
 
   const renderForUser = () => {
     const menuItems = (
       <>
         <MenuItemLink text="My profile" to={`/profiles/${profile.username}`} />
         {isTLX() && <MenuItemLink text="My account" to="/account" />}
-        <MenuItemLink text="Log out" to="/logout" />
+        <MenuItem text="Log out" onClick={logOut} />
       </>
     );
 

--- a/judgels-client/src/components/UserWidget/UserWidget.test.jsx
+++ b/judgels-client/src/components/UserWidget/UserWidget.test.jsx
@@ -1,7 +1,11 @@
-import { act, render } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 
+import { setSession } from '../../modules/session';
 import { QueryClientProviderWrapper } from '../../test/QueryClientProviderWrapper';
 import { TestRouter } from '../../test/RouterWrapper';
+import { nockApi } from '../../utils/nock';
 import { UserWidget } from './UserWidget';
 
 describe('UserWidget', () => {
@@ -36,5 +40,21 @@ describe('UserWidget', () => {
       profile: { username: 'user' },
     });
     expect(container.querySelector('[data-key="username"]')).toBeInTheDocument();
+  });
+
+  test('logs out in place', async () => {
+    setSession('token', { jid: 'jid123' });
+    nockApi().post('/session/logout').reply(200);
+
+    const { container } = await renderComponent({
+      user: { jid: 'jid123', username: 'user', email: 'user@domain.com' },
+      profile: { username: 'user' },
+    });
+
+    const user = userEvent.setup();
+    await user.click(container.querySelector('.widget-user__profile'));
+    await user.click(screen.getByText('Log out'));
+
+    await waitFor(() => expect(nock.isDone()).toBe(true));
   });
 });

--- a/judgels-client/src/routes/account/logout/LogoutPage/LogoutPage.jsx
+++ b/judgels-client/src/routes/account/logout/LogoutPage/LogoutPage.jsx
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { Navigate } from '@tanstack/react-router';
 import { useEffect } from 'react';
 
 import { logOutMutationOptions } from '../../../../modules/queries/session';
@@ -10,5 +11,8 @@ export default function LogoutPage() {
     logOutMutation.mutate();
   }, []);
 
+  if (logOutMutation.isError) {
+    return <Navigate to="/" />;
+  }
   return null;
 }


### PR DESCRIPTION
## Problem

"Log out" in the user menu was a plain link to `/logout`. When logout is disabled (`Disable logout` session setting), the logout request fails only *after* navigating there — and `LogoutPage` renders `null`, so the user is left on a blank, broken page with just the "Logout is currently disabled." toast.

## Fix

- `UserWidget`: "Log out" now runs the logout mutation in place and navigates to `/` only on success. When logout is disabled, the user stays where they are and just sees the error toast.
- `LogoutPage`: for direct visits to `/logout`, an error now redirects home instead of rendering a blank page.
- Added a `UserWidget` test that opens the user menu, clicks "Log out", and asserts the logout API is called.
