### PR TITLE
Show form field errors only after editing or submitting

### DIFF
--- a/judgels-client/src/components/forms/FormInputValidation/FormInputValidation.test.jsx
+++ b/judgels-client/src/components/forms/FormInputValidation/FormInputValidation.test.jsx
@@ -3,8 +3,14 @@ import { render, screen } from '@testing-library/react';
 import { FormInputValidation } from './FormInputValidation';
 
 describe('FormInputValidation', () => {
-  const renderComponent = ({ touched = false, valid = false, error = 'Required' } = {}) => {
-    render(<FormInputValidation meta={{ touched, valid, error }} />);
+  const renderComponent = ({
+    touched = false,
+    modified = false,
+    submitFailed = false,
+    valid = false,
+    error = 'Required',
+  } = {}) => {
+    render(<FormInputValidation meta={{ touched, modified, submitFailed, valid, error }} />);
   };
 
   test('when first rendered, does not render any errors', () => {
@@ -13,12 +19,22 @@ describe('FormInputValidation', () => {
   });
 
   test('when valid, does not render any errors', () => {
-    renderComponent({ touched: true, valid: true });
+    renderComponent({ touched: true, modified: true, valid: true });
+    expect(screen.queryByText('Required')).not.toBeInTheDocument();
+  });
+
+  test('when touched but not modified, does not render any errors', () => {
+    renderComponent({ touched: true, modified: false, valid: false });
     expect(screen.queryByText('Required')).not.toBeInTheDocument();
   });
 
   test('when invalid, renders the error', () => {
-    renderComponent({ touched: true, valid: false });
+    renderComponent({ touched: true, modified: true, valid: false });
+    expect(screen.getByText('Required')).toBeInTheDocument();
+  });
+
+  test('when submit failed, renders the error', () => {
+    renderComponent({ submitFailed: true, valid: false });
     expect(screen.getByText('Required')).toBeInTheDocument();
   });
 });

--- a/judgels-client/src/components/forms/meta.js
+++ b/judgels-client/src/components/forms/meta.js
@@ -1,7 +1,7 @@
 import { Intent } from '@blueprintjs/core';
 
 export function isValid(meta) {
-  return !meta.touched || meta.valid;
+  return !((meta.touched && meta.modified) || meta.submitFailed) || meta.valid;
 }
 
 export function getIntent(meta) {

--- a/judgels-client/src/components/forms/meta.test.js
+++ b/judgels-client/src/components/forms/meta.test.js
@@ -4,19 +4,22 @@ import { getIntent, getIntentClassName, isValid } from './meta';
 
 describe('meta', () => {
   test('isValid()', () => {
-    expect(isValid({ touched: false, valid: false })).toBeTruthy();
-    expect(isValid({ touched: false, valid: true })).toBeTruthy();
-    expect(isValid({ touched: true, valid: false })).toBeFalsy();
-    expect(isValid({ touched: true, valid: true })).toBeTruthy();
+    expect(isValid({ touched: false, modified: false, submitFailed: false, valid: false })).toBeTruthy();
+    expect(isValid({ touched: true, modified: false, submitFailed: false, valid: false })).toBeTruthy();
+    expect(isValid({ touched: false, modified: true, submitFailed: false, valid: false })).toBeTruthy();
+    expect(isValid({ touched: true, modified: true, submitFailed: false, valid: false })).toBeFalsy();
+    expect(isValid({ touched: true, modified: true, submitFailed: false, valid: true })).toBeTruthy();
+    expect(isValid({ touched: false, modified: false, submitFailed: true, valid: false })).toBeFalsy();
+    expect(isValid({ touched: false, modified: false, submitFailed: true, valid: true })).toBeTruthy();
   });
 
   test('getIntent()', () => {
-    expect(getIntent({ touched: true, valid: false })).toEqual(Intent.DANGER);
-    expect(getIntent({ touched: true, valid: true })).toBeUndefined();
+    expect(getIntent({ touched: true, modified: true, valid: false })).toEqual(Intent.DANGER);
+    expect(getIntent({ touched: true, modified: true, valid: true })).toBeUndefined();
   });
 
   test('getIntentClassName()', () => {
-    expect(getIntentClassName({ touched: true, valid: false })['pt-intent-danger']).toBeTruthy();
-    expect(getIntentClassName({ touched: true, valid: true })['pt-intent-danger']).toBeFalsy();
+    expect(getIntentClassName({ touched: true, modified: true, valid: false })['pt-intent-danger']).toBeTruthy();
+    expect(getIntentClassName({ touched: true, modified: true, valid: true })['pt-intent-danger']).toBeFalsy();
   });
 });


### PR DESCRIPTION
Clicking into a form field and blurring it — without typing anything, and without submitting — immediately showed "Required" (e.g. the create contest dialog).

The shared `isValid()` helper in `judgels-client/src/components/forms/meta.js` drives every form field's error text and danger intent, and it gated on `meta.touched`. react-final-form sets `touched` on the first blur, so focus + tab away was enough to trigger it.

Now errors show only when the field was actually edited (`touched && modified`), or after a submit attempt (`submitFailed`, which final-form sets on all fields).

Tests for `meta` and `FormInputValidation` updated accordingly; full client suite passes.