### PR TITLE
Allow higher divisions to register when they may participate unofficially

### DIFF
--- a/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestContestantApiIntegrationTests.java
+++ b/judgels-backends/judgels-server-app/src/integTest/java/judgels/api/ContestContestantApiIntegrationTests.java
@@ -63,6 +63,32 @@ class ContestContestantApiIntegrationTests extends BaseContestApiIntegrationTest
 
         contestantClient.unregisterMyselfAsContestant(userAToken, contest.getJid());
         assertThat(contestantClient.getMyContestantState(userAToken, contest.getJid())).isEqualTo(REGISTRABLE);
+
+        enableModule(contest, DIVISION, new ContestModulesConfig.Builder()
+                .division(new DivisionModuleConfig.Builder().division(2).build())
+                .build());
+        assertThat(contestantClient.getMyContestantState(userToken, contest.getJid()))
+                .isEqualTo(REGISTRABLE);
+        assertThat(contestantClient.getMyContestantState(userAToken, contest.getJid()))
+                .isEqualTo(REGISTRABLE_WRONG_DIVISION);
+        assertThat(contestantClient.getMyContestantState(userBToken, contest.getJid()))
+                .isEqualTo(REGISTRABLE);
+
+        enableModule(contest, DIVISION, new ContestModulesConfig.Builder()
+                .division(new DivisionModuleConfig.Builder()
+                        .division(2)
+                        .allowHigherDivisionsUnofficially(true)
+                        .build())
+                .build());
+        assertThat(contestantClient.getMyContestantState(userToken, contest.getJid()))
+                .isEqualTo(REGISTRABLE);
+        assertThat(contestantClient.getMyContestantState(userAToken, contest.getJid()))
+                .isEqualTo(REGISTRABLE);
+        assertThat(contestantClient.getMyContestantState(userBToken, contest.getJid()))
+                .isEqualTo(REGISTRABLE);
+
+        contestantClient.registerMyselfAsContestant(userAToken, contest.getJid());
+        assertThat(contestantClient.getMyContestantState(userAToken, contest.getJid())).isEqualTo(REGISTRANT);
     }
 
     @Test

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/contest/contestant/ContestContestantRoleChecker.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/contest/contestant/ContestContestantRoleChecker.java
@@ -85,10 +85,22 @@ public class ContestContestantRoleChecker {
     }
 
     private boolean canRegisterInDivision(Optional<UserRating> rating, Contest contest) {
-        Optional<DivisionModuleConfig> config = moduleStore.getDivisionModuleConfig(contest.getJid());
-        if (!config.isPresent()) {
+        Optional<DivisionModuleConfig> maybeConfig = moduleStore.getDivisionModuleConfig(contest.getJid());
+        if (!maybeConfig.isPresent()) {
             return true;
         }
-        return ratingProvider.isRatingInDivision(rating, config.get().getDivision());
+        DivisionModuleConfig config = maybeConfig.get();
+        if (ratingProvider.isRatingInDivision(rating, config.getDivision())) {
+            return true;
+        }
+        if (!config.getAllowHigherDivisionsUnofficially()) {
+            return false;
+        }
+        for (int division = 1; division < config.getDivision(); division++) {
+            if (ratingProvider.isRatingInDivision(rating, division)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Problem

The `allowHigherDivisionsUnofficially` option on the Division module (#973) was wired into rating computation and the scoreboard, but never into the registration gate. `ContestContestantRoleChecker.canRegisterInDivision` only checked `isRatingInDivision`, so higher-division users were stuck at `REGISTRABLE_WRONG_DIVISION` and could never actually join as the unofficial participants the feature exists for.

## Fix

When the option is enabled, also accept users whose rating falls in a higher division — divisions are numbered from the highest one, so any division number below the contest's counts.

## Test

`register_unregister_contest` now continues into a division 2 contest: userA (rating 2000, division 1) is `REGISTRABLE_WRONG_DIVISION` by default, and becomes `REGISTRABLE` — and can actually register — once `allowHigherDivisionsUnofficially` is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)