### PR TITLE
Fix footer shown in course chapter problem page after client-side navigation

### DIFF
--- a/judgels-client/src/components/AppContent/AppContent.jsx
+++ b/judgels-client/src/components/AppContent/AppContent.jsx
@@ -1,12 +1,15 @@
+import { useLocation } from '@tanstack/react-router';
 import classNames from 'classnames';
 
 import './AppContent.scss';
 
 export function AppContent({ children }) {
+  const location = useLocation();
+
   return (
     <div
       className={classNames('app-content', {
-        'is-course-chapter-problem': isInCourseChapterProblemPath(),
+        'is-course-chapter-problem': isInCourseChapterProblemPath(location.pathname),
       })}
     >
       {children}
@@ -14,6 +17,6 @@ export function AppContent({ children }) {
   );
 }
 
-function isInCourseChapterProblemPath() {
-  return /\/courses\/[^\/]+\/chapters\/[^\/]+\/problems\//.test(window.location.pathname);
+function isInCourseChapterProblemPath(pathname) {
+  return /\/courses\/[^/]+\/chapters\/[^/]+\/problems\//.test(pathname);
 }


### PR DESCRIPTION
## Problem

In paths like `/courses/basic/chapters/A/problems/A`, the footer should be hidden and the page should not scroll past the problem worksheet/editor. This was broken when navigating client-side (e.g. from the chapter page into a problem) — the footer appeared and the page scrolled.

## Cause

`AppContent` computed the `is-course-chapter-problem` class from `window.location.pathname` at render time. Under TanStack Router, `App` (the `app` layout route) mounts once and does not re-render on child navigation, so the class was only correct for the page that was hard-loaded.

## Fix

Derive the path from `useLocation()` so the class is recomputed on every navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)