### PR TITLE
Remove license key logic

### DIFF
--- a/deployment/v2-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
+++ b/deployment/v2-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
@@ -48,9 +48,6 @@ judgels:
   baseDataDir: var/data
 
   app:
-{% if app_licenseKey is defined %}
-    licenseKey: {{ app_licenseKey }}
-{% endif %}
     name: {{ app_name }}
 
 {% if rabbitmq_username is defined %}

--- a/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
+++ b/deployment/v3-ubuntu-24.04/ansible/conf/judgels-server.yml.j2
@@ -49,9 +49,6 @@ judgels:
 
   app:
     mode: {{ app_mode | default('JUDGELS', true) }}
-{% if app_licenseKey is defined %}
-    licenseKey: {{ app_licenseKey }}
-{% endif %}
 
 {% if rabbitmq_username is defined %}
   rabbitmq:
@@ -121,7 +118,7 @@ judgels:
   superadmin:
     initialPassword: {{ superadmin_initialPassword }}
 
-{% if app_mode | default('JUDGELS', true) == 'TLX' or app_licenseKey is defined %}
+{% if app_mode | default('JUDGELS', true) == 'TLX' %}
 training:
 {% if training_aws_accessKey is defined %}
   aws:

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsApp.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsApp.java
@@ -1,16 +1,11 @@
 package judgels.app;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JudgelsApp {
     private static final Logger LOGGER = LoggerFactory.getLogger(JudgelsApp.class);
     private static final String TLX_MODE = "TLX";
-    private static final String TLX_HASH = "73d675663861b55f68aef37a9edce4e90392c0a3a11ffed47893d774a6203bf6";
 
     private static JudgelsAppEdition edition = JudgelsAppEdition.FREE;
 
@@ -40,25 +35,6 @@ public class JudgelsApp {
 
     private static void initializeEdition(JudgelsAppConfiguration config) {
         if (config.getMode().filter(TLX_MODE::equals).isPresent()) {
-            edition = JudgelsAppEdition.TLX;
-            return;
-        }
-
-        if (config.getLicenseKey().isEmpty()) {
-            return;
-        }
-
-        MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException e) {
-            return;
-        }
-
-        byte[] hashbytes = digest.digest(config.getLicenseKey().get().getBytes(StandardCharsets.UTF_8));
-        String hash = Hex.encodeHexString(hashbytes);
-
-        if (hash.equals(TLX_HASH)) {
             edition = JudgelsAppEdition.TLX;
         }
     }

--- a/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsAppConfiguration.java
+++ b/judgels-backends/judgels-server-app/src/main/java/judgels/app/JudgelsAppConfiguration.java
@@ -8,7 +8,6 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableJudgelsAppConfiguration.class)
 public interface JudgelsAppConfiguration {
     Optional<String> getMode();
-    Optional<String> getLicenseKey();
 
     class Builder extends ImmutableJudgelsAppConfiguration.Builder {}
 }


### PR DESCRIPTION
The TLX edition is now selected solely by the `judgels.app.mode` config, so the license key hash check is no longer needed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)