### PR TITLE
Fix misplaced dropdown popover arrow in selects

### DIFF
--- a/judgels-client/src/components/forms/FormSelect2/FormSelect2.jsx
+++ b/judgels-client/src/components/forms/FormSelect2/FormSelect2.jsx
@@ -30,7 +30,7 @@ export function FormSelect2({ input, className, label, meta, optionValues, optio
         onItemSelect={onChange}
         inputProps={{ ...inputProps, autoComplete: 'off' }}
         filterable={isUsingFilter}
-        popoverProps={{ usePortal: false }}
+        popoverProps={{ usePortal: false, targetTagName: 'span' }}
       >
         <Button
           data-key={inputProps.name}

--- a/judgels-client/src/components/forms/FormTableSelect2/FormTableSelect2.jsx
+++ b/judgels-client/src/components/forms/FormTableSelect2/FormTableSelect2.jsx
@@ -32,7 +32,7 @@ export function FormTableSelect2(props) {
         onItemSelect={onChange}
         inputProps={inputProps}
         filterable={false}
-        popoverProps={{ usePortal: false }}
+        popoverProps={{ usePortal: false, targetTagName: 'span' }}
       >
         <Button
           disabled={disabled}

--- a/judgels-client/src/routes/admin/roles/RoleSelect/RoleSelect.jsx
+++ b/judgels-client/src/routes/admin/roles/RoleSelect/RoleSelect.jsx
@@ -35,7 +35,7 @@ export function RoleSelect({ label, value, onChange }) {
       items={roleValues}
       activeItem={value}
       filterable={false}
-      popoverProps={{ usePortal: false }}
+      popoverProps={{ usePortal: false, targetTagName: 'span' }}
       onItemSelect={onChange}
       itemRenderer={(item, { handleClick, modifiers }) => (
         <MenuItem active={modifiers.active} key={item || 'none'} text={roleNames[item]} onClick={handleClick} />


### PR DESCRIPTION
Dropdown popovers (e.g. the Status field in the contest announcement form) rendered their arrow at the top **right**, far from the button that opened them.

Cause: Blueprint's `Select` wraps its target in a `div` by default, so the popper reference element was the full-width form row rather than the button. The arrow was centered on that row and clamped to the popover's right edge.

Fix: pass `targetTagName: 'span'` so the target hugs the button and the arrow points at it. Side benefit: clicking the empty space to the right of the button no longer opens the dropdown.

Applied to `FormSelect2`, `FormTableSelect2`, and `RoleSelect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)