### PR TITLE
Increase compilation time limit

### DIFF
--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/grading/compilers/FunctionalCompiler.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/grading/compilers/FunctionalCompiler.java
@@ -35,7 +35,7 @@ public class FunctionalCompiler implements Compiler {
             throw new PreparationException(this.graderFilename + " is missing");
         }
 
-        sandbox.setTimeLimitInMilliseconds(30 * 1000);
+        sandbox.setTimeLimitInMilliseconds(60 * 1000);
         sandbox.setMemoryLimitInKilobytes(1024 * 1024);
 
         sandbox.resetRedirections();

--- a/judgels-backends/judgels-grader-engines/src/main/java/judgels/grading/compilers/SingleSourceFileCompiler.java
+++ b/judgels-backends/judgels-grader-engines/src/main/java/judgels/grading/compilers/SingleSourceFileCompiler.java
@@ -22,7 +22,7 @@ public class SingleSourceFileCompiler implements Compiler {
     private GradingLanguage language;
 
     public void prepare(Sandbox sandbox, File compilationDir, GradingLanguage language) {
-        sandbox.setTimeLimitInMilliseconds(20 * 1000);
+        sandbox.setTimeLimitInMilliseconds(60 * 1000);
         sandbox.setMemoryLimitInKilobytes(1024 * 1024);
 
         sandbox.resetRedirections();


### PR DESCRIPTION
Compiling C++ sources that include `bits/stdc++.h` can occasionally exceed the previous compilation limits, which surfaces as a compilation timeout.

Raise the compilation CPU time limit to 60s in both compilers:

- `SingleSourceFileCompiler`: 20s → 60s
- `FunctionalCompiler`: 30s → 60s

`IsolateSandbox.setTimeLimitInMilliseconds` derives the wall time limit as CPU limit + 8s, so the wall ceiling goes from 28s/38s to 68s. That covers both a genuinely slow compile and one stalled by CPU contention on a busy grader.

This also covers custom scorer compilation, which goes through `SingleSourceFileCompiler` once per submission.

Memory limits are left unchanged at 1GB. Raising them is risky on small graders: with `maxProcesses > 1` the limit is applied per box as `--cg-mem`, so N worker threads can demand N × the cap, and a cap above physical RAM means the kernel OOM killer fires before the cgroup limit does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)