### PR TITLE
Add gap between submission cards in scoreboard submissions dialog

### DIFF
--- a/judgels-client/src/routes/contests/contests/single/scoreboard/ContestUserProblemSubmissionsDialog/ContestUserProblemSubmissionsDialog.jsx
+++ b/judgels-client/src/routes/contests/contests/single/scoreboard/ContestUserProblemSubmissionsDialog/ContestUserProblemSubmissionsDialog.jsx
@@ -1,4 +1,5 @@
 import { Classes, Dialog } from '@blueprintjs/core';
+import { Flex } from '@blueprintjs/labs';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { useState } from 'react';
@@ -84,7 +85,9 @@ export default function ContestUserProblemSubmissionsDialog({ userJid, problemJi
       canOutsideClickClose={true}
       enforceFocus={true}
     >
-      <div className={Classes.DIALOG_BODY}>{renderContent()}</div>
+      <Flex asChild flexDirection="column" gap={2}>
+        <div className={Classes.DIALOG_BODY}>{renderContent()}</div>
+      </Flex>
     </Dialog>
   );
 }


### PR DESCRIPTION
The dialog body was a plain `div`, so the stacked `ContentCard`s rendered flush against each other. Wrapped it in `Flex flexDirection="column" gap={2}` (via `asChild`), matching how card lists are spaced elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)