### PR TITLE
Fix file upload tests on Node versions shipping undici 7

### DIFF
--- a/judgels-client/src/setupTests.js
+++ b/judgels-client/src/setupTests.js
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import nock from 'nock';
+import { Blob as NodeBlob, File as NodeFile } from 'node:buffer';
 import { TextDecoder, TextEncoder } from 'node:util';
 import { afterEach } from 'vitest';
 import { vi } from 'vitest';
@@ -8,6 +9,12 @@ import { clearSession } from './modules/session';
 
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+global.Blob = NodeBlob;
+global.File = NodeFile;
+global.FormData = (
+  await new Response('', { headers: { 'content-type': 'application/x-www-form-urlencoded' } }).formData()
+).constructor;
 
 nock.disableNetConnect();
 


### PR DESCRIPTION
## Problem

Two frontend tests fail on Node 24 but pass in CI:

- `ContestFilesPage.test.jsx` > `upload form`
- `ContestProblemPage/Programming/ContestProblemPage.test.jsx` > `form`

Both mock a multipart `POST` with a body predicate. The request is sent, but the nock interceptor never matches, so `isDone()` stays `false`. The failures are deterministic, not flaky — reproduced 4/4 runs.

## Cause

jsdom provides its own `Blob`, `File` and `FormData`, but global `fetch` is Node's undici. The two disagree about what a file part is.

undici 7 (Node 24) identifies multipart file parts by its own `Blob`/`File` brand, so a jsdom `File` serializes as an empty part named `blob`:

```
Content-Disposition: form-data; name="file"; filename="blob"
Content-Type: text/plain

                      <- content dropped
```

undici 6 (Node 20/22) duck-typed instead, which is why CI on Node 20 stays green.

Duck typing cannot be satisfied from the outside on undici 7. Adding `arrayBuffer()`, `text()` and `stream()` to jsdom's `Blob.prototype` — jsdom's `File` already carries `Symbol.toStringTag === 'File'` and the correct `name` — still produced `filename="blob"` with body `[object Blob]`. undici needs genuine instances.

## Fix

Source `Blob`, `File` and `FormData` from Node in `setupTests.js`, so they always match the undici that `fetch` consumes. `Blob` and `File` come from `node:buffer`; `FormData` is not exported by any `node:` module, so it is read off an instance.

No new dependency. Sourcing from `node:buffer` rather than an npm `undici` also avoids pinning a second undici copy that could mismatch the built-in one at CI time.

## Verification

| | Node 20.15 (undici 6.13) | Node 22.12 (undici 6.21) | Node 24.15 (undici 7.24) |
| --- | --- | --- | --- |
| Before | n/a | 303 passed | 2 failed / 301 passed |
| After | serialization verified | **303 passed** | **303 passed** |

Serialized part is now correct:

```
Content-Disposition: form-data; name="file"; filename="editorial.txt"
Content-Type: text/plain

content
```

Compared the full JSON test set before and after: identical 303 tests, none added or lost. `yarn lint` clean.

The only jsdom-Blob-identity dependency in `src/` is `createObjectURL` in `modules/api/http.js`, whose blob already comes from native `fetch`, so it is unaffected.